### PR TITLE
Reconnect using all options

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -28,8 +28,9 @@ function Connection(r, options, resolve, reject) {
   this.r = r;
   this.state = 0; // Track the progress of the handshake. -1 will be used for an error state.
 
-  // Set default options - We have to save them in case the user tries to reconnect
-  if (!helper.isPlainObject(options)) options = {};
+  // Retain `options` for reconnecting
+  this.options = options || (options = {});
+
   this.host = options.host || r._host;
   this.port = options.port || r._port;
   if (options.authKey != null) {
@@ -678,6 +679,11 @@ Connection.prototype._processResponse = function(response, token) {
 Connection.prototype.reconnect = function(options, callback) {
   var self = this;
 
+  // When `options.connection` is defined, you must create a new socket to reconnect.
+  if (self.options.connection) {
+    throw new Err.ReqlRuntimeError('Cannot call `reconnect` if `options.connection` was defined');
+  }
+
   if (typeof options === 'function') {
     callback = options;
     options = {};
@@ -688,12 +694,7 @@ Connection.prototype.reconnect = function(options, callback) {
   if (options.noreplyWait === true) {
     var p = new Promise(function(resolve, reject) {
       self.close(options).then(function() {
-        self.r.connect({
-          host: self.host,
-          port: self.port,
-          authKey: self.authKey,
-          db: self.db
-        }).then(function(c) {
+        self.r.connect(self.options).then(function(c) {
           resolve(c);
         }).error(function(e) {
           reject(e);
@@ -704,12 +705,7 @@ Connection.prototype.reconnect = function(options, callback) {
     }).nodeify(callback);
   }
   else {
-    return self.r.connect({
-      host: self.host,
-      port: self.port,
-      authKey: self.authKey,
-      db: self.db
-    }, callback);
+    return self.r.connect(self.options, callback);
   }
 
   return p;


### PR DESCRIPTION
Throw an error if `options.connection` is defined.
Retain the `options` for subsequent calls to `r.connect` when trying to reconnect.
The following options were not being used in reconnections:
  - username
  - password
  - pingInterval
  - timeout
  - ssl