### PR TITLE
Refactor tests using async/await and applying standardjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "devDependencies": {
     "browserify": "^16.2.2",
     "dev-null": ">= 0.1.1",
-    "mocha": ">= 1.20.0"
+    "mocha": ">= 4.0.0",
+    "standard": "^11.0.1"
   }
 }

--- a/test/accessing-reql.js
+++ b/test/accessing-reql.js
@@ -21,14 +21,6 @@ describe('accessing-reql', function () {
       connection = await r.connect(config)
       assert(connection.open)
     }
-    // remove any dbs created between each test case
-    for (dbName of await r.dbList().run(connection)) {
-      if (dbName === 'rethinkdb' || dbName === 'test') {
-        continue
-      } else {
-        await r.dbDrop(dbName).run(connection)
-      }
-    }
 
     await connection.close()
     assert(!connection.open)

--- a/test/accessing-reql.js
+++ b/test/accessing-reql.js
@@ -9,7 +9,7 @@ const {beforeEach, afterEach, describe, it} = require('mocha')
 
 describe('accessing-reql', function () {
   let connection // global connection
-  let dbName, tableName, result
+  let dbName, tableName
 
   beforeEach(async () => {
     connection = await r.connect(config)
@@ -29,26 +29,27 @@ describe('accessing-reql', function () {
         await r.dbDrop(dbName).run(connection)
       }
     }
+
     await connection.close()
     assert(!connection.open)
   })
 
-  it('`run` should throw an error when called without connection', async () => {
+  it('`run` should throw when called without connection', async () => {
     try {
       await r.expr(1).run()
-      assert.fail('shold throw an error')
+      assert.fail('should throw')
     } catch (e) {
       assert.equal(e.message, '`run` was called without a connection and no pool has been created after:\nr.expr(1)')
     }
   })
 
-  it('`run` should throw an error when called with a closed connection', async () => {
+  it('`run` should throw when called with a closed connection', async () => {
     try {
       connection.close()
       assert(!connection.open)
 
       await r.expr(1).run(connection)
-      assert.fail('should throw an error')
+      assert.fail('should throw')
     } catch (e) {
       assert.equal(e.message, '`run` was called with a closed connection after:\nr.expr(1)')
     }
@@ -58,8 +59,7 @@ describe('accessing-reql', function () {
     dbName = uuid()
     tableName = uuid()
 
-    assert(connection.open)
-    result = await r.dbCreate(dbName).run(connection)
+    let result = await r.dbCreate(dbName).run(connection)
     assert.equal(result.config_changes.length, 1)
     assert.equal(result.dbs_created, 1)
 
@@ -85,7 +85,7 @@ describe('accessing-reql', function () {
     dbName = uuid()
     tableName = uuid()
 
-    var result = await r.dbCreate(dbName).run(connection)
+    let result = await r.dbCreate(dbName).run(connection)
     assert.equal(result.dbs_created, 1)
 
     result = await r.db(dbName).tableCreate(tableName).run(connection)
@@ -105,7 +105,7 @@ describe('accessing-reql', function () {
     dbName = uuid()
     tableName = uuid()
 
-    var result = await r.dbCreate(dbName).run(connection)
+    let result = await r.dbCreate(dbName).run(connection)
     assert.equal(result.dbs_created, 1)
 
     result = await r.db(dbName).tableCreate(tableName).run(connection)
@@ -126,11 +126,10 @@ describe('accessing-reql', function () {
   })
 
   it('`reconnect` should work with options', async function () {
-    assert(connection.open)
     connection = await connection.reconnect({noreplyWait: true})
     assert(connection.open)
 
-    result = await r.expr(1).run(connection)
+    let result = await r.expr(1).run(connection)
     assert.equal(result, 1)
 
     connection = await connection.reconnect({noreplyWait: false})
@@ -149,7 +148,7 @@ describe('accessing-reql', function () {
   it('`noReplyWait` should throw', async function () {
     try {
       await connection.noReplyWait()
-      assert.fail('should throw an error')
+      assert.fail('should throw')
     } catch (e) {
       assert.equal(e.message, 'Did you mean to use `noreplyWait` instead of `noReplyWait`?')
     }
@@ -163,7 +162,7 @@ describe('accessing-reql', function () {
     await r.dbCreate(dbName).run(connection)
     await r.db(dbName).tableCreate(tableName).run(connection)
 
-    result = await r.db(dbName).table(tableName).insert(largeishObject).run(connection, {noreply: true})
+    let result = await r.db(dbName).table(tableName).insert(largeishObject).run(connection, {noreply: true})
     assert.equal(result, undefined)
 
     result = await r.db(dbName).table(tableName).count().run(connection)
@@ -177,7 +176,7 @@ describe('accessing-reql', function () {
   })
 
   it('`run` should take an argument', async function () {
-    result = await r.expr(1).run(connection, {readMode: 'primary'})
+    let result = await r.expr(1).run(connection, {readMode: 'primary'})
     assert.equal(result, 1)
 
     result = await r.expr(1).run(connection, {readMode: 'majority'})
@@ -199,20 +198,20 @@ describe('accessing-reql', function () {
 
   it('`run` should throw on an unrecognized argument', async function () {
     try {
-      result = await r.expr(1).run(connection, {foo: 'bar'})
-      assert.fail('should throw an error')
+      await r.expr(1).run(connection, {foo: 'bar'})
+      assert.fail('should throw')
     } catch (e) {
       assert.equal(e.message, 'Unrecognized option `foo` in `run`. Available options are readMode <string>, durability <string>, noreply <bool>, timeFormat <string>, groupFormat: <string>, profile <bool>, binaryFormat <bool>, cursor <bool>, stream <bool>.')
     }
   })
 
   it('`r()` should be a shortcut for r.expr()', async function () {
-    result = await r(1).run(connection)
+    const result = await r(1).run(connection)
     assert.deepEqual(result, 1)
   })
 
   it('`timeFormat` should work', async function () {
-    result = await r.now().run(connection)
+    let result = await r.now().run(connection)
     assert(result instanceof Date)
 
     result = await r.now().run(connection, {timeFormat: 'native'})
@@ -223,12 +222,12 @@ describe('accessing-reql', function () {
   })
 
   it('`binaryFormat` should work', async function () {
-    result = await r.binary(Buffer.from([1, 2, 3])).run(connection, {binaryFormat: 'raw'})
+    const result = await r.binary(Buffer.from([1, 2, 3])).run(connection, {binaryFormat: 'raw'})
     assert.equal(result.$reql_type$, 'BINARY')
   })
 
   it('`groupFormat` should work', async function () {
-    result = await r.expr([
+    const result = await r.expr([
       {name: 'Michel', grownUp: true},
       {name: 'Laurent', grownUp: true},
       {name: 'Sophie', grownUp: true},
@@ -240,7 +239,7 @@ describe('accessing-reql', function () {
   })
 
   it('`profile` should work', async function () {
-    result = await r.expr(true).run(connection, {profile: false})
+    let result = await r.expr(true).run(connection, {profile: false})
     assert(result)
 
     result = await r.expr(true).run(connection, {profile: true})
@@ -262,7 +261,7 @@ describe('accessing-reql', function () {
         port: port,
         timeout: 1
       })
-      assert.fail('should throw an error')
+      assert.fail('should throw')
     } catch (err) {
       await server.close()
 
@@ -271,7 +270,7 @@ describe('accessing-reql', function () {
   })
 
   it('`server` should work', async function () {
-    var response = await connection.server()
+    const response = await connection.server()
     assert(typeof response.name === 'string')
     assert(typeof response.id === 'string')
   })
@@ -280,7 +279,7 @@ describe('accessing-reql', function () {
     const restrictedDbName = uuid()
     const restrictedTableName = uuid()
 
-    result = await r.dbCreate(restrictedDbName).run(connection)
+    let result = await r.dbCreate(restrictedDbName).run(connection)
     assert.equal(result.config_changes.length, 1)
     assert.equal(result.dbs_created, 1)
 
@@ -293,6 +292,7 @@ describe('accessing-reql', function () {
       id: user,
       password: password
     }).run(connection)
+    assert.equal(result.inserted, 1)
     result = await r.db(restrictedDbName).table(restrictedTableName).grant(user, {
       read: true, write: true, config: true
     }).run(connection)
@@ -314,15 +314,15 @@ describe('accessing-reql', function () {
       require(path.join(__dirname, '/../lib'))({
         servers: []
       })
-      assert.fail('should throw an error')
+      assert.fail('should throw')
     } catch (e) {
       assert.equal(e.message, 'If `servers` is an array, it must contain at least one server.')
     }
   })
 
   it('should not throw an error (since 1.13, the token is now stored outside the query): `connection` should extend events.Emitter and emit an error if the server failed to parse the protobuf message', async function () {
-    connection.addListener('error', () => assert.fail('should not throw'))
-    result = await Array(687).fill(1).reduce((acc, curr) => acc.add(curr), r.expr(1)).run(connection)
+    connection.addListener('error', assert.ifError)
+    const result = await Array(687).fill(1).reduce((acc, curr) => acc.add(curr), r.expr(1)).run(connection)
     assert.equal(result, 688)
   })
 })

--- a/test/accessing-reql.js
+++ b/test/accessing-reql.js
@@ -123,10 +123,6 @@ It('`reconnect` should work', function* (done) {
     connection = yield connection.reconnect();
     assert(connection);
 
-
-    result = yield r.tableList().run(connection);
-    assert.deepEqual(result, [tableName])
-
     done();
   }
   catch(e) {

--- a/test/accessing-reql.js
+++ b/test/accessing-reql.js
@@ -1,508 +1,315 @@
-var config = require(__dirname+'/config.js');
-var r = require(__dirname+'/../lib')({pool: false, silent: true});
-var util = require(__dirname+'/util/common.js');
-var assert = require('assert');
-
-var uuid = util.uuid;
-var It = util.It;
-
-var connection; // global connection
-var dbName, tableName, result;
+const path = require('path')
+const config = require(path.join(__dirname, '/config.js'))
+const r = require(path.join(__dirname, '/../lib'))({pool: false, silent: true})
+const util = require(path.join(__dirname, '/util/common.js'))
+const assert = require('assert')
+const uuid = util.uuid
+const net = require('net')
+const {beforeEach, afterEach, describe, it} = require('mocha')
 
 
-It('Testing `run` without connection', function* (done) {
-  try {
-    r.expr(1).run()
-  }
-  catch(e) {
-    if (e.message === '`run` was called without a connection and no pool has been created after:\nr.expr(1)') {
-      done()
+describe('accessing-reql', function () {
+  let connection // global connection
+  let dbName, tableName, result
+
+  beforeEach(async () => {
+    connection = await r.connect(config)
+    assert(connection.open)
+  })
+
+  afterEach(async () => {
+    if (!connection.open) {
+      connection = await r.connect(config)
+      assert(connection.open)
     }
-    else {
-      done(e);
+    // clean up any dbs
+    /*
+    for (dbName of await r.dbList().run(connection)) {
+      if (dbName === 'rethinkdb' || dbName === 'test') {
+        continue
+      } else {
+        await r.dbDrop(dbName).run(connection)
+      }
     }
-  }
-})
-It('Testing `run` with a closed connection', function* (done) {
-  try {
-    connection = yield r.connect(config);
-    assert(connection);
-    connection.close()
-    yield r.expr(1).run(connection)
-  }
-  catch(e) {
-    if (e.message === '`run` was called with a closed connection after:\nr.expr(1)') {
-      done()
+    */
+    // close connection before next test case
+    await connection.close()
+    assert(!connection.open)
+  })
+
+  it('`run` should throw an error when called without connection', async () => {
+    try {
+      await r.expr(1).run()
+      assert.fail('shold throw an error')
+    } catch (e) {
+      assert.equal(e.message, '`run` was called without a connection and no pool has been created after:\nr.expr(1)')
     }
-    else {
-      done(e);
+  })
+
+  it('`run` should throw an error when called with a closed connection', async () => {
+    try {
+      connection.close()
+      assert(!connection.open)
+
+      await r.expr(1).run(connection)
+      assert.fail('should throw an error')
+    } catch (e) {
+      assert.equal(e.message, '`run` was called with a closed connection after:\nr.expr(1)')
     }
-  }
-})
+  })
 
-It('Init for `cursor.js`', function* (done) {
-  try {
-    connection = yield r.connect(config);
-    assert(connection);
+  it('should be able to create a db, a table, insert array into table, delete array from table, drop table and drop db', async () => {
+    dbName = uuid()
+    tableName = uuid()
 
-    dbName = uuid();
-    var tableName = uuid();
+    assert(connection.open)
+    result = await r.dbCreate(dbName).run(connection)
+    assert.equal(result.config_changes.length, 1)
+    assert.equal(result.dbs_created, 1)
 
-    result = yield r.dbCreate(dbName).run(connection);
-    assert.equal(result.config_changes.length, 1);
-    assert.equal(result.dbs_created, 1);
+    result = await r.db(dbName).tableCreate(tableName).run(connection)
+    assert.equal(result.tables_created, 1)
 
-    result = yield r.db(dbName).tableCreate(tableName).run(connection);
-    assert.equal(result.tables_created, 1);
+    result = await r.db(dbName).table(tableName).insert(new Array(100).fill({})).run(connection)
+    assert.equal(result.inserted, 100)
 
-    result = yield r.db(dbName).table(tableName).insert(eval('['+new Array(100).join('{}, ')+'{}]')).run(connection);
-    assert.equal(result.inserted, 100);
+    result = await r.db(dbName).table(tableName).delete().run(connection)
+    assert.equal(result.deleted, 100)
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+    result = await r.db(dbName).tableDrop(tableName).run(connection)
+    assert.equal(result.config_changes.length, 1)
+    assert.equal(result.tables_dropped, 1)
 
-It('`run` should use the default database', function* (done) {
-  try{
-    dbName = uuid();
-    tableName = uuid();
+    result = await r.dbDrop(dbName).run(connection)
+    assert.equal(result.config_changes.length, 1)
+    assert.equal(result.dbs_dropped, 1)
+  })
+  
+  it('`run` should use the default database', async () => {
+    dbName = uuid()
+    tableName = uuid()
 
-    var result = yield r.dbCreate(dbName).run(connection);
-    assert.equal(result.dbs_created, 1);
+    var result = await r.dbCreate(dbName).run(connection)
+    assert.equal(result.dbs_created, 1)
 
-    result = yield r.db(dbName).tableCreate(tableName).run(connection);
-    assert.equal(result.tables_created, 1);
+    result = await r.db(dbName).tableCreate(tableName).run(connection)
+    assert.equal(result.tables_created, 1)
 
-    result = yield connection.close();
+    await connection.close()
+    assert(!connection.open)
 
-    connection = yield r.connect({db: dbName, host: config.host, port: config.port, authKey: config.authKey});
-    assert(connection);
+    connection = await r.connect({db: dbName, host: config.host, port: config.port, authKey: config.authKey})
+    assert(connection)
 
-    result = yield r.tableList().run(connection);
+    result = await r.tableList().run(connection)
     assert.deepEqual(result, [tableName])
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`use` should work', function* (done) {
-  try{
-    dbName = uuid();
-    tableName = uuid();
+  it('`use` should work', async function () {
+    dbName = uuid()
+    tableName = uuid()
 
-    var result = yield r.dbCreate(dbName).run(connection);
-    assert.equal(result.dbs_created, 1);
+    var result = await r.dbCreate(dbName).run(connection)
+    assert.equal(result.dbs_created, 1)
 
-    result = yield r.db(dbName).tableCreate(tableName).run(connection);
-    assert.equal(result.tables_created, 1);
+    result = await r.db(dbName).tableCreate(tableName).run(connection)
+    assert.equal(result.tables_created, 1)
 
-    connection.use(dbName);
+    connection.use(dbName)
 
-    result = yield r.tableList().run(connection);
+    result = await r.tableList().run(connection)
     assert.deepEqual(result, [tableName])
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`reconnect` should work', function* (done) {
-  try{
-    var result = yield r.expr(1).run(connection);
-    assert.equal(result, 1);
+  it('`reconnect` should work', async function () {
+    await connection.close()
+    assert(!connection.open)
 
-    result = yield connection.close();
+    connection = await connection.reconnect()
+    assert(connection.open)
+  })
 
-    assert(connection);
-    connection = yield connection.reconnect();
-    assert(connection);
+  it('`reconnect` should work with options', async function () {
+    assert(connection.open)
+    connection = await connection.reconnect({noreplyWait: true})
+    assert(connection.open)
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`reconnect` should work with options', function* (done) {
-  try{
-    var result = yield r.expr(1).run(connection);
-    assert.equal(result, 1);
+    result = await r.expr(1).run(connection)
+    assert.equal(result, 1)
 
-    assert(connection);
-    connection = yield connection.reconnect({noreplyWait: true});
-    assert(connection);
+    connection = await connection.reconnect({noreplyWait: false})
+    assert(connection.open)
 
-    result = yield r.expr(1).run(connection);
-    assert.equal(result, 1);
+    result = await r.expr(1).run(connection)
+    assert.equal(result, 1)
 
-    connection = yield connection.reconnect({noreplyWait: false});
-    assert(connection);
+    connection = await connection.reconnect()
+    assert(connection)
 
-    result = yield r.expr(1).run(connection);
-    assert.equal(result, 1);
+    result = await r.expr(1).run(connection)
+    assert.equal(result, 1)
+  })
 
-    connection = yield connection.reconnect();
-    assert(connection);
-
-    result = yield r.expr(1).run(connection);
-    assert.equal(result, 1);
-
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-
-
-It('`noReplyWait` should throw', function* (done) {
-  try{
-    result = yield connection.noReplyWait()
-  }
-  catch(e) {
-    if (e.message === 'Did you mean to use `noreplyWait` instead of `noReplyWait`?') {
-      done();
+  it('`noReplyWait` should throw', async function () {
+    try {
+      await connection.noReplyWait()
+      assert.fail('should throw an error')
+    } catch (e) {
+      assert.equal(e.message, 'Did you mean to use `noreplyWait` instead of `noReplyWait`?')
     }
-    else {
-      done(e);
+  })
+
+  it('`noreplyWait` should work', async function () {
+    await connection.noreplyWait()
+  })
+
+  it('`run` should take an argument', async function () {
+    result = await r.expr(1).run(connection, {readMode: 'primary'})
+    assert.equal(result, 1)
+
+    result = await r.expr(1).run(connection, {readMode: 'majority'})
+    assert.equal(result, 1)
+
+    result = await r.expr(1).run(connection, {profile: false})
+    assert.equal(result, 1)
+
+    result = await r.expr(1).run(connection, {profile: true})
+    assert(result.profile)
+    assert.equal(result.result, 1)
+
+    result = await r.expr(1).run(connection, {durability: 'soft'})
+    assert.equal(result, 1)
+
+    result = await r.expr(1).run(connection, {durability: 'hard'})
+    assert.equal(result, 1)
+  })
+
+  it('`run` should throw on an unrecognized argument', async function () {
+    try {
+      result = await r.expr(1).run(connection, {foo: 'bar'})
+      assert.fail('should throw an error')
+    } catch (e) {
+      assert.equal(e.message, 'Unrecognized option `foo` in `run`. Available options are readMode <string>, durability <string>, noreply <bool>, timeFormat <string>, groupFormat: <string>, profile <bool>, binaryFormat <bool>, cursor <bool>, stream <bool>.')
     }
-  }
+  })
 
-})
-It('`noreplyWait` should work', function* (done) {
-  try{
-    result = yield connection.noreplyWait()
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-
-
-
- 
-It('`run` should take an argument', function* (done) {
-  try {
-    var result = yield connection.close();
-    assert(connection);
-    connection = yield r.connect(config);
-    assert(connection);
-
-    result = yield r.expr(1).run(connection, {readMode: 'primary'});
-    assert.equal(result, 1);
-
-    result = yield r.expr(1).run(connection, {readMode: 'majority'});
-    assert.equal(result, 1);
-
-    result = yield r.expr(1).run(connection, {profile: false});
-    assert.equal(result, 1);
-
-    result = yield r.expr(1).run(connection, {profile: true});
-    assert(result.profile);
-    assert.equal(result.result, 1);
-
-    result = yield r.expr(1).run(connection, {durability: 'soft'});
-    assert.equal(result, 1);
-
-    result = yield r.expr(1).run(connection, {durability: 'hard'});
-    assert.equal(result, 1);
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-
-It('`run` should throw on an unrecognized argument', function* (done) {
-  try {
-    result = yield r.expr(1).run(connection, {foo: 'bar'});
-  }
-  catch(e) {
-    if (e.message === 'Unrecognized option `foo` in `run`. Available options are readMode <string>, durability <string>, noreply <bool>, timeFormat <string>, groupFormat: <string>, profile <bool>, binaryFormat <bool>, cursor <bool>, stream <bool>.') {
-      done();
-    }
-    else{
-      done(e);
-    }
-  }
-})
-
-
-It('`r()` should be a shortcut for r.expr()', function* (done) {
-  try {
-    result = yield r(1).run(connection);
+  it('`r()` should be a shortcut for r.expr()', async function () {
+    result = await r(1).run(connection)
     assert.deepEqual(result, 1)
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+  })
 
-It('`timeFormat` should work', function* (done) {
-  try {
-    result = yield r.now().run(connection);
-    assert(result instanceof Date);
+  it('`timeFormat` should work', async function () {
+    result = await r.now().run(connection)
+    assert(result instanceof Date)
 
-    result = yield r.now().run(connection, {timeFormat: 'native'});
-    assert(result instanceof Date);
+    result = await r.now().run(connection, {timeFormat: 'native'})
+    assert(result instanceof Date)
 
-    result = yield r.now().run(connection, {timeFormat: 'raw'});
+    result = await r.now().run(connection, {timeFormat: 'raw'})
     assert.equal(result.$reql_type$, 'TIME')
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`binaryFormat` should work', function* (done) {
-  try {
-    result = yield r.binary(new Buffer([1,2,3])).run(connection, {binaryFormat: 'raw'});
-    assert.equal(result.$reql_type$, 'BINARY');
+  it('`binaryFormat` should work', async function () {
+    result = await r.binary(Buffer.from([1, 2, 3])).run(connection, {binaryFormat: 'raw'})
+    assert.equal(result.$reql_type$, 'BINARY')
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-
-It('`groupFormat` should work', function* (done) {
-  try {
-    var result = yield r.expr([{name: 'Michel', grownUp: true},{name: 'Laurent', grownUp: true},
-      {name: 'Sophie', grownUp: true},{name: 'Luke', grownUp: false},{name: 'Mino', grownUp: false}]).group('grownUp').run(connection, {groupFormat: 'raw'});
+  it('`groupFormat` should work', async function () {
+    result = await r.expr([
+      {name: 'Michel', grownUp: true},
+      {name: 'Laurent', grownUp: true},
+      {name: 'Sophie', grownUp: true},
+      {name: 'Luke', grownUp: false},
+      {name: 'Mino', grownUp: false}
+    ]).group('grownUp').run(connection, {groupFormat: 'raw'})
 
     assert.deepEqual(result, { '$reql_type$': 'GROUPED_DATA', 'data': [ [ false, [ { 'grownUp': false, 'name': 'Luke' }, { 'grownUp': false, 'name': 'Mino' } ] ], [ true, [ { 'grownUp': true, 'name': 'Michel' }, { 'grownUp': true, 'name': 'Laurent' }, { 'grownUp': true, 'name': 'Sophie' } ] ] ] })
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-
-
-It('`profile` should work', function* (done) {
-  try{
-    result = yield r.expr(true).run(connection, {profile: false});
+  it('`profile` should work', async function () {
+    result = await r.expr(true).run(connection, {profile: false})
     assert(result)
 
-    result = yield r.expr(true).run(connection, {profile: true});
+    result = await r.expr(true).run(connection, {profile: true})
     assert(result.profile)
     assert.equal(result.result, true)
 
-    result = yield r.expr(true).run(connection, {profile: false});
+    result = await r.expr(true).run(connection, {profile: false})
     assert.equal(result, true)
+  })
 
-    done();
-  }
-  catch(e){
-  }
-})
+  it('`timeout` option should work', async function () {
+    let server, port
+    try {
+      port = Math.floor(Math.random() * (65535 - 1025) + 1025)
 
+      server = net.createServer().listen(port)
 
-It('Test error message when running a query on a closed connection', function* (done) {
-  try {
-    yield connection.close();
-    yield r.expr(1).run(connection)
-  }
-  catch(e) {
-    if (e.message.match('`run` was called with a closed connection after:')) {
-      done();
+      connection = await r.connect({
+        port: port,
+        timeout: 1
+      })
+      assert.fail('should throw an error')
+    } catch (err) {
+      await server.close()
+
+      assert.equal(err.message, 'Failed to connect to localhost:' + port + ' in less than 1s.')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-It('Test timeout', function* (done) {
-  var server;
-  try {
-    var port = Math.floor(Math.random()*(65535-1025)+1025)
+  it('`server` should work', async function () {
+    var response = await connection.server()
+    assert(typeof response.name === 'string')
+    assert(typeof response.id === 'string')
+  })
 
-    server = require('net').createServer(function(c) {
-    }).listen(port);
+  it('`grant` should work', async function () {
 
-    connection = yield r.connect({
-      port: port,
-      timeout: 1
-    });
-    done(new Error('Was expecting an error'));
-  }
-  catch(err) {
-    //close server
-    if (err.message === 'Failed to connect to localhost:'+port+' in less than 1s.') {
-      done();
-    }
-    else {
-      done(err)
-    }
-  }
-})
+    const restrictedDbName = uuid()
+    const restrictedTableName = uuid()
 
-It('`server` should work', function* (done) {
-  try{
-    connection = yield r.connect(config);
-    var response = yield connection.server();
-    assert(typeof response.name === 'string');
-    assert(typeof response.id === 'string');
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+    result = await r.dbCreate(restrictedDbName).run(connection)
+    assert.equal(result.config_changes.length, 1)
+    assert.equal(result.dbs_created, 1)
+    result = await r.db(restrictedDbName).tableCreate(restrictedTableName).run(connection)
+    assert.equal(result.tables_created, 1)
 
-It('`grant` should work', function* (done) {
-  try{
-    connection = yield r.connect(config);
-    assert(connection);
-
-    var restrictedDbName = uuid();
-    var restrictedTableName = uuid();
-
-    result = yield r.dbCreate(restrictedDbName).run(connection);
-    assert.equal(result.config_changes.length, 1);
-    assert.equal(result.dbs_created, 1);
-    result = yield r.db(restrictedDbName).tableCreate(restrictedTableName).run(connection);
-    assert.equal(result.tables_created, 1);
-
-    var user = uuid();
-    var password = uuid();
-    result = yield r.db('rethinkdb').table('users').insert({
+    const user = uuid()
+    const password = uuid()
+    result = await r.db('rethinkdb').table('users').insert({
       id: user,
       password: password
-    }).run(connection);
-    result = yield r.db(restrictedDbName).table(restrictedTableName).grant(user, {
+    }).run(connection)
+    result = await r.db(restrictedDbName).table(restrictedTableName).grant(user, {
       read: true, write: true, config: true
-    }).run(connection);
+    }).run(connection)
     assert.deepEqual(result, {
       granted: 1,
       permissions_changes: [{
         new_val: {
           config: true,
-        read: true,
-        write: true
+          read: true,
+          write: true
         },
         old_val: null
       }]
-    });
+    })
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-
-It('If `servers` is specified, it cannot be empty', function* (done) {
-  try{
-    var r = require(__dirname+'/../lib')({
-      servers: []
-    });
-  } catch(e) {
-    assert.equal(e.message, 'If `servers` is an array, it must contain at least one server.');
-    done();
-  }
-})
-
-/* Since 1.13, the token is stored oustide the query, so this error shouldn't happen anymore
-It('`connection` should extend events.Emitter and emit an error if the server failed to parse the protobuf message', function* (done) {
-  try{
-    connection.addListener('error', function() {
-      done();
-    });
-
-    result = yield r.expr(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .run(connection);
-  }
-  catch(e){
-    if (e.message === 'Client is buggy (failed to deserialize protobuf).\nClosing all outstanding queries...') {
-      //done will be called by the listener on 'error'
-      //done()
+  it('If `servers` is specified, it cannot be empty', function () {
+    try {
+      require(path.join(__dirname, '/../lib'))({
+        servers: []
+      })
+      assert.fail('should throw an error')
+    } catch (e) {
+      assert.equal(e.message, 'If `servers` is an array, it must contain at least one server.')
     }
-    else {
-      done(e);
-    }
-  }
+  })
+
+  it('should not throw an error (since 1.13, the token is now stored outside the query): `connection` should extend events.Emitter and emit an error if the server failed to parse the protobuf message', async function () {
+    connection.addListener('error', () => assert.fail('should not throw'))
+    result = await Array(687).fill(1).reduce((acc, curr) => acc.add(curr), r.expr(1)).run(connection)
+    assert.equal(result, 688)
+  })
 })
-*/

--- a/test/administration.js
+++ b/test/administration.js
@@ -1,265 +1,159 @@
-var config = require(__dirname+'/config.js');
-var r = require(__dirname+'/../lib')(config);
-var util = require(__dirname+'/util/common.js');
-var assert = require('assert');
-var Promise = require('bluebird');
+const path = require('path')
+const config = require(path.join(__dirname, '/config.js'))
+const rethinkdbdash = require(path.join(__dirname, '/../lib'))
+const util = require(path.join(__dirname, '/util/common.js'))
+const assert = require('assert')
+const uuid = util.uuid
+const {before, after, describe, it} = require('mocha')
 
-var It = util.It;
-var uuid = util.uuid;
+describe('administration', () => {
+  let r, dbName, tableName, result
 
-var dbName, tableName, result, pks;
+  before(async () => {
+    r = await rethinkdbdash(config)
 
+    dbName = uuid()
+    tableName = uuid()
 
-It('Init for `administration.js`', function* (done) {
-  try {
-    dbName = uuid();
-    tableName = uuid();
+    result = await r.dbCreate(dbName).run()
+    assert.equal(result.dbs_created, 1)
 
-    result = yield r.dbCreate(dbName).run();
-    assert.equal(result.dbs_created, 1);
+    result = await r.db(dbName).tableCreate(tableName).run()
+    assert.equal(result.tables_created, 1)
 
-    result = yield r.db(dbName).tableCreate(tableName).run();
-    assert.equal(result.tables_created, 1);
+    result = await r.db(dbName).table(tableName).insert(Array(100).fill({})).run()
+    assert.equal(result.inserted, 100)
+    assert.equal(result.generated_keys.length, 100)
+  })
 
-    result = yield r.db(dbName).table(tableName).insert(eval('['+new Array(100).join('{}, ')+'{}]')).run();
-    assert.equal(result.inserted, 100);
-    pks = result.generated_keys;
+  after(async () => {
+    await r.getPoolMaster().drain()
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
+  it('`config` should work', async function () {
+    result = await r.db(dbName).config().run()
+    assert.equal(result.name, dbName)
+
+    result = await r.db(dbName).table(tableName).config().run()
+    assert.equal(result.name, tableName)
+  })
+
+  it('`config` should throw if called with an argument', async function () {
+    try {
+      await r.db(dbName).config('hello').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message.match(/^`config` takes 0 argument, 1 provided after:/))
+    }
+  })
+
+  it('`status` should work', async function () {
+    result = await r.db(dbName).table(tableName).status().run()
+    assert.equal(result.name, tableName)
+    assert.notEqual(result.status, undefined)
+  })
+
+  it('`status` should throw if called with an argument', async function (done) {
+    try {
+      await r.db(dbName).table(tableName).status('hello').run()
+      assert.fail('should throw')
+    } catch (e) {
+      if (e.message.match(/^`status` takes 0 argument, 1 provided after:/)) {
+        done()
+      } else {
+        done(e)
+      }
+    }
+  })
+
+  it('`wait` should work', async function () {
+    result = await r.db(dbName).table(tableName).wait().run()
+    assert.equal(result.ready, 1)
+
+    await r.db(dbName).table(tableName).wait({waitFor: 'ready_for_writes', timeout: 2000}).run()
+  })
+
+  it('`wait` should work with options', async function () {
+    result = await r.db(dbName).table(tableName).wait({waitFor: 'ready_for_writes'}).run()
+    assert.equal(result.ready, 1)
+  })
+
+  it('`r.wait` should throw', async function () {
+    try {
+      await r.wait().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message.match(/^`wait` can only be called on a table or a database since 2.3./))
+    }
+  })
+
+  it('`wait` should throw if called with 2 arguments', async function () {
+    try {
+      await r.db(dbName).table(tableName).wait('hello', 'world').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message.match(/^`wait` takes at most 1 argument, 2 provided after:/))
+    }
+  })
+
+  it('`reconfigure` should work - 1', async function () {
+    result = await r.db(dbName).table(tableName).reconfigure({shards: 1, replicas: 1}).run()
+    assert.equal(result.reconfigured, 1)
+  })
+
+  it('`reconfigure` should work - 2 - dryRun', async function () {
+    result = await r.db(dbName).table(tableName).reconfigure({shards: 1, replicas: 1, dryRun: true}).run()
+    assert.equal(result.reconfigured, 0)
+  })
+
+  it('`r.reconfigure` should throw', async function () {
+    try {
+      result = await r.reconfigure().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message.match(/^`reconfigure` can only be called on a table or a database since 2.3./))
+    }
+  })
+
+  it('`reconfigure` should throw on an unrecognized key', async function () {
+    try {
+      result = await r.db(dbName).table(tableName).reconfigure({foo: 1}).run()
+      assert.fail('should throw')
+      assert.equal(result.reconfigured, 0)
+    } catch (e) {
+      assert(e.message.match(/^Unrecognized option `foo` in `reconfigure` after:/))
+    }
+  })
+
+  it('`reconfigure` should throw on a number', async function () {
+    try {
+      result = await r.db(dbName).table(tableName).reconfigure(1).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message.match(/^First argument of `reconfigure` must be an object./))
+    }
+  })
+
+  it('`rebalanced` should work - 1', async function () {
+    result = await r.db(dbName).table(tableName).rebalance().run()
+    assert.equal(result.rebalanced, 1)
+  })
+
+  it('`r.rebalance` should throw', async function () {
+    try {
+      result = await r.rebalance().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message.match(/^`rebalance` can only be called on a table or a database since 2.3./))
+    }
+  })
+
+  it('`rebalance` should throw if an argument is provided', async function () {
+    try {
+      result = await r.db(dbName).table(tableName).rebalance(1).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message.match(/^`rebalance` takes 0 argument, 1 provided after:/))
+    }
+  })
 })
-
-It('`config` should work', function* (done) {
-  try {
-    result = yield r.db(dbName).config().run();
-    assert.equal(result.name, dbName);
-
-    result = yield r.db(dbName).table(tableName).config().run();
-    assert.equal(result.name, tableName);
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-
-It('`config` should throw if called with an argument', function* (done) {
-  try{
-    var result = yield r.db(dbName).config("hello").run();
-  }
-  catch(e) {
-    if (e.message.match(/^`config` takes 0 argument, 1 provided after:/)) {
-      done()
-    }
-    else {
-      done(e);
-    }
-  }
-})
-
-It('`status` should work', function* (done) {
-  try {
-    result = yield r.db(dbName).table(tableName).status().run();
-    assert.equal(result.name, tableName);
-    assert.notEqual(result.status, undefined);
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-
-It('`status` should throw if called with an argument', function* (done) {
-  try{
-    var result = yield r.db(dbName).table(tableName).status("hello").run();
-  }
-  catch(e) {
-    if (e.message.match(/^`status` takes 0 argument, 1 provided after:/)) {
-      done()
-    }
-    else {
-      done(e);
-    }
-  }
-})
-
-It('`wait` should work', function* (done) {
-  try {
-    result = yield r.db(dbName).table(tableName).wait().run();
-    assert.equal(result.ready, 1);
-
-    yield r.db(dbName).table(tableName).wait({waitFor: 'ready_for_writes', timeout: 2000}).run();
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-
-It('`wait` should work with options', function* (done) {
-  try {
-    result = yield r.db(dbName).table(tableName).wait({waitFor: 'ready_for_writes'}).run();
-    assert.equal(result.ready, 1);
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-
-
-It('`r.wait` should throw', function* (done) {
-  try {
-    result = yield r.wait().run();
-    done(new Error('r.wait is expected to throw'));
-  }
-  catch(e) {
-    if (e.message.match(/^`wait` can only be called on a table or a database since 2.3./)) {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
-})
-
-It('`wait` should throw if called with 2 arguments', function* (done) {
-  try{
-    var result = yield r.db(dbName).table(tableName).wait("hello", "world").run();
-  }
-  catch(e) {
-    if (e.message.match(/^`wait` takes at most 1 argument, 2 provided after:/)) {
-      done()
-    }
-    else {
-      done(e);
-    }
-  }
-})
-
-It('`reconfigure` should work - 1', function* (done) {
-  try {
-    result = yield r.db(dbName).table(tableName).reconfigure({shards: 1, replicas: 1}).run();
-    assert.equal(result.reconfigured, 1);
-
-    done();
-  }
-  catch(e) {
-console.log(e);
-    done(e);
-  }
-})
-
-It('`reconfigure` should work - 2 - dryRun', function* (done) {
-  try {
-    result = yield r.db(dbName).table(tableName).reconfigure({shards: 1, replicas: 1, dryRun: true}).run();
-    assert.equal(result.reconfigured, 0);
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-
-It('`r.reconfigure` should throw', function* (done) {
-  try {
-    result = yield r.reconfigure().run();
-    done(new Error('r.reconfigure is expected to throw'));
-  }
-  catch(e) {
-    if (e.message.match(/^`reconfigure` can only be called on a table or a database since 2.3./)) {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
-})
-
-It('`reconfigure` should throw on an unrecognized key', function* (done) {
-  try {
-    result = yield r.db(dbName).table(tableName).reconfigure({foo: 1}).run();
-    assert.equal(result.reconfigured, 0);
-
-    done();
-  }
-  catch(e) {
-    if (e.message.match(/^Unrecognized option `foo` in `reconfigure` after:/)) {
-      done();
-    }
-    else{
-      done(e);
-    }
-  }
-})
-
-
-It('`reconfigure` should throw on a number', function* (done) {
-  try {
-    result = yield r.db(dbName).table(tableName).reconfigure(1).run();
-
-    done();
-  }
-  catch(e) {
-    if (e.message.match(/^First argument of `reconfigure` must be an object./)) {
-      done();
-    }
-    else{
-      done(e);
-    }
-
-  }
-})
-
-It('`rebalanced` should work - 1', function* (done) {
-  try {
-    result = yield r.db(dbName).table(tableName).rebalance().run();
-    assert.equal(result.rebalanced, 1);
-
-    done();
-  }
-  catch(e) {
-console.log(e);
-    done(e);
-  }
-})
-
-It('`r.rebalance` should throw', function* (done) {
-  try {
-    result = yield r.rebalance().run();
-    done(new Error('r.rebalance is expected to throw'));
-  }
-  catch(e) {
-    if (e.message.match(/^`rebalance` can only be called on a table or a database since 2.3./)) {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
-})
-
-It('`rebalance` should throw if an argument is provided', function* (done) {
-  try {
-    result = yield r.db(dbName).table(tableName).rebalance(1).run();
-
-    done();
-  }
-  catch(e) {
-    if (e.message.match(/^`rebalance` takes 0 argument, 1 provided after:/)) {
-      done();
-    }
-    else{
-      done(e);
-    }
-
-  }
-})
-

--- a/test/administration.js
+++ b/test/administration.js
@@ -53,28 +53,25 @@ describe('administration', () => {
     assert.notEqual(result.status, undefined)
   })
 
-  it('`status` should throw if called with an argument', async function (done) {
+  it('`status` should throw if called with an argument', async function () {
     try {
       await r.db(dbName).table(tableName).status('hello').run()
       assert.fail('should throw')
     } catch (e) {
-      if (e.message.match(/^`status` takes 0 argument, 1 provided after:/)) {
-        done()
-      } else {
-        done(e)
-      }
+      assert(e.message.match(/^`status` takes 0 argument, 1 provided after:/))
     }
   })
 
   it('`wait` should work', async function () {
     result = await r.db(dbName).table(tableName).wait().run()
     assert.equal(result.ready, 1)
-
-    await r.db(dbName).table(tableName).wait({waitFor: 'ready_for_writes', timeout: 2000}).run()
   })
 
   it('`wait` should work with options', async function () {
     result = await r.db(dbName).table(tableName).wait({waitFor: 'ready_for_writes'}).run()
+    assert.equal(result.ready, 1)
+
+    result = await r.db(dbName).table(tableName).wait({waitFor: 'ready_for_writes', timeout: 2000}).run()
     assert.equal(result.ready, 1)
   })
 
@@ -119,7 +116,6 @@ describe('administration', () => {
     try {
       result = await r.db(dbName).table(tableName).reconfigure({foo: 1}).run()
       assert.fail('should throw')
-      assert.equal(result.reconfigured, 0)
     } catch (e) {
       assert(e.message.match(/^Unrecognized option `foo` in `reconfigure` after:/))
     }

--- a/test/administration.js
+++ b/test/administration.js
@@ -7,7 +7,7 @@ const uuid = util.uuid
 const {before, after, describe, it} = require('mocha')
 
 describe('administration', () => {
-  let r, dbName, tableName, result
+  let r, dbName, tableName
 
   before(async () => {
     r = await rethinkdbdash(config)
@@ -15,7 +15,7 @@ describe('administration', () => {
     dbName = uuid()
     tableName = uuid()
 
-    result = await r.dbCreate(dbName).run()
+    let result = await r.dbCreate(dbName).run()
     assert.equal(result.dbs_created, 1)
 
     result = await r.db(dbName).tableCreate(tableName).run()
@@ -31,7 +31,7 @@ describe('administration', () => {
   })
 
   it('`config` should work', async function () {
-    result = await r.db(dbName).config().run()
+    let result = await r.db(dbName).config().run()
     assert.equal(result.name, dbName)
 
     result = await r.db(dbName).table(tableName).config().run()
@@ -48,7 +48,7 @@ describe('administration', () => {
   })
 
   it('`status` should work', async function () {
-    result = await r.db(dbName).table(tableName).status().run()
+    const result = await r.db(dbName).table(tableName).status().run()
     assert.equal(result.name, tableName)
     assert.notEqual(result.status, undefined)
   })
@@ -63,12 +63,12 @@ describe('administration', () => {
   })
 
   it('`wait` should work', async function () {
-    result = await r.db(dbName).table(tableName).wait().run()
+    const result = await r.db(dbName).table(tableName).wait().run()
     assert.equal(result.ready, 1)
   })
 
   it('`wait` should work with options', async function () {
-    result = await r.db(dbName).table(tableName).wait({waitFor: 'ready_for_writes'}).run()
+    let result = await r.db(dbName).table(tableName).wait({waitFor: 'ready_for_writes'}).run()
     assert.equal(result.ready, 1)
 
     result = await r.db(dbName).table(tableName).wait({waitFor: 'ready_for_writes', timeout: 2000}).run()
@@ -94,18 +94,18 @@ describe('administration', () => {
   })
 
   it('`reconfigure` should work - 1', async function () {
-    result = await r.db(dbName).table(tableName).reconfigure({shards: 1, replicas: 1}).run()
+    const result = await r.db(dbName).table(tableName).reconfigure({shards: 1, replicas: 1}).run()
     assert.equal(result.reconfigured, 1)
   })
 
   it('`reconfigure` should work - 2 - dryRun', async function () {
-    result = await r.db(dbName).table(tableName).reconfigure({shards: 1, replicas: 1, dryRun: true}).run()
+    const result = await r.db(dbName).table(tableName).reconfigure({shards: 1, replicas: 1, dryRun: true}).run()
     assert.equal(result.reconfigured, 0)
   })
 
   it('`r.reconfigure` should throw', async function () {
     try {
-      result = await r.reconfigure().run()
+      await r.reconfigure().run()
       assert.fail('should throw')
     } catch (e) {
       assert(e.message.match(/^`reconfigure` can only be called on a table or a database since 2.3./))
@@ -114,7 +114,7 @@ describe('administration', () => {
 
   it('`reconfigure` should throw on an unrecognized key', async function () {
     try {
-      result = await r.db(dbName).table(tableName).reconfigure({foo: 1}).run()
+      await r.db(dbName).table(tableName).reconfigure({foo: 1}).run()
       assert.fail('should throw')
     } catch (e) {
       assert(e.message.match(/^Unrecognized option `foo` in `reconfigure` after:/))
@@ -123,7 +123,7 @@ describe('administration', () => {
 
   it('`reconfigure` should throw on a number', async function () {
     try {
-      result = await r.db(dbName).table(tableName).reconfigure(1).run()
+      await r.db(dbName).table(tableName).reconfigure(1).run()
       assert.fail('should throw')
     } catch (e) {
       assert(e.message.match(/^First argument of `reconfigure` must be an object./))
@@ -131,13 +131,13 @@ describe('administration', () => {
   })
 
   it('`rebalanced` should work - 1', async function () {
-    result = await r.db(dbName).table(tableName).rebalance().run()
+    const result = await r.db(dbName).table(tableName).rebalance().run()
     assert.equal(result.rebalanced, 1)
   })
 
   it('`r.rebalance` should throw', async function () {
     try {
-      result = await r.rebalance().run()
+      await r.rebalance().run()
       assert.fail('should throw')
     } catch (e) {
       assert(e.message.match(/^`rebalance` can only be called on a table or a database since 2.3./))
@@ -146,7 +146,7 @@ describe('administration', () => {
 
   it('`rebalance` should throw if an argument is provided', async function () {
     try {
-      result = await r.db(dbName).table(tableName).rebalance(1).run()
+      await r.db(dbName).table(tableName).rebalance(1).run()
       assert.fail('should throw')
     } catch (e) {
       assert(e.message.match(/^`rebalance` takes 0 argument, 1 provided after:/))

--- a/test/aggregation.js
+++ b/test/aggregation.js
@@ -1,430 +1,247 @@
-var config = require(__dirname+'/config.js');
-var r = require(__dirname+'/../lib')(config);
-var util = require(__dirname+'/util/common.js');
-var assert = require('assert');
+const path = require('path')
+const config = require(path.join(__dirname, '/config.js'))
+const rethinkdbdash = require(path.join(__dirname, '/../lib'))
+const util = require(path.join(__dirname, '/util/common.js'))
+const assert = require('assert')
+const uuid = util.uuid
+const {before, after, describe, it} = require('mocha')
 
-var uuid = util.uuid;
-var It = util.It;
+describe('aggregation', () => {
+  let r, dbName, tableName, result
 
-var uuid = util.uuid;
-var dbName, tableName;
+  before(async () => {
+    r = await rethinkdbdash(config)
 
+    dbName = uuid()
+    tableName = uuid()
 
-It('Init for `aggregation.js`', function* (done) {
-  try {
-    dbName = uuid();
-    tableName = uuid();
+    result = await r.dbCreate(dbName).run()
+    assert.equal(result.dbs_created, 1)
 
-    var result = yield r.dbCreate(dbName).run();
-    assert.equal(result.dbs_created, 1);
+    result = await r.db(dbName).tableCreate(tableName).run()
+    assert.equal(result.tables_created, 1)
+  })
 
-    var result = yield r.db(dbName).tableCreate(tableName).run();
-    assert.equal(result.tables_created, 1);
+  after(async () => {
+    await r.getPoolMaster().drain()
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-
-It('`reduce` should work -- no base ', function* (done) {
-  try {
-    var result = yield r.expr([1,2,3]).reduce(function(left, right) { return left.add(right) }).run();
-    assert.equal(result, 6);
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`reduce` should throw if no argument has been passed', function* (done) {
-  try {
-    var result = yield r.db(dbName).table(tableName).reduce().run();
-  }
-  catch(e) {
-    if (e.message === "`reduce` takes 1 argument, 0 provided after:\nr.db(\""+dbName+"\").table(\""+tableName+"\")") {
-      done()
+  it('`reduce` should work -- no base ', async () => {
+    result = await r.expr([1, 2, 3]).reduce(function (left, right) { return left.add(right) }).run()
+    assert.equal(result, 6)
+  })
+  it('`reduce` should throw if no argument has been passed', async () => {
+    try {
+      result = await r.db(dbName).table(tableName).reduce().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === '`reduce` takes 1 argument, 0 provided after:\nr.db("' + dbName + '").table("' + tableName + '")')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-It('`fold` should work', function* (done) {
-  try {
-    var result = yield r.expr([1,2,3]).fold(10, function(left, right) { return left.add(right) }).run();
-    assert.equal(result, 16);
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`fold` should work -- with emit', function* (done) {
-  try {
-    var result = yield r.expr(['foo', 'bar', 'buzz', 'hello', 'world']).fold(0, function(acc, row) {
-      return acc.add(1);
+  it('`fold` should work', async () => {
+    result = await r.expr([1, 2, 3]).fold(10, function (left, right) { return left.add(right) }).run()
+    assert.equal(result, 16)
+  })
+
+  it('`fold` should work -- with emit', async () => {
+    result = await r.expr(['foo', 'bar', 'buzz', 'hello', 'world']).fold(0, function (acc, row) {
+      return acc.add(1)
     }, {
-      emit: function(oldAcc, element, newAcc) {
-        return [oldAcc, element, newAcc];
+      emit: function (oldAcc, element, newAcc) {
+        return [oldAcc, element, newAcc]
       }
-    }).run();
-    assert.deepEqual(result, [0, 'foo', 1, 1, 'bar', 2, 2, 'buzz', 3, 3, 'hello', 4, 4, 'world', 5]);
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`fold` should work -- with emit and finalEmit', function* (done) {
-  try {
-    var result = yield r.expr(['foo', 'bar', 'buzz', 'hello', 'world']).fold(0, function(acc, row) {
-      return acc.add(1);
+    }).run()
+    assert.deepEqual(result, [0, 'foo', 1, 1, 'bar', 2, 2, 'buzz', 3, 3, 'hello', 4, 4, 'world', 5])
+  })
+
+  it('`fold` should work -- with emit and finalEmit', async () => {
+    result = await r.expr(['foo', 'bar', 'buzz', 'hello', 'world']).fold(0, function (acc, row) {
+      return acc.add(1)
     }, {
-      emit: function(oldAcc, element, newAcc) {
-        return [oldAcc, element, newAcc];
+      emit: function (oldAcc, element, newAcc) {
+        return [oldAcc, element, newAcc]
       },
-      finalEmit: function(acc) {
+      finalEmit: function (acc) {
         return [acc]
       }
-    }).run();
-    assert.deepEqual(result, [0, 'foo', 1, 1, 'bar', 2, 2, 'buzz', 3, 3, 'hello', 4, 4, 'world', 5, 5]);
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+    }).run()
+    assert.deepEqual(result, [0, 'foo', 1, 1, 'bar', 2, 2, 'buzz', 3, 3, 'hello', 4, 4, 'world', 5, 5])
+  })
 
+  it('`count` should work -- no arg ', async () => {
+    result = await r.expr([0, 1, 2, 3, 4, 5]).count().run()
+    assert.equal(result, 6)
+  })
 
-It('`count` should work -- no arg ', function* (done) {
-  try {
-    var result = yield r.expr([0, 1, 2, 3, 4, 5]).count().run();
-    assert.equal(result, 6);
+  it('`count` should work -- filter ', async () => {
+    result = await r.expr([0, 1, 2, 3, 4, 5]).count(r.row.eq(2)).run()
+    assert.equal(result, 1)
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`count` should work -- filter ', function* (done) {
-  try {
-    var result = yield r.expr([0, 1, 2, 3, 4, 5]).count(r.row.eq(2)).run();
-    assert.equal(result, 1);
+    result = await r.expr([0, 1, 2, 3, 4, 5]).count(function (doc) { return doc.eq(2) }).run()
+    assert.equal(result, 1)
+  })
 
-    result = yield r.expr([0, 1, 2, 3, 4, 5]).count(function(doc) { return doc.eq(2) }).run();
-    assert.equal(result, 1);
+  it('`group` should work ', async () => {
+    result = await r.expr([{name: 'Michel', grownUp: true}, {name: 'Laurent', grownUp: true},
+      {name: 'Sophie', grownUp: true}, {name: 'Luke', grownUp: false}, {name: 'Mino', grownUp: false}]).group('grownUp').run()
+    result.sort()
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`group` should work ', function* (done) {
-  try {
-    var result = yield r.expr([{name: "Michel", grownUp: true},{name: "Laurent", grownUp: true},
-      {name: "Sophie", grownUp: true},{name: "Luke", grownUp: false},{name: "Mino", grownUp: false}]).group('grownUp').run();
-    result.sort();
+    assert.deepEqual(result, [ { 'group': false, 'reduction': [ { 'grownUp': false, 'name': 'Luke' }, { 'grownUp': false, 'name': 'Mino' } ] }, { 'group': true, 'reduction': [ { 'grownUp': true, 'name': 'Michel' }, { 'grownUp': true, 'name': 'Laurent' }, { 'grownUp': true, 'name': 'Sophie' } ] } ])
+  })
 
-    assert.deepEqual(result, [ { "group": false, "reduction": [ { "grownUp": false, "name": "Luke" }, { "grownUp": false, "name": "Mino" } ] }, { "group": true, "reduction": [ { "grownUp": true, "name": "Michel" }, { "grownUp": true, "name": "Laurent" }, { "grownUp": true, "name": "Sophie" } ] } ])
+  it('`group` should work with r.row', async () => {
+    result = await r.expr([{name: 'Michel', grownUp: true}, {name: 'Laurent', grownUp: true},
+      {name: 'Sophie', grownUp: true}, {name: 'Luke', grownUp: false}, {name: 'Mino', grownUp: false}]).group(r.row('grownUp')).run()
+    result.sort()
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`group` should work with r.row', function* (done) {
-  try {
-    var result = yield r.expr([{name: "Michel", grownUp: true},{name: "Laurent", grownUp: true},
-      {name: "Sophie", grownUp: true},{name: "Luke", grownUp: false},{name: "Mino", grownUp: false}]).group(r.row('grownUp')).run();
-    result.sort();
+    assert.deepEqual(result, [ { 'group': false, 'reduction': [ { 'grownUp': false, 'name': 'Luke' }, { 'grownUp': false, 'name': 'Mino' } ] }, { 'group': true, 'reduction': [ { 'grownUp': true, 'name': 'Michel' }, { 'grownUp': true, 'name': 'Laurent' }, { 'grownUp': true, 'name': 'Sophie' } ] } ])
+  })
 
-    assert.deepEqual(result, [ { "group": false, "reduction": [ { "grownUp": false, "name": "Luke" }, { "grownUp": false, "name": "Mino" } ] }, { "group": true, "reduction": [ { "grownUp": true, "name": "Michel" }, { "grownUp": true, "name": "Laurent" }, { "grownUp": true, "name": "Sophie" } ] } ])
+  it('`group` should work with an index ', async () => {
+    result = await r.db(dbName).table(tableName).insert([
+      {id: 1, group: 1},
+      {id: 2, group: 1},
+      {id: 3, group: 1},
+      {id: 4, group: 4}
+    ]).run()
+    result = await r.db(dbName).table(tableName).indexCreate('group').run()
+    result = await r.db(dbName).table(tableName).indexWait('group').run()
+    result = await r.db(dbName).table(tableName).group({index: 'group'}).run()
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`group` should work with an index ', function* (done) {
+    assert.equal(result.length, 2)
+    assert(result[0].reduction.length === 3 || result[0].reduction.length === 1)
+    assert(result[1].reduction.length === 3 || result[1].reduction.length === 1)
+  })
 
-  try {
-    var result = yield r.db(dbName).table(tableName).insert([
-      {id:1, group: 1},
-      {id:2, group: 1},
-      {id:3, group: 1},
-      {id:4, group: 4},
-      ]).run();
-    result = yield r.db(dbName).table(tableName).indexCreate("group").run();
-    result = yield r.db(dbName).table(tableName).indexWait("group").run();
-    result = yield r.db(dbName).table(tableName).group({index: "group"}).run();
+  it('`groupFormat` should work -- with raw', async () => {
+    result = await r.expr([{name: 'Michel', grownUp: true}, {name: 'Laurent', grownUp: true},
+      {name: 'Sophie', grownUp: true}, {name: 'Luke', grownUp: false}, {name: 'Mino', grownUp: false}]).group('grownUp').run({groupFormat: 'raw'})
 
-    assert.equal(result.length, 2);
-    assert(result[0].reduction.length === 3 || result[0].reduction.length === 1);
-    assert(result[1].reduction.length === 3 || result[1].reduction.length === 1);
-    done();
-  }
-  catch(e) {
-    console.log(e);
-    done(e);
-  }
-})
+    assert.deepEqual(result, { '$reql_type$': 'GROUPED_DATA', 'data': [ [ false, [ { 'grownUp': false, 'name': 'Luke' }, { 'grownUp': false, 'name': 'Mino' } ] ], [ true, [ { 'grownUp': true, 'name': 'Michel' }, { 'grownUp': true, 'name': 'Laurent' }, { 'grownUp': true, 'name': 'Sophie' } ] ] ] })
+  })
 
-It('`groupFormat` should work -- with raw', function* (done) {
-  try {
-    var result = yield r.expr([{name: "Michel", grownUp: true},{name: "Laurent", grownUp: true},
-      {name: "Sophie", grownUp: true},{name: "Luke", grownUp: false},{name: "Mino", grownUp: false}]).group('grownUp').run({groupFormat: "raw"});
+  it('`group` results should be properly parsed ', async () => {
+    result = await r.expr([{name: 'Michel', date: r.now()}, {name: 'Laurent', date: r.now()},
+      {name: 'Sophie', date: r.now().sub(1000)}]).group('date').run()
+    assert.equal(result.length, 2)
+    assert(result[0].group instanceof Date)
+    assert(result[0].reduction[0].date instanceof Date)
+  })
 
-    assert.deepEqual(result, { "$reql_type$": "GROUPED_DATA", "data": [ [ false, [ { "grownUp": false, "name": "Luke" }, { "grownUp": false, "name": "Mino" } ] ], [ true, [ { "grownUp": true, "name": "Michel" }, { "grownUp": true, "name": "Laurent" }, { "grownUp": true, "name": "Sophie" } ] ] ] })
+  it('`ungroup` should work ', async () => {
+    result = await r.expr([{name: 'Michel', grownUp: true}, {name: 'Laurent', grownUp: true},
+      {name: 'Sophie', grownUp: true}, {name: 'Luke', grownUp: false}, {name: 'Mino', grownUp: false}]).group('grownUp').ungroup().run()
+    result.sort()
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+    assert.deepEqual(result, [ { 'group': false, 'reduction': [ { 'grownUp': false, 'name': 'Luke' }, { 'grownUp': false, 'name': 'Mino' } ] }, { 'group': true, 'reduction': [ { 'grownUp': true, 'name': 'Michel' }, { 'grownUp': true, 'name': 'Laurent' }, { 'grownUp': true, 'name': 'Sophie' } ] } ])
+  })
 
-It('`group` results should be properly parsed ', function* (done) {
-  try {
-    var result = yield r.expr([{name: "Michel", date: r.now()},{name: "Laurent", date: r.now()},
-        {name: "Sophie", date: r.now().sub(1000)}]).group('date').run();
-    assert.equal(result.length, 2);
-    assert(result[0].group instanceof Date);
-    assert(result[0].reduction[0].date instanceof Date);
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+  it('`contains` should work ', async () => {
+    result = await r.expr([1, 2, 3]).contains(2).run()
+    assert.equal(result, true)
 
+    result = await r.expr([1, 2, 3]).contains(1, 2).run()
+    assert.equal(result, true)
 
-It('`ungroup` should work ', function* (done) {
-  try {
-    var result = yield r.expr([{name: "Michel", grownUp: true},{name: "Laurent", grownUp: true},
-      {name: "Sophie", grownUp: true},{name: "Luke", grownUp: false},{name: "Mino", grownUp: false}]).group('grownUp').ungroup().run();
-    result.sort();
+    result = await r.expr([1, 2, 3]).contains(1, 5).run()
+    assert.equal(result, false)
 
-    assert.deepEqual(result, [ { "group": false, "reduction": [ { "grownUp": false, "name": "Luke" }, { "grownUp": false, "name": "Mino" } ] }, { "group": true, "reduction": [ { "grownUp": true, "name": "Michel" }, { "grownUp": true, "name": "Laurent" }, { "grownUp": true, "name": "Sophie" } ] } ])
+    result = await r.expr([1, 2, 3]).contains(function (doc) { return doc.eq(1) }).run()
+    assert.equal(result, true)
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+    result = await r.expr([1, 2, 3]).contains(r.row.eq(1)).run()
+    assert.equal(result, true)
 
-It('`contains` should work ', function* (done) {
-  try{
-    var result = yield r.expr([1,2,3]).contains(2).run();
-    assert.equal(result, true);
+    result = await r.expr([1, 2, 3]).contains(r.row.eq(1), r.row.eq(2)).run()
+    assert.equal(result, true)
 
-    result = yield r.expr([1,2,3]).contains(1, 2).run();
-    assert.equal(result, true);
+    result = await r.expr([1, 2, 3]).contains(r.row.eq(1), r.row.eq(5)).run()
+    assert.equal(result, false)
+  })
 
-    result = yield r.expr([1,2,3]).contains(1, 5).run();
-    assert.equal(result, false);
-
-    result = yield r.expr([1,2,3]).contains(function(doc) { return doc.eq(1) }).run();
-    assert.equal(result, true);
-
-    result = yield r.expr([1,2,3]).contains(r.row.eq(1)).run();
-    assert.equal(result, true);
-
-    result = yield r.expr([1,2,3]).contains(r.row.eq(1), r.row.eq(2)).run();
-    assert.equal(result, true);
-
-    result = yield r.expr([1,2,3]).contains(r.row.eq(1), r.row.eq(5)).run();
-    assert.equal(result, false);
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`contains` should throw if called without arguments', function* (done) {
-  try {
-    var result = yield r.db(dbName).table(tableName).contains().run();
-  }
-  catch(e) {
-    if (e.message === "`contains` takes at least 1 argument, 0 provided after:\nr.db(\""+dbName+"\").table(\""+tableName+"\")") {
-      done()
+  it('`contains` should throw if called without arguments', async () => {
+    try {
+      result = await r.db(dbName).table(tableName).contains().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === '`contains` takes at least 1 argument, 0 provided after:\nr.db("' + dbName + '").table("' + tableName + '")')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-It('`sum` should work ', function* (done) {
-  try{
-    var result = yield r.expr([1,2,3]).sum().run();
-    assert.equal(result, 6);
+  it('`sum` should work ', async () => {
+    result = await r.expr([1, 2, 3]).sum().run()
+    assert.equal(result, 6)
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-
-It('`sum` should work with a field', function* (done) {
-  try {
-    var result = yield r.expr([{a: 2}, {a: 10}, {a: 9}]).sum('a').run();
+  it('`sum` should work with a field', async () => {
+    result = await r.expr([{a: 2}, {a: 10}, {a: 9}]).sum('a').run()
     assert.deepEqual(result, 21)
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+  })
 
+  it('`avg` should work ', async () => {
+    result = await r.expr([1, 2, 3]).avg().run()
+    assert.equal(result, 2)
+  })
 
+  it('`r.avg` should work ', async () => {
+    result = await r.avg([1, 2, 3]).run()
+    assert.equal(result, 2)
+  })
 
-It('`avg` should work ', function* (done) {
-  try{
-    var result = yield r.expr([1,2,3]).avg().run();
-    assert.equal(result, 2);
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`r.avg` should work ', function* (done) {
-  try{
-    var result = yield r.avg([1,2,3]).run();
-    assert.equal(result, 2);
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+  it('`avg` should work with a field', async () => {
+    result = await r.expr([{a: 2}, {a: 10}, {a: 9}]).avg('a').run()
+    assert.equal(result, 7)
+  })
 
-It('`avg` should work with a field', function* (done) {
-  try {
-    var result = yield r.expr([{a: 2}, {a: 10}, {a: 9}]).avg('a').run();
-    assert.equal(result, 7);
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`r.avg` should work with a field', function* (done) {
-  try {
-    var result = yield r.avg([{a: 2}, {a: 10}, {a: 9}], 'a').run();
-    assert.equal(result, 7);
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+  it('`r.avg` should work with a field', async () => {
+    result = await r.avg([{a: 2}, {a: 10}, {a: 9}], 'a').run()
+    assert.equal(result, 7)
+  })
 
-It('`min` should work ', function* (done) {
-  try{
-    var result = yield r.expr([1,2,3]).min().run();
-    assert.equal(result, 1);
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`r.min` should work ', function* (done) {
-  try{
-    var result = yield r.min([1,2,3]).run();
-    assert.equal(result, 1);
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+  it('`min` should work ', async () => {
+    result = await r.expr([1, 2, 3]).min().run()
+    assert.equal(result, 1)
+  })
 
-It('`min` should work with a field', function* (done) {
-  try {
-    var result = yield r.expr([{a: 2}, {a: 10}, {a: 9}]).min('a').run();
-    assert.deepEqual(result, {a: 2});
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`r.min` should work with a field', function* (done) {
-  try {
-    var result = yield r.min([{a: 2}, {a: 10}, {a: 9}], 'a').run();
-    assert.deepEqual(result, {a: 2});
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+  it('`r.min` should work ', async () => {
+    result = await r.min([1, 2, 3]).run()
+    assert.equal(result, 1)
+  })
 
-It('`max` should work ', function* (done) {
-  try{
-    var result = yield r.expr([1,2,3]).max().run();
-    assert.equal(result, 3);
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`r.max` should work ', function* (done) {
-  try{
-    var result = yield r.max([1,2,3]).run();
-    assert.equal(result, 3);
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+  it('`min` should work with a field', async () => {
+    result = await r.expr([{a: 2}, {a: 10}, {a: 9}]).min('a').run()
+    assert.deepEqual(result, {a: 2})
+  })
 
-It('`distinct` should work', function* (done) {
-  try {
-    var result = yield r.expr([1,2,3,1,2,1,3,2,2,1,4]).distinct().orderBy(r.row).run();
-    assert.deepEqual(result, [1,2,3,4]);
-    done();
-  }
-  catch(e) {
-    console.log(e);
-    done(e);
-  }
-})
-It('`r.distinct` should work', function* (done) {
-  try {
-    var result = yield r.distinct([1,2,3,1,2,1,3,2,2,1,4]).orderBy(r.row).run();
-    assert.deepEqual(result, [1,2,3,4]);
-    done();
-  }
-  catch(e) {
-    console.log(e);
-    done(e);
-  }
-})
+  it('`r.min` should work with a field', async () => {
+    result = await r.min([{a: 2}, {a: 10}, {a: 9}], 'a').run()
+    assert.deepEqual(result, {a: 2})
+  })
 
-It('`distinct` should work with an index', function* (done) {
-  try {
-    var result = yield r.db(dbName).table(tableName).distinct({index: "id"}).count().run();
-    var result2 = yield r.db(dbName).table(tableName).count().run();
-    assert.equal(result, result2);
-    done();
-  }
-  catch(e) {
-    console.log(e);
-    done(e);
-  }
+  it('`max` should work ', async () => {
+    result = await r.expr([1, 2, 3]).max().run()
+    assert.equal(result, 3)
+  })
+
+  it('`r.max` should work ', async () => {
+    result = await r.max([1, 2, 3]).run()
+    assert.equal(result, 3)
+  })
+
+  it('`distinct` should work', async () => {
+    result = await r.expr([1, 2, 3, 1, 2, 1, 3, 2, 2, 1, 4]).distinct().orderBy(r.row).run()
+    assert.deepEqual(result, [1, 2, 3, 4])
+  })
+
+  it('`r.distinct` should work', async () => {
+    result = await r.distinct([1, 2, 3, 1, 2, 1, 3, 2, 2, 1, 4]).orderBy(r.row).run()
+    assert.deepEqual(result, [1, 2, 3, 4])
+  })
+
+  it('`distinct` should work with an index', async () => {
+    result = await r.db(dbName).table(tableName).distinct({index: 'id'}).count().run()
+    const result2 = await r.db(dbName).table(tableName).count().run()
+    assert.equal(result, result2)
+  })
 })

--- a/test/aggregation.js
+++ b/test/aggregation.js
@@ -6,7 +6,7 @@ const {uuid} = require(path.join(__dirname, './util/common.js'))
 const {before, after, describe, it} = require('mocha')
 
 describe('aggregation', () => {
-  let r, dbName, tableName, result
+  let r, dbName, tableName
 
   before(async () => {
     r = await rethinkdbdash(config)
@@ -14,9 +14,8 @@ describe('aggregation', () => {
     dbName = uuid()
     tableName = uuid()
 
-    result = await r.dbCreate(dbName).run()
+    let result = await r.dbCreate(dbName).run()
     assert.equal(result.dbs_created, 1)
-
     result = await r.db(dbName).tableCreate(tableName).run()
     assert.equal(result.tables_created, 1)
   })
@@ -26,12 +25,12 @@ describe('aggregation', () => {
   })
 
   it('`reduce` should work -- no base ', async () => {
-    result = await r.expr([1, 2, 3]).reduce(function (left, right) { return left.add(right) }).run()
+    const result = await r.expr([1, 2, 3]).reduce(function (left, right) { return left.add(right) }).run()
     assert.equal(result, 6)
   })
   it('`reduce` should throw if no argument has been passed', async () => {
     try {
-      result = await r.db(dbName).table(tableName).reduce().run()
+      await r.db(dbName).table(tableName).reduce().run()
       assert.fail('should throw')
     } catch (e) {
       assert(e.message === '`reduce` takes 1 argument, 0 provided after:\nr.db("' + dbName + '").table("' + tableName + '")')
@@ -39,12 +38,12 @@ describe('aggregation', () => {
   })
 
   it('`fold` should work', async () => {
-    result = await r.expr([1, 2, 3]).fold(10, function (left, right) { return left.add(right) }).run()
+    const result = await r.expr([1, 2, 3]).fold(10, function (left, right) { return left.add(right) }).run()
     assert.equal(result, 16)
   })
 
   it('`fold` should work -- with emit', async () => {
-    result = await r.expr(['foo', 'bar', 'buzz', 'hello', 'world']).fold(0, function (acc, row) {
+    const result = await r.expr(['foo', 'bar', 'buzz', 'hello', 'world']).fold(0, function (acc, row) {
       return acc.add(1)
     }, {
       emit: function (oldAcc, element, newAcc) {
@@ -55,7 +54,7 @@ describe('aggregation', () => {
   })
 
   it('`fold` should work -- with emit and finalEmit', async () => {
-    result = await r.expr(['foo', 'bar', 'buzz', 'hello', 'world']).fold(0, function (acc, row) {
+    const result = await r.expr(['foo', 'bar', 'buzz', 'hello', 'world']).fold(0, function (acc, row) {
       return acc.add(1)
     }, {
       emit: function (oldAcc, element, newAcc) {
@@ -69,59 +68,97 @@ describe('aggregation', () => {
   })
 
   it('`count` should work -- no arg ', async () => {
-    result = await r.expr([0, 1, 2, 3, 4, 5]).count().run()
+    const result = await r.expr([0, 1, 2, 3, 4, 5]).count().run()
     assert.equal(result, 6)
   })
 
   it('`count` should work -- filter ', async () => {
-    result = await r.expr([0, 1, 2, 3, 4, 5]).count(r.row.eq(2)).run()
+    let result = await r.expr([0, 1, 2, 3, 4, 5]).count(r.row.eq(2)).run()
     assert.equal(result, 1)
-
     result = await r.expr([0, 1, 2, 3, 4, 5]).count(function (doc) { return doc.eq(2) }).run()
     assert.equal(result, 1)
   })
 
   it('`group` should work ', async () => {
-    result = await r.expr([{name: 'Michel', grownUp: true}, {name: 'Laurent', grownUp: true},
-      {name: 'Sophie', grownUp: true}, {name: 'Luke', grownUp: false}, {name: 'Mino', grownUp: false}]).group('grownUp').run()
+    const result = await r.expr([{name: 'Michel', grownUp: true}, {name: 'Laurent', grownUp: true},
+      {name: 'Sophie', grownUp: true}, {name: 'Luke', grownUp: false}, {
+        name: 'Mino',
+        grownUp: false
+      }]).group('grownUp').run()
     result.sort()
 
-    assert.deepEqual(result, [ { 'group': false, 'reduction': [ { 'grownUp': false, 'name': 'Luke' }, { 'grownUp': false, 'name': 'Mino' } ] }, { 'group': true, 'reduction': [ { 'grownUp': true, 'name': 'Michel' }, { 'grownUp': true, 'name': 'Laurent' }, { 'grownUp': true, 'name': 'Sophie' } ] } ])
+    assert.deepEqual(result, [{
+      'group': false,
+      'reduction': [{'grownUp': false, 'name': 'Luke'}, {'grownUp': false, 'name': 'Mino'}]
+    }, {
+      'group': true,
+      'reduction': [{'grownUp': true, 'name': 'Michel'}, {'grownUp': true, 'name': 'Laurent'}, {
+        'grownUp': true,
+        'name': 'Sophie'
+      }]
+    }])
   })
 
   it('`group` should work with r.row', async () => {
-    result = await r.expr([{name: 'Michel', grownUp: true}, {name: 'Laurent', grownUp: true},
-      {name: 'Sophie', grownUp: true}, {name: 'Luke', grownUp: false}, {name: 'Mino', grownUp: false}]).group(r.row('grownUp')).run()
+    const result = await r.expr([{name: 'Michel', grownUp: true}, {name: 'Laurent', grownUp: true},
+      {name: 'Sophie', grownUp: true}, {name: 'Luke', grownUp: false}, {
+        name: 'Mino',
+        grownUp: false
+      }]).group(r.row('grownUp')).run()
     result.sort()
 
-    assert.deepEqual(result, [ { 'group': false, 'reduction': [ { 'grownUp': false, 'name': 'Luke' }, { 'grownUp': false, 'name': 'Mino' } ] }, { 'group': true, 'reduction': [ { 'grownUp': true, 'name': 'Michel' }, { 'grownUp': true, 'name': 'Laurent' }, { 'grownUp': true, 'name': 'Sophie' } ] } ])
+    assert.deepEqual(result, [{
+      'group': false,
+      'reduction': [{'grownUp': false, 'name': 'Luke'}, {'grownUp': false, 'name': 'Mino'}]
+    }, {
+      'group': true,
+      'reduction': [{'grownUp': true, 'name': 'Michel'}, {'grownUp': true, 'name': 'Laurent'}, {
+        'grownUp': true,
+        'name': 'Sophie'
+      }]
+    }])
   })
 
   it('`group` should work with an index ', async () => {
-    result = await r.db(dbName).table(tableName).insert([
+    let result = await r.db(dbName).table(tableName).insert([
       {id: 1, group: 1},
       {id: 2, group: 1},
       {id: 3, group: 1},
       {id: 4, group: 4}
     ]).run()
+    assert.equal(result.inserted, 4)
     result = await r.db(dbName).table(tableName).indexCreate('group').run()
+    assert.equal(result.created, 1)
     result = await r.db(dbName).table(tableName).indexWait('group').run()
+    assert.equal(result.length, 1)
+    assert.equal(result[0].ready, true, 'expected index group to be ready after waiting for it')
     result = await r.db(dbName).table(tableName).group({index: 'group'}).run()
-
     assert.equal(result.length, 2)
     assert(result[0].reduction.length === 3 || result[0].reduction.length === 1)
     assert(result[1].reduction.length === 3 || result[1].reduction.length === 1)
   })
 
   it('`groupFormat` should work -- with raw', async () => {
-    result = await r.expr([{name: 'Michel', grownUp: true}, {name: 'Laurent', grownUp: true},
-      {name: 'Sophie', grownUp: true}, {name: 'Luke', grownUp: false}, {name: 'Mino', grownUp: false}]).group('grownUp').run({groupFormat: 'raw'})
+    const result = await r.expr([{name: 'Michel', grownUp: true}, {name: 'Laurent', grownUp: true},
+      {name: 'Sophie', grownUp: true}, {name: 'Luke', grownUp: false}, {
+        name: 'Mino',
+        grownUp: false
+      }]).group('grownUp').run({groupFormat: 'raw'})
 
-    assert.deepEqual(result, { '$reql_type$': 'GROUPED_DATA', 'data': [ [ false, [ { 'grownUp': false, 'name': 'Luke' }, { 'grownUp': false, 'name': 'Mino' } ] ], [ true, [ { 'grownUp': true, 'name': 'Michel' }, { 'grownUp': true, 'name': 'Laurent' }, { 'grownUp': true, 'name': 'Sophie' } ] ] ] })
+    assert.deepEqual(result, {
+      '$reql_type$': 'GROUPED_DATA',
+      'data': [[false, [{'grownUp': false, 'name': 'Luke'}, {
+        'grownUp': false,
+        'name': 'Mino'
+      }]], [true, [{'grownUp': true, 'name': 'Michel'}, {'grownUp': true, 'name': 'Laurent'}, {
+        'grownUp': true,
+        'name': 'Sophie'
+      }]]]
+    })
   })
 
   it('`group` results should be properly parsed ', async () => {
-    result = await r.expr([{name: 'Michel', date: r.now()}, {name: 'Laurent', date: r.now()},
+    const result = await r.expr([{name: 'Michel', date: r.now()}, {name: 'Laurent', date: r.now()},
       {name: 'Sophie', date: r.now().sub(1000)}]).group('date').run()
     assert.equal(result.length, 2)
     assert(result[0].group instanceof Date)
@@ -129,39 +166,45 @@ describe('aggregation', () => {
   })
 
   it('`ungroup` should work ', async () => {
-    result = await r.expr([{name: 'Michel', grownUp: true}, {name: 'Laurent', grownUp: true},
-      {name: 'Sophie', grownUp: true}, {name: 'Luke', grownUp: false}, {name: 'Mino', grownUp: false}]).group('grownUp').ungroup().run()
+    const result = await r.expr([{name: 'Michel', grownUp: true}, {name: 'Laurent', grownUp: true},
+      {name: 'Sophie', grownUp: true}, {name: 'Luke', grownUp: false}, {
+        name: 'Mino',
+        grownUp: false
+      }]).group('grownUp').ungroup().run()
     result.sort()
 
-    assert.deepEqual(result, [ { 'group': false, 'reduction': [ { 'grownUp': false, 'name': 'Luke' }, { 'grownUp': false, 'name': 'Mino' } ] }, { 'group': true, 'reduction': [ { 'grownUp': true, 'name': 'Michel' }, { 'grownUp': true, 'name': 'Laurent' }, { 'grownUp': true, 'name': 'Sophie' } ] } ])
+    assert.deepEqual(result, [{
+      'group': false,
+      'reduction': [{'grownUp': false, 'name': 'Luke'}, {'grownUp': false, 'name': 'Mino'}]
+    }, {
+      'group': true,
+      'reduction': [{'grownUp': true, 'name': 'Michel'}, {'grownUp': true, 'name': 'Laurent'}, {
+        'grownUp': true,
+        'name': 'Sophie'
+      }]
+    }])
   })
 
   it('`contains` should work ', async () => {
-    result = await r.expr([1, 2, 3]).contains(2).run()
+    let result = await r.expr([1, 2, 3]).contains(2).run()
     assert.equal(result, true)
-
     result = await r.expr([1, 2, 3]).contains(1, 2).run()
     assert.equal(result, true)
-
     result = await r.expr([1, 2, 3]).contains(1, 5).run()
     assert.equal(result, false)
-
     result = await r.expr([1, 2, 3]).contains(function (doc) { return doc.eq(1) }).run()
     assert.equal(result, true)
-
     result = await r.expr([1, 2, 3]).contains(r.row.eq(1)).run()
     assert.equal(result, true)
-
     result = await r.expr([1, 2, 3]).contains(r.row.eq(1), r.row.eq(2)).run()
     assert.equal(result, true)
-
     result = await r.expr([1, 2, 3]).contains(r.row.eq(1), r.row.eq(5)).run()
     assert.equal(result, false)
   })
 
   it('`contains` should throw if called without arguments', async () => {
     try {
-      result = await r.db(dbName).table(tableName).contains().run()
+      await r.db(dbName).table(tableName).contains().run()
       assert.fail('should throw')
     } catch (e) {
       assert(e.message === '`contains` takes at least 1 argument, 0 provided after:\nr.db("' + dbName + '").table("' + tableName + '")')
@@ -169,77 +212,77 @@ describe('aggregation', () => {
   })
 
   it('`sum` should work ', async () => {
-    result = await r.expr([1, 2, 3]).sum().run()
+    const result = await r.expr([1, 2, 3]).sum().run()
     assert.equal(result, 6)
   })
 
   it('`sum` should work with a field', async () => {
-    result = await r.expr([{a: 2}, {a: 10}, {a: 9}]).sum('a').run()
+    const result = await r.expr([{a: 2}, {a: 10}, {a: 9}]).sum('a').run()
     assert.deepEqual(result, 21)
   })
 
   it('`avg` should work ', async () => {
-    result = await r.expr([1, 2, 3]).avg().run()
+    const result = await r.expr([1, 2, 3]).avg().run()
     assert.equal(result, 2)
   })
 
   it('`r.avg` should work ', async () => {
-    result = await r.avg([1, 2, 3]).run()
+    const result = await r.avg([1, 2, 3]).run()
     assert.equal(result, 2)
   })
 
   it('`avg` should work with a field', async () => {
-    result = await r.expr([{a: 2}, {a: 10}, {a: 9}]).avg('a').run()
+    const result = await r.expr([{a: 2}, {a: 10}, {a: 9}]).avg('a').run()
     assert.equal(result, 7)
   })
 
   it('`r.avg` should work with a field', async () => {
-    result = await r.avg([{a: 2}, {a: 10}, {a: 9}], 'a').run()
+    const result = await r.avg([{a: 2}, {a: 10}, {a: 9}], 'a').run()
     assert.equal(result, 7)
   })
 
   it('`min` should work ', async () => {
-    result = await r.expr([1, 2, 3]).min().run()
+    const result = await r.expr([1, 2, 3]).min().run()
     assert.equal(result, 1)
   })
 
   it('`r.min` should work ', async () => {
-    result = await r.min([1, 2, 3]).run()
+    const result = await r.min([1, 2, 3]).run()
     assert.equal(result, 1)
   })
 
   it('`min` should work with a field', async () => {
-    result = await r.expr([{a: 2}, {a: 10}, {a: 9}]).min('a').run()
+    const result = await r.expr([{a: 2}, {a: 10}, {a: 9}]).min('a').run()
     assert.deepEqual(result, {a: 2})
   })
 
   it('`r.min` should work with a field', async () => {
-    result = await r.min([{a: 2}, {a: 10}, {a: 9}], 'a').run()
+    const result = await r.min([{a: 2}, {a: 10}, {a: 9}], 'a').run()
     assert.deepEqual(result, {a: 2})
   })
 
   it('`max` should work ', async () => {
-    result = await r.expr([1, 2, 3]).max().run()
+    const result = await r.expr([1, 2, 3]).max().run()
     assert.equal(result, 3)
   })
 
   it('`r.max` should work ', async () => {
-    result = await r.max([1, 2, 3]).run()
+    const result = await r.max([1, 2, 3]).run()
     assert.equal(result, 3)
   })
 
   it('`distinct` should work', async () => {
-    result = await r.expr([1, 2, 3, 1, 2, 1, 3, 2, 2, 1, 4]).distinct().orderBy(r.row).run()
+    const result = await r.expr([1, 2, 3, 1, 2, 1, 3, 2, 2, 1, 4]).distinct().orderBy(r.row).run()
     assert.deepEqual(result, [1, 2, 3, 4])
   })
 
   it('`r.distinct` should work', async () => {
-    result = await r.distinct([1, 2, 3, 1, 2, 1, 3, 2, 2, 1, 4]).orderBy(r.row).run()
+    const result = await r.distinct([1, 2, 3, 1, 2, 1, 3, 2, 2, 1, 4]).orderBy(r.row).run()
     assert.deepEqual(result, [1, 2, 3, 4])
   })
 
   it('`distinct` should work with an index', async () => {
-    result = await r.db(dbName).table(tableName).distinct({index: 'id'}).count().run()
+    const result = await r.db(dbName).table(tableName).distinct({index: 'id'}).count().run()
     const result2 = await r.db(dbName).table(tableName).count().run()
     assert.equal(result, result2)
   })

--- a/test/aggregation.js
+++ b/test/aggregation.js
@@ -1,9 +1,8 @@
 const path = require('path')
 const config = require(path.join(__dirname, '/config.js'))
 const rethinkdbdash = require(path.join(__dirname, '/../lib'))
-const util = require(path.join(__dirname, '/util/common.js'))
 const assert = require('assert')
-const uuid = util.uuid
+const {uuid} = require(path.join(__dirname, './util/common.js'))
 const {before, after, describe, it} = require('mocha')
 
 describe('aggregation', () => {

--- a/test/backtrace.js
+++ b/test/backtrace.js
@@ -7,14 +7,14 @@ const uuid = util.uuid
 const {before, after, describe, it} = require('mocha')
 
 describe('backtraces', () => {
-  let r, dbName, tableName, result
+  let r, dbName, tableName
 
   before(async () => {
     r = await rethinkdbdash(config)
     dbName = uuid()
     tableName = uuid()
 
-    result = await r.dbCreate(dbName).run()
+    let result = await r.dbCreate(dbName).run()
     assert.equal(result.dbs_created, 1)
 
     result = await r.db(dbName).tableCreate(tableName).run()

--- a/test/backtrace.js
+++ b/test/backtrace.js
@@ -948,11 +948,16 @@ It('Test backtrace for r.expr([1,2,3]).eqJoin("id", r.db(dbName).table(tableName
     done(new Error("Should have thrown an error"))
   }
   catch(e) {
-    if (e.message === "Cannot perform get_field on a non-object non-sequence `1` in:\nr.expr([1, 2, 3]).eqJoin(\"id\", r.db(\""+dbName+"\").table(\""+tableName+"\"))\n                         ^^^^                                                                                     \n    .add(1)\n") {
+    if(e.message === `Cannot perform get_field on a non-object non-sequence \`1\` in:
+r.expr([1, 2, 3]).eqJoin("id", r.db("${dbName}").table("${tableName}"))
+                         ^^^^                                                                                     
+    .add(1)
+`) {
       done()
     }
     else {
-      console.log(e.message); done(e);
+      console.log(e.message + 'great');
+      done(e);
     }
   }
 })
@@ -982,7 +987,7 @@ It('Test backtrace for r.expr([1,2,3]).eqJoin("id", r.db(dbName).table(tableName
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -1012,7 +1017,7 @@ It('Test backtrace for r.expr([1,2,3]).map(function(v) { return v}).add(1)', fun
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -1038,7 +1043,7 @@ It('Test backtrace for r.expr([1,2,3]).withFields("foo", "bar").add(1)', functio
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -1068,7 +1073,7 @@ It('Test backtrace for r.expr([1,2,3]).concatMap(function(v) { return v}).add(1)
             done()
         }
         else {
-            done(e);
+          done(e);
         }
     }
 })
@@ -1090,11 +1095,14 @@ It('Test backtrace for r.expr([1,2,3]).orderBy("foo").add(1)', function* (done) 
     done(new Error("Should have thrown an error"))
   }
   catch(e) {
-    if (e.message === "Cannot perform get_field on a non-object non-sequence `3` in:\nr.expr([1, 2, 3]).orderBy(\"foo\").add(1)\n                          ^^^^^        \n") {
+    if(e.message === `Cannot perform get_field on a non-object non-sequence \`2\` in:
+r.expr([1, 2, 3]).orderBy("foo").add(1)
+                          ^^^^^        
+`) {
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -1121,7 +1129,7 @@ It('Test backtrace for r.expr([1,2,3]).skip("foo").add(1)', function* (done) {
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -1148,7 +1156,7 @@ It('Test backtrace for r.expr([1,2,3]).limit("foo").add(1)', function* (done) {
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -1174,7 +1182,7 @@ It('Test backtrace for r.expr([1,2,3]).slice("foo", "bar").add(1)', function* (d
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -1254,7 +1262,7 @@ It('Test backtrace for r.expr([1,2,3]).isEmpty().add("Hello")', function* (done)
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -1280,7 +1288,7 @@ It('Test backtrace for r.expr([1,2,3]).union([5,6]).add("Hello")', function* (do
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -1307,7 +1315,7 @@ It('Test backtrace for r.expr([1,2,3]).sample("Hello")', function* (done) {
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -1338,7 +1346,7 @@ It('Test backtrace for r.expr([1,2,3]).count(function() { return true}).add("Hel
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -1365,7 +1373,7 @@ It('Test backtrace for r.expr([1,2,3]).distinct().add("Hello")', function* (done
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -1392,7 +1400,7 @@ It('Test backtrace for r.expr([1,2,3]).contains("foo", "bar").add("Hello")', fun
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -1449,7 +1457,7 @@ It('Test backtrace for r.expr([1,2,3]).pluck("foo").add("Hello")', function* (do
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -1476,7 +1484,7 @@ It('Test backtrace for r.expr([1,2,3]).without("foo").add("Hello")', function* (
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -1503,7 +1511,7 @@ It('Test backtrace for r.expr([1,2,3]).merge("foo").add("Hello")', function* (do
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -1530,7 +1538,7 @@ It('Test backtrace for r.expr([1,2,3]).append("foo").add("Hello")', function* (d
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -1557,7 +1565,7 @@ It('Test backtrace for r.expr([1,2,3]).prepend("foo").add("Hello")', function* (
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -1584,7 +1592,7 @@ It('Test backtrace for r.expr([1,2,3]).difference("foo").add("Hello")', function
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -1610,7 +1618,7 @@ It('Test backtrace for r.expr([1,2,3]).setInsert("foo").add("Hello")', function*
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -1636,7 +1644,7 @@ It('Test backtrace for r.expr([1,2,3]).setUnion("foo").add("Hello")', function* 
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -1662,7 +1670,7 @@ It('Test backtrace for r.expr([1,2,3]).setIntersection("foo").add("Hello")', fun
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -1715,7 +1723,7 @@ It('Test backtrace for r.expr([1,2,3]).hasFields("foo").add("Hello")', function*
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -1741,7 +1749,7 @@ It('Test backtrace for r.expr([1,2,3]).insertAt("foo", 2).add("Hello")', functio
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -1767,7 +1775,7 @@ It('Test backtrace for r.expr([1,2,3]).spliceAt("foo", 2).add("Hello")', functio
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -1794,7 +1802,7 @@ It('Test backtrace for r.expr([1,2,3]).deleteAt("foo", 2).add("Hello")', functio
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -1821,7 +1829,7 @@ It('Test backtrace for r.expr([1,2,3]).changeAt("foo", 2).add("Hello")', functio
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -1874,7 +1882,7 @@ It('Test backtrace for r.expr([1,2,3]).match("foo").add("Hello")', function* (do
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -1901,7 +1909,7 @@ It('Test backtrace for r.expr([1,2,3]).add("Hello")', function* (done) {
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -1928,7 +1936,7 @@ It('Test backtrace for r.expr([1,2,3]).sub("Hello")', function* (done) {
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -1954,7 +1962,7 @@ It('Test backtrace for r.expr([1,2,3]).mul("Hello")', function* (done) {
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -1980,7 +1988,7 @@ It('Test backtrace for r.expr([1,2,3]).div("Hello")', function* (done) {
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -2007,7 +2015,7 @@ It('Test backtrace for r.expr([1,2,3]).mod("Hello")', function* (done) {
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -2033,7 +2041,7 @@ It('Test backtrace for r.expr([1,2,3]).and(r.expr("Hello").add(2))', function* (
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -2060,7 +2068,7 @@ It('Test backtrace for r.expr(false).or(r.expr("Hello").add(2))', function* (don
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -2087,7 +2095,7 @@ It('Test backtrace for r.expr([1,2,3]).eq(r.expr("Hello").add(2))', function* (d
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -2113,7 +2121,7 @@ It('Test backtrace for r.expr([1,2,3]).ne(r.expr("Hello").add(2))', function* (d
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -2139,7 +2147,7 @@ It('Test backtrace for r.expr([1,2,3]).gt(r.expr("Hello").add(2))', function* (d
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -2165,7 +2173,7 @@ It('Test backtrace for r.expr([1,2,3]).lt(r.expr("Hello").add(2))', function* (d
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -2192,7 +2200,7 @@ It('Test backtrace for r.expr([1,2,3]).le(r.expr("Hello").add(2))', function* (d
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -2218,7 +2226,7 @@ It('Test backtrace for r.expr([1,2,3]).ge(r.expr("Hello").add(2))', function* (d
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -2244,7 +2252,7 @@ It('Test backtrace for r.expr([1,2,3]).not().add(r.expr("Hello").add(2))', funct
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -2270,7 +2278,7 @@ It('Test backtrace for r.now().add("Hello")', function* (done) {
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -2297,7 +2305,7 @@ It('Test backtrace for r.time(1023, 11, 3, "Z").add("Hello")', function* (done) 
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -2324,7 +2332,7 @@ It('Test backtrace for r.epochTime(12132131).add("Hello")', function* (done) {
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -2350,7 +2358,7 @@ It('Test backtrace for r.ISO8601("UnvalidISO961String").add("Hello")', function*
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -2376,7 +2384,7 @@ It('Test backtrace for r.now().inTimezone("noTimezone").add("Hello")', function*
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -2402,7 +2410,7 @@ It('Test backtrace for r.now().timezone().add(true)', function* (done) {
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -2428,7 +2436,7 @@ It('Test backtrace for r.now().during(r.now(), r.now()).add(true)', function* (d
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -2454,7 +2462,7 @@ It('Test backtrace for r.now().timeOfDay().add(true)', function* (done) {
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -2481,7 +2489,7 @@ It('Test backtrace for r.now().year().add(true)', function* (done) {
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -2507,7 +2515,7 @@ It('Test backtrace for r.now().month().add(true)', function* (done) {
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -2533,7 +2541,7 @@ It('Test backtrace for r.now().day().add(true)', function* (done) {
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -2559,7 +2567,7 @@ It('Test backtrace for r.now().dayOfWeek().add(true)', function* (done) {
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -2585,7 +2593,7 @@ It('Test backtrace for r.now().dayOfYear().add(true)', function* (done) {
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -2612,7 +2620,7 @@ It('Test backtrace for r.now().hours().add(true)', function* (done) {
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -2638,7 +2646,7 @@ It('Test backtrace for r.now().minutes().add(true)', function* (done) {
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -2664,7 +2672,7 @@ It('Test backtrace for r.now().seconds().add(true)', function* (done) {
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -2690,7 +2698,7 @@ It('Test backtrace for r.now().toISO8601().add(true)', function* (done) {
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -2716,7 +2724,7 @@ It('Test backtrace for r.now().toEpochTime().add(true)', function* (done) {
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -2803,7 +2811,7 @@ It('Test backtrace for r.expr(1).forEach(function(foo) { return foo("bar") })', 
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -2830,7 +2838,7 @@ It('Test backtrace for r.error("foo")', function* (done) {
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -2861,7 +2869,7 @@ It('Test backtrace for r.expr({a:1})("b").default("bar").add(2)', function* (don
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -2891,7 +2899,7 @@ It('Test backtrace for r.expr({a:1}).add(2)', function* (done) {
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -2921,7 +2929,7 @@ It('Test backtrace for r.expr({a:1}).add(r.js("2"))', function* (done) {
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -2947,7 +2955,7 @@ It('Test backtrace for r.expr(2).coerceTo("ARRAY")', function* (done) {
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -2973,7 +2981,7 @@ It('Test backtrace for r.expr(2).add("foo").typeOf()', function* (done) {
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -2999,7 +3007,7 @@ It('Test backtrace for r.expr(2).add("foo").info()', function* (done) {
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -3051,7 +3059,7 @@ It('Test backtrace for r.db(dbName).table(tableName).replace({a:1}, {nonValid:tr
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -3116,7 +3124,7 @@ It('Test backtrace for r.expr([1,2]).map(r.row.add("eh"))', function* (done) {
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -3164,56 +3172,35 @@ It('Test backtrace for r.table("foo").add(1).add(1).add("hello-super-long-string
     done(new Error("Should have thrown an error"))
   }
   catch(e) {
-    if (e.message === `Database \`test\` does not exist in:
+    if (e.message === `Table \`test.foo\` does not exist in:
 r.table("foo").add(1).add(1).add("hello-super-long-string").add("another-long-string")
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^                                                                        
     .add("one-last-string").map(function(var_1) {
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
         return r.expr([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]).map(function(var_2) {
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
             return var_2("b").add("hello-super-long-string").add("another-long-string").add("one-last-string")
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                 .add("hello-super-long-string").add("another-long-string").add("one-last-string")
-                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                 .add("hello-super-long-string").add("another-long-string").add("one-last-string")
-                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                 .add("hello-super-long-string").add("another-long-string").add("one-last-string")
-                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                 .add("hello-super-long-string").add("another-long-string").add("one-last-string")
-                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                 .mul(var_2("b")).merge({
-                ^^^^^^^^^^^^^^^^^^^^^^^^
                     firstName: "xxxxxx",
-                    ^^^^^^^^^^^^^^^^^^^^
                     lastName: "yyyy",
-                    ^^^^^^^^^^^^^^^^^
                     email: "xxxxx@yyyy.com",
-                    ^^^^^^^^^^^^^^^^^^^^^^^^
                     phone: "xxx-xxx-xxxx"
-                    ^^^^^^^^^^^^^^^^^^^^^
                 })
-                ^^
         }).add(2).map(function(var_3) {
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
             return var_3.add("hello-super-long-string").add("another-long-string").add("one-last-string")
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                 .add("hello-super-long-string").add("another-long-string").add("one-last-string")
-                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                 .add("hello-super-long-string").add("another-long-string").add("one-last-string")
-                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                 .add("hello-super-long-string").add("another-long-string").add("one-last-string")
-                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                 .add("hello-super-long-string").add("another-long-string").add("one-last-string")
-                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
         })
-        ^^
     })
-    ^^
 `) {
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -3242,7 +3229,7 @@ It('Test backtrace for r.expr({a:1, b:r.expr(1).add("eh")})', function* (done) {
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -3280,7 +3267,7 @@ It('Test backtrace for r.db(dbName).table(tableName).replace({a:1}, {durability:
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -3313,7 +3300,7 @@ It('Test backtrace for r.db(dbName).table(tableName).replace({a:1}, {durability:
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -3346,7 +3333,7 @@ It('Test backtrace for r.db(dbName).table(tableName).replace({a:1}, {durability:
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -3374,7 +3361,7 @@ It('Test backtrace for r.expr({a:r.expr(1).add("eh"), b: 2})', function* (done) 
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -3400,7 +3387,7 @@ It('Test backtrace for r.expr([1,2,3]).add("eh")', function* (done) {
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -3431,7 +3418,7 @@ It('Test backtrace for r.expr({a:1}).add("eh")', function* (done) {
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -3458,7 +3445,7 @@ It('Test backtrace for r.expr([1,2,3]).group("foo")', function* (done) {
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -3515,7 +3502,7 @@ It('Test backtrace for r.expr([1,2,3,"hello"]).sum()', function* (done) {
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -3541,7 +3528,7 @@ It('Test backtrace for r.expr([1,2,3,"hello"]).avg()', function* (done) {
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -3567,7 +3554,7 @@ It('Test backtrace for r.expr([]).min()', function* (done) {
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -3592,7 +3579,7 @@ It('Test backtrace for r.expr([]).max()', function* (done) {
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -3617,7 +3604,7 @@ It('Test backtrace for r.expr([]).avg()', function* (done) {
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -3643,7 +3630,7 @@ It('Test backtrace for r.expr(1).upcase()', function* (done) {
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })
@@ -3668,7 +3655,7 @@ It('Test backtrace for r.expr(1).downcase()', function* (done) {
       done()
     }
     else {
-      console.log(e.message); done(e);
+      done(e);
     }
   }
 })

--- a/test/backtrace.js
+++ b/test/backtrace.js
@@ -6,7 +6,7 @@ const assert = require('assert')
 const uuid = util.uuid
 const {before, after, describe, it} = require('mocha')
 
-describe('administration', () => {
+describe('backtraces', () => {
   let r, dbName, tableName, result
 
   before(async () => {

--- a/test/backtrace.js
+++ b/test/backtrace.js
@@ -1,35 +1,35 @@
-var config = require(__dirname+'/config.js');
-var r = require(__dirname+'/../lib')(config);
-var util = require(__dirname+'/util/common.js');
-var assert = require('assert');
+const path = require('path')
+const config = require(path.join(__dirname, '/config.js'))
+const rethinkdbdash = require(path.join(__dirname, '/../lib'))
+const util = require(path.join(__dirname, '/util/common.js'))
+const assert = require('assert')
+const uuid = util.uuid
+const {before, after, describe, it} = require('mocha')
 
-var uuid = util.uuid;
-var It = util.It;
+describe('administration', () => {
+  let r, dbName, tableName, result
 
-var uuid = util.uuid;
-var dbName, tableName, pks, result;
+  before(async () => {
+    r = await rethinkdbdash(config)
+    dbName = uuid()
+    tableName = uuid()
 
-It('Init for backtraces', function* (done) {
-  try {
-    dbName = uuid();
-    tableName = uuid();
+    result = await r.dbCreate(dbName).run()
+    assert.equal(result.dbs_created, 1)
 
-    result = yield r.dbCreate(dbName).run();
-    assert.equal(result.dbs_created, 1);
+    result = await r.db(dbName).tableCreate(tableName).run()
+    assert.equal(result.tables_created, 1)
 
-    result = yield r.db(dbName).tableCreate(tableName).run();
-    assert.equal(result.tables_created, 1);
+    result = await r.db(dbName).table(tableName).insert(Array(100).fill({})).run()
+    assert.equal(result.inserted, 100)
+    assert.equal(result.generated_keys.length, 100)
+  })
 
-    result = yield r.db(dbName).table(tableName).insert(eval('['+new Array(100).join('{}, ')+'{}]')).run();
-    assert.equal(result.inserted, 100);
+  after(async () => {
+    await r.getPoolMaster().drain()
+  })
 
-    done();
-  }
-  catch(e) {
-    console.log(e.message); done(e);
-  }
-})
-/*
+  /*
  *** NOTE ***
  *
  * Most of the backtraces are broken on the server.
@@ -42,59 +42,45 @@ It('Init for backtraces', function* (done) {
  ************
  */
 
-/*
+  /*
 Frames:
 [ { type: 'POS', pos: 0 } ]
 
 Error:
 Expected type STRING but found NUMBER in:
 r.dbDrop(1)
-     ^ 
+     ^
 */
-It('Test backtrace for r.dbDrop(1)', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.dbDrop(1).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type STRING but found NUMBER in:\nr.dbDrop(1)\n         ^ \n") {
-      done()
+  it('Test backtrace for r.dbDrop(1)', async () => {
+    try {
+      r.nextVarId = 1
+      await r.dbDrop(1).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type STRING but found NUMBER in:\nr.dbDrop(1)\n         ^ \n')
     }
-    else {
-      console.log(e.message); done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 [ { type: 'POS', pos: 0 } ]
 
 Error:
 Expected type STRING but found NUMBER in:
 r.dbCreate(1)
-       ^ 
+       ^
 */
-It('Test backtrace for r.dbCreate(1)', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.dbCreate(1).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type STRING but found NUMBER in:\nr.dbCreate(1)\n           ^ \n") {
-      done()
+  it('Test backtrace for r.dbCreate(1)', async () => {
+    try {
+      r.nextVarId = 1
+      await r.dbCreate(1).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type STRING but found NUMBER in:\nr.dbCreate(1)\n           ^ \n')
     }
-    else {
-      console.log(e.message); done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 //TODO Broken on the server
 Frames:
 [ { type: 'POS', pos: 0 }, { type: 'POS', pos: 1 } ]
@@ -106,25 +92,17 @@ r.dbList().do(function(var_1) {
        ^^^^^^^^^^^^^^
 })
 */
-It('Test backtrace for r.dbList().do(function(x) { return x.add("a") })', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.dbList().do(function(x) { return x.add("a") }).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type ARRAY but found STRING in:\nr.dbList().do(function(var_1) {\n    return var_1.add(\"a\")\n           ^^^^^^^^^^^^^^\n})\n") {
-      done()
+  it('Test backtrace for r.dbList().do(function(x) { return x.add("a") })', async () => {
+    try {
+      r.nextVarId = 1
+      await r.dbList().do(function (x) { return x.add('a') }).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type ARRAY but found STRING in:\nr.dbList().do(function(var_1) {\n    return var_1.add("a")\n           ^^^^^^^^^^^^^^\n})\n')
     }
-    else {
-      console.log(e.message); done(e);
-    }
-  }
-})
+  })
 
-
-
-/*
+  /*
 //TODO Broken on the server
 Frames:
 [ { type: 'POS', pos: 0 }, { type: 'POS', pos: 1 } ]
@@ -136,24 +114,17 @@ r.expr(2).do(function(var_1) {
        ^^^^^^^^^^^^^^
 })
 */
-It('Test backtrace for r.expr(2).do(function(x) { return x.add("a") })', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr(2).do(function(x) { return x.add("a") }).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found STRING in:\nr.expr(2).do(function(var_1) {\n    return var_1.add(\"a\")\n           ^^^^^^^^^^^^^^\n})\n") {
-      done()
+  it('Test backtrace for r.expr(2).do(function(x) { return x.add("a") })', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr(2).do(function (x) { return x.add('a') }).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found STRING in:\nr.expr(2).do(function(var_1) {\n    return var_1.add("a")\n           ^^^^^^^^^^^^^^\n})\n')
     }
-    else {
-      console.log(e.message); done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 //TODO Broken on the server
 Frames:
 []
@@ -163,24 +134,17 @@ Table `551f695a834f94e0fe215e19441b01c9` already exists in:
 r.db("7debc6e4a249569a1a6280fd6e871270").tableCreate("551f695a834f94e0fe215e19441b01c9")
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.db(dbName).tableCreate(tableName)', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.db(dbName).tableCreate(tableName).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Table `"+dbName+"."+tableName+"` already exists in:\nr.db(\""+dbName+"\").tableCreate(\""+tableName+"\")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n") {
-      done()
+  it('Test backtrace for r.db(dbName).tableCreate(tableName)', async () => {
+    try {
+      r.nextVarId = 1
+      await r.db(dbName).tableCreate(tableName).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Table `' + dbName + '.' + tableName + '` already exists in:\nr.db("' + dbName + '").tableCreate("' + tableName + '")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n')
     }
-    else {
-      console.log(e.message); done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 //TODO Broken on the server
 Frames:
 []
@@ -190,25 +154,17 @@ Table `nonExistingTable` does not exist in:
 r.db("4ab068e0ed6b05f71dcd4b07034698c4").tableDrop("nonExistingTable")
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.db(dbName).tableDrop("nonExistingTable")', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.db(dbName).tableDrop("nonExistingTable").run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Table `"+dbName+".nonExistingTable` does not exist in:\nr.db(\""+dbName+"\").tableDrop(\"nonExistingTable\")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n") {
-      done()
+  it('Test backtrace for r.db(dbName).tableDrop("nonExistingTable")', async () => {
+    try {
+      r.nextVarId = 1
+      await r.db(dbName).tableDrop('nonExistingTable').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Table `' + dbName + '.nonExistingTable` does not exist in:\nr.db("' + dbName + '").tableDrop("nonExistingTable")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n')
     }
-    else {
-      console.log(e.message); done(e);
-    }
-  }
-})
+  })
 
-
-
-/*
+  /*
 //TODO Broken on the server
 Frames:
 [ { type: 'POS', pos: 0 }, { type: 'POS', pos: 1 } ]
@@ -220,24 +176,17 @@ r.db("9cdeba73602f74f7ad67f77c76a87528").tableList().do(function(var_1) {
        ^^^^^^^^^^^^^^
 })
 */
-It('Test backtrace for r.db(dbName).tableList().do(function(x) { return x.add("a") })', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.db(dbName).tableList().do(function(x) { return x.add("a") }).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type ARRAY but found STRING in:\nr.db(\""+dbName+"\").tableList().do(function(var_1) {\n    return var_1.add(\"a\")\n           ^^^^^^^^^^^^^^\n})\n") {
-      done()
+  it('Test backtrace for r.db(dbName).tableList().do(function(x) { return x.add("a") })', async () => {
+    try {
+      r.nextVarId = 1
+      await r.db(dbName).tableList().do(function (x) { return x.add('a') }).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type ARRAY but found STRING in:\nr.db("' + dbName + '").tableList().do(function(var_1) {\n    return var_1.add("a")\n           ^^^^^^^^^^^^^^\n})\n')
     }
-    else {
-      console.log(e.message); done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 [ { type: 'POS', pos: 1 }, { type: 'POS', pos: 1 } ]
 
@@ -250,24 +199,17 @@ r.expr(["zoo", "zoo"]).forEach(function(var_1) {
     ^^^^^^^^^^^^^^^^^^^
 })
 */
-It('Test backtrace for r.expr(["zoo", "zoo"]).forEach(function(index) { return r.db(dbName).table(tableName).indexCreate(index) })', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr(["zoo", "zoo"]).forEach(function(index) { return r.db(dbName).table(tableName).indexCreate(index) }).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Index `zoo` already exists on table `"+dbName+"."+tableName+"` in:\nr.expr([\"zoo\", \"zoo\"]).forEach(function(var_1) {\n    return r.db(\""+dbName+"\").table(\""+tableName+"\")\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n        .indexCreate(var_1)\n        ^^^^^^^^^^^^^^^^^^^\n})\n") {
-      done()
+  it('Test backtrace for r.expr(["zoo", "zoo"]).forEach(function(index) { return r.db(dbName).table(tableName).indexCreate(index) })', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr(['zoo', 'zoo']).forEach(function (index) { return r.db(dbName).table(tableName).indexCreate(index) }).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Index `zoo` already exists on table `' + dbName + '.' + tableName + '` in:\nr.expr(["zoo", "zoo"]).forEach(function(var_1) {\n    return r.db("' + dbName + '").table("' + tableName + '")\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n        .indexCreate(var_1)\n        ^^^^^^^^^^^^^^^^^^^\n})\n')
     }
-    else {
-      console.log(e.message); done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 //TODO Broken on the server
 Frames:
 []
@@ -279,24 +221,17 @@ r.db("91105f3567295643808ed9bab508ec25").table("35adbd4339c2fd4d285f27543e1663ec
   .indexDrop("nonExistingIndex")
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.db(dbName).table(tableName).indexDrop("nonExistingIndex")', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.db(dbName).table(tableName).indexDrop("nonExistingIndex").run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Index `nonExistingIndex` does not exist on table `"+dbName+"."+tableName+"` in:\nr.db(\""+dbName+"\").table(\""+tableName+"\")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    .indexDrop(\"nonExistingIndex\")\n    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n") {
-      done()
+  it('Test backtrace for r.db(dbName).table(tableName).indexDrop("nonExistingIndex")', async () => {
+    try {
+      r.nextVarId = 1
+      await r.db(dbName).table(tableName).indexDrop('nonExistingIndex').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Index `nonExistingIndex` does not exist on table `' + dbName + '.' + tableName + '` in:\nr.db("' + dbName + '").table("' + tableName + '")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    .indexDrop("nonExistingIndex")\n    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n')
     }
-    else {
-      console.log(e.message); done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 //TODO Broken on the server
 Frames:
 [ { type: 'POS', pos: 0 }, { type: 'POS', pos: 1 } ]
@@ -309,24 +244,17 @@ r.db("7973e432e0aed7e4b1e6951f6049157d").table("37c62a0922bc471c6d751f8f75560cb8
          ^^^^^^^^^^^^^^
   })
 */
-It('Test backtrace for r.db(dbName).table(tableName).indexList().do(function(x) { return x.add("a") })', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.db(dbName).table(tableName).indexList().do(function(x) { return x.add("a") }).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type ARRAY but found STRING in:\nr.db(\""+dbName+"\").table(\""+tableName+"\")\n    .indexList().do(function(var_1) {\n        return var_1.add(\"a\")\n               ^^^^^^^^^^^^^^\n    })\n") {
-      done()
+  it('Test backtrace for r.db(dbName).table(tableName).indexList().do(function(x) { return x.add("a") })', async () => {
+    try {
+      r.nextVarId = 1
+      await r.db(dbName).table(tableName).indexList().do(function (x) { return x.add('a') }).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type ARRAY but found STRING in:\nr.db("' + dbName + '").table("' + tableName + '")\n    .indexList().do(function(var_1) {\n        return var_1.add("a")\n               ^^^^^^^^^^^^^^\n    })\n')
     }
-    else {
-      console.log(e.message); done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 //TODO Broken on the server
 [ { type: 'POS', pos: 0 }, { type: 'POS', pos: 1 } ]
@@ -339,25 +267,17 @@ r.db("a0d88feb61e3d0743bde45b625e7f237").table("8e1f71fefc1f86b66348c96466951df3
          ^^^^^^^^^^^^^^
   })
 */
-It('Test backtrace for r.db(dbName).table(tableName).indexWait().do(function(x) { return x.add("a") })', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.db(dbName).table(tableName).indexWait().do(function(x) { return x.add("a") }).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type ARRAY but found STRING in:\nr.db(\""+dbName+"\").table(\""+tableName+"\")\n    .indexWait().do(function(var_1) {\n        return var_1.add(\"a\")\n               ^^^^^^^^^^^^^^\n    })\n") {
-      done()
+  it('Test backtrace for r.db(dbName).table(tableName).indexWait().do(function(x) { return x.add("a") })', async () => {
+    try {
+      r.nextVarId = 1
+      await r.db(dbName).table(tableName).indexWait().do(function (x) { return x.add('a') }).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type ARRAY but found STRING in:\nr.db("' + dbName + '").table("' + tableName + '")\n    .indexWait().do(function(var_1) {\n        return var_1.add("a")\n               ^^^^^^^^^^^^^^\n    })\n')
     }
-    else {
-      console.log(e.message); done(e);
-    }
-  }
-})
+  })
 
-
-
-/*
+  /*
 Frames:
 [ { type: 'POS', pos: 0 } ]
 
@@ -367,27 +287,20 @@ r.db("d095569a80834591e8053539e111299a").table("be4967584fdf58b6a5dab0cd633ba046
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   .indexWait("foo", "bar")
 */
-// https://github.com/rethinkdb/rethinkdb/issues/4501
-/*
-It('Test backtrace for r.db(dbName).table(tableName).indexWait("foo", "bar")', function* (done) {
-  try {
+  // https://github.com/rethinkdb/rethinkdb/issues/4501
+  /*
+it('Test backtrace for r.db(dbName).table(tableName).indexWait("foo", "bar")', async () => {
     r.nextVarId=1;
-    yield r.db(dbName).table(tableName).indexWait("foo", "bar").run()
-    done(new Error("Should have thrown an error"))
+    await r.db(dbName).table(tableName).indexWait("foo", "bar").run()
+    assert.fail('should throw')
   }
   catch(e) {
-    if (e.message === "Index `bar` was not found on table `"+dbName+"."+tableName+"` in:\nr.db(\""+dbName+"\").table(\""+tableName+"\")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    .indexWait(\"foo\", \"bar\")\n") {
-      done()
-    }
-    else {
-      console.log(e.message); done(e);
-    }
+    assert(e.message === "Index `bar` was not found on table `"+dbName+"."+tableName+"` in:\nr.db(\""+dbName+"\").table(\""+tableName+"\")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    .indexWait(\"foo\", \"bar\")\n")
   }
 })
 */
 
-
-/*
+  /*
 //TODO Broken on the server
 Frames:
 [ { type: 'POS', pos: 1 } ]
@@ -398,24 +311,17 @@ r.db("340daf900a4168235e5e21e53f8ccdd1").table("9276ce6940b79f4b4f64ab7812532c6e
   .indexStatus().and(r.expr(1).add("a"))
              ^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.db(dbName).table(tableName).indexStatus().and( r.expr(1).add("a"))', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.db(dbName).table(tableName).indexStatus().and( r.expr(1).add("a")).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found STRING in:\nr.db(\""+dbName+"\").table(\""+tableName+"\")\n    .indexStatus().and(r.expr(1).add(\"a\"))\n                       ^^^^^^^^^^^^^^^^^^ \n") {
-      done()
+  it('Test backtrace for r.db(dbName).table(tableName).indexStatus().and( r.expr(1).add("a"))', async () => {
+    try {
+      r.nextVarId = 1
+      await r.db(dbName).table(tableName).indexStatus().and(r.expr(1).add('a')).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found STRING in:\nr.db("' + dbName + '").table("' + tableName + '")\n    .indexStatus().and(r.expr(1).add("a"))\n                       ^^^^^^^^^^^^^^^^^^ \n')
     }
-    else {
-      console.log(e.message); done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 [ 1 ]
 
@@ -424,85 +330,63 @@ Index `bar` was not found on table `64f4fc7f01449d2b7aa567576b291659.449aba95189
 r.db("64f4fc7f01449d2b7aa567576b291659").table("449aba951895d77bc975046902f51310")
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     .indexStatus("foo", "bar").do(function(var_1) {
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^                     
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^
         return var_1.add("a")
     })
 */
-It('Test backtrace for r.db(dbName).table(tableName).indexStatus("foo", "bar").do(function(x) { return x.add("a") })', function* (done) {
+  it('Test backtrace for r.db(dbName).table(tableName).indexStatus("foo", "bar").do(function(x) { return x.add("a") })', async () => {
     try {
-        r.nextVarId=1;
-        yield r.db(dbName).table(tableName).indexStatus("foo", "bar").do(function(x) { return x.add("a") }).run()
-        done(new Error("Should have thrown an error"))
+      r.nextVarId = 1
+      await r.db(dbName).table(tableName).indexStatus('foo', 'bar').do(function (x) { return x.add('a') }).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Index `bar` was not found on table `' + dbName + '.' + tableName + '` in:\nr.db("' + dbName + '").table("' + tableName + '")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    .indexStatus("foo", "bar").do(function(var_1) {\n    ^^^^^^^^^^^^^^^^^^^^^^^^^^                     \n        return var_1.add("a")\n    })\n')
     }
-    catch(e) {
-        if (e.message === "Index `bar` was not found on table `"+dbName+"."+tableName+"` in:\nr.db(\""+dbName+"\").table(\""+tableName+"\")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    .indexStatus(\"foo\", \"bar\").do(function(var_1) {\n    ^^^^^^^^^^^^^^^^^^^^^^^^^^                     \n        return var_1.add(\"a\")\n    })\n") {
-            done()
-        }
-        else {
-            done(e);
-        }
-    }
-})
+  })
 
-
-/*
+  /*
 Frames:
 [ 0 ]
 
 Error:
 Table `882c5069473a016b03069a24679271c5.nonExistingTable` does not exist in:
 r.db("882c5069473a016b03069a24679271c5").table("nonExistingTable").update({
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^         
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   foo: "bar"
 })
 */
-It('Test backtrace for r.db(dbName).table("nonExistingTable").update({foo: "bar"})', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.db(dbName).table("nonExistingTable").update({foo: "bar"}).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Table `"+dbName+".nonExistingTable` does not exist in:\nr.db(\""+dbName+"\").table(\"nonExistingTable\").update({\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^         \n    foo: \"bar\"\n})\n") {
-      done()
+  it('Test backtrace for r.db(dbName).table("nonExistingTable").update({foo: "bar"})', async () => {
+    try {
+      r.nextVarId = 1
+      await r.db(dbName).table('nonExistingTable').update({foo: 'bar'}).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Table `' + dbName + '.nonExistingTable` does not exist in:\nr.db("' + dbName + '").table("nonExistingTable").update({\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^         \n    foo: "bar"\n})\n')
     }
-    else {
-      console.log(e.message); done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 [ 0 ]
 
 Error:
 Table `8d192301ed6e6937c7d2e6d836f79b20.nonExistingTable` does not exist in:
 r.db("8d192301ed6e6937c7d2e6d836f79b20").table("nonExistingTable").update(function(var_1) {
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                         
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   return var_1("foo")
 })
 */
-It('Test backtrace for r.db(dbName).table("nonExistingTable").update(function(doc) { return doc("foo") })', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.db(dbName).table("nonExistingTable").update(function(doc) { return doc("foo") }).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Table `"+dbName+".nonExistingTable` does not exist in:\nr.db(\""+dbName+"\").table(\"nonExistingTable\").update(function(var_1) {\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                         \n    return var_1(\"foo\")\n})\n") {
-      done()
+  it('Test backtrace for r.db(dbName).table("nonExistingTable").update(function(doc) { return doc("foo") })', async () => {
+    try {
+      r.nextVarId = 1
+      await r.db(dbName).table('nonExistingTable').update(function (doc) { return doc('foo') }).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Table `' + dbName + '.nonExistingTable` does not exist in:\nr.db("' + dbName + '").table("nonExistingTable").update(function(var_1) {\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                         \n    return var_1("foo")\n})\n')
     }
-    else {
-      console.log(e.message); done(e);
-    }
-  }
-})
+  })
 
-
-
-/*
+  /*
 //TODO Broken on the server
 Frames:
 [ { type: 'POS', pos: 0 } ]
@@ -510,28 +394,21 @@ Frames:
 Error:
 Table `nonExistingTable` does not exist in:
 r.db("e7e04bbadd0f0b43f3561b32f2e1b5d6").table("nonExistingTable").replace({
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^          
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   foo: "bar"
 })
 */
-It('Test backtrace for r.db(dbName).table("nonExistingTable").replace({foo: "bar"})', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.db(dbName).table("nonExistingTable").replace({foo: "bar"}).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Table `"+dbName+".nonExistingTable` does not exist in:\nr.db(\""+dbName+"\").table(\"nonExistingTable\").replace({\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^          \n    foo: \"bar\"\n})\n") {
-      done()
+  it('Test backtrace for r.db(dbName).table("nonExistingTable").replace({foo: "bar"})', async () => {
+    try {
+      r.nextVarId = 1
+      await r.db(dbName).table('nonExistingTable').replace({foo: 'bar'}).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Table `' + dbName + '.nonExistingTable` does not exist in:\nr.db("' + dbName + '").table("nonExistingTable").replace({\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^          \n    foo: "bar"\n})\n')
     }
-    else {
-      console.log(e.message); done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 //TODO Broken on the server
 Frames:
 [ { type: 'POS', pos: 0 } ]
@@ -539,28 +416,21 @@ Frames:
 Error:
 Table `nonExistingTable` does not exist in:
 r.db("9ca06265cbe173eeb27decb1baedb031").table("nonExistingTable").replace(function(var_1) {
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                          
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   return var_1("foo")
 })
 */
-It('Test backtrace for r.db(dbName).table("nonExistingTable").replace(function(doc) { return doc("foo") })', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.db(dbName).table("nonExistingTable").replace(function(doc) { return doc("foo") }).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Table `"+dbName+".nonExistingTable` does not exist in:\nr.db(\""+dbName+"\").table(\"nonExistingTable\").replace(function(var_1) {\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                          \n    return var_1(\"foo\")\n})\n") {
-      done()
+  it('Test backtrace for r.db(dbName).table("nonExistingTable").replace(function(doc) { return doc("foo") })', async () => {
+    try {
+      r.nextVarId = 1
+      await r.db(dbName).table('nonExistingTable').replace(function (doc) { return doc('foo') }).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Table `' + dbName + '.nonExistingTable` does not exist in:\nr.db("' + dbName + '").table("nonExistingTable").replace(function(var_1) {\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                          \n    return var_1("foo")\n})\n')
     }
-    else {
-      console.log(e.message); done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 //TODO Broken on the server
 Frames:
 [ { type: 'POS', pos: 0 } ]
@@ -570,25 +440,17 @@ Table `nonExistingTable` does not exist in:
 r.db("0ec51cb31ddf56339cd7acab73b08a2c").table("nonExistingTable").delete()
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.db(dbName).table("nonExistingTable").delete()', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.db(dbName).table("nonExistingTable").delete().run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Table `"+dbName+".nonExistingTable` does not exist in:\nr.db(\""+dbName+"\").table(\"nonExistingTable\").delete()\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^         \n") {
-      done()
+  it('Test backtrace for r.db(dbName).table("nonExistingTable").delete()', async () => {
+    try {
+      r.nextVarId = 1
+      await r.db(dbName).table('nonExistingTable').delete().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Table `' + dbName + '.nonExistingTable` does not exist in:\nr.db("' + dbName + '").table("nonExistingTable").delete()\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^         \n')
     }
-    else {
-      console.log(e.message); done(e);
-    }
-  }
-})
+  })
 
-
-
-/*
+  /*
 //TODO Broken on the server
 Frames:
 [ { type: 'POS', pos: 0 } ]
@@ -598,24 +460,17 @@ Table `nonExistingTable` does not exist in:
 r.db("a01528b1d8902639d48b9c0adcc397a5").table("nonExistingTable").sync()
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.db(dbName).table("nonExistingTable").sync()', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.db(dbName).table("nonExistingTable").sync().run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Table `"+dbName+".nonExistingTable` does not exist in:\nr.db(\""+dbName+"\").table(\"nonExistingTable\").sync()\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^       \n") {
-      done()
+  it('Test backtrace for r.db(dbName).table("nonExistingTable").sync()', async () => {
+    try {
+      r.nextVarId = 1
+      await r.db(dbName).table('nonExistingTable').sync().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Table `' + dbName + '.nonExistingTable` does not exist in:\nr.db("' + dbName + '").table("nonExistingTable").sync()\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^       \n')
     }
-    else {
-      console.log(e.message); done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 [ { type: 'POS', pos: 0 } ]
 
@@ -624,24 +479,17 @@ Database `nonExistingDb` does not exist in:
 r.db("nonExistingDb").table("nonExistingTable")
 ^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.db("nonExistingDb").table("nonExistingTable")', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.db("nonExistingDb").table("nonExistingTable").run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Database `nonExistingDb` does not exist in:\nr.db(\"nonExistingDb\").table(\"nonExistingTable\")\n^^^^^^^^^^^^^^^^^^^^^                          \n") {
-      done()
+  it('Test backtrace for r.db("nonExistingDb").table("nonExistingTable")', async () => {
+    try {
+      r.nextVarId = 1
+      await r.db('nonExistingDb').table('nonExistingTable').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Database `nonExistingDb` does not exist in:\nr.db("nonExistingDb").table("nonExistingTable")\n^^^^^^^^^^^^^^^^^^^^^                          \n')
     }
-    else {
-      console.log(e.message); done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 //TODO Broken on the server
 Frames:
 []
@@ -651,24 +499,17 @@ Table `nonExistingTable` does not exist in:
 r.db("d1869ecfd2f2e939f5f9ff18b7293370").table("nonExistingTable")
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.db(dbName).table("nonExistingTable")', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.db(dbName).table("nonExistingTable").run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Table `"+dbName+".nonExistingTable` does not exist in:\nr.db(\""+dbName+"\").table(\"nonExistingTable\")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n") {
-      done()
+  it('Test backtrace for r.db(dbName).table("nonExistingTable")', async () => {
+    try {
+      r.nextVarId = 1
+      await r.db(dbName).table('nonExistingTable').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Table `' + dbName + '.nonExistingTable` does not exist in:\nr.db("' + dbName + '").table("nonExistingTable")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n')
     }
-    else {
-      }
-  }
-})
+  })
 
-
-
-/*
+  /*
 Frames:
 [ { type: 'POS', pos: 0 }, { type: 'POS', pos: 1 } ]
 
@@ -680,23 +521,17 @@ r.db("9a3275b288394920100ca6cd5d9ebc77").table("aaf8fd26eb4093b4bcd1c051acd44b80
          ^^^^^^^^^^^^
   })
 */
-It('Test backtrace for r.db(dbName).table(tableName).get(1).do(function(x) { return x.add(3) })', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.db(dbName).table(tableName).get(1).do(function(x) { return x.add(3) }).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found NULL in:\nr.db(\""+dbName+"\").table(\""+tableName+"\")\n    .get(1).do(function(var_1) {\n        return var_1.add(3)\n               ^^^^^^^^^^^^\n    })\n") {
-      done()
+  it('Test backtrace for r.db(dbName).table(tableName).get(1).do(function(x) { return x.add(3) })', async () => {
+    try {
+      r.nextVarId = 1
+      await r.db(dbName).table(tableName).get(1).do(function (x) { return x.add(3) }).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found NULL in:\nr.db("' + dbName + '").table("' + tableName + '")\n    .get(1).do(function(var_1) {\n        return var_1.add(3)\n               ^^^^^^^^^^^^\n    })\n')
     }
-    else {
-      console.log(e.message); done(e);
-    }
-  }
-})
+  })
 
-/*
+  /*
 Frames:
 [ 1 ]
 
@@ -706,30 +541,21 @@ SELECTION ON table(0c2967f3799eb2025b4cd92342dfe4a9) in:
 r.db("cd911f3c958c1ec7637f7f2dc2827245").table("0c2967f3799eb2025b4cd92342dfe4a9")
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   .getAll(1, 2, 3).do(function(var_1) {
-  ^^^^^^^^^^^^^^^^                     
+  ^^^^^^^^^^^^^^^^
     return var_1.add(3)
   })
 */
-It('Test backtrace for r.db(dbName).table(tableName).getAll(1, 2, 3).do(function(x) { return x.add(3) })', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.db(dbName).table(tableName).getAll(1, 2, 3).do(function(x) { return x.add(3) }).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type DATUM but found SELECTION:\nSELECTION ON table("+tableName+") in:\nr.db(\""+dbName+"\").table(\""+tableName+"\")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    .getAll(1, 2, 3).do(function(var_1) {\n    ^^^^^^^^^^^^^^^^                     \n        return var_1.add(3)\n    })\n") {
-      done()
+  it('Test backtrace for r.db(dbName).table(tableName).getAll(1, 2, 3).do(function(x) { return x.add(3) })', async () => {
+    try {
+      r.nextVarId = 1
+      await r.db(dbName).table(tableName).getAll(1, 2, 3).do(function (x) { return x.add(3) }).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type DATUM but found SELECTION:\nSELECTION ON table(' + tableName + ') in:\nr.db("' + dbName + '").table("' + tableName + '")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    .getAll(1, 2, 3).do(function(var_1) {\n    ^^^^^^^^^^^^^^^^                     \n        return var_1.add(3)\n    })\n')
     }
-    else {
-      console.log(e.message); done(e);
-    }
-  }
-})
+  })
 
-
-
-
-/*
+  /*
 Frames:
 [ 1 ]
 
@@ -743,28 +569,21 @@ r.db("52bdcbc788f0c0b00357fa1840f62a81").table("2fb59ffdec1b6605369953703547f82d
     index: "foo"
     ^^^^^^^^^^^^
   }).do(function(var_1) {
-  ^^                     
+  ^^
     return var_1.add(3)
   })
 */
-It('Test backtrace for r.db(dbName).table(tableName).getAll(1, 2, 3, { index: "foo"}).do(function(x) { return x.add(3) })', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.db(dbName).table(tableName).getAll(1, 2, 3, { index: "foo"}).do(function(x) { return x.add(3) }).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type DATUM but found SELECTION:\nSELECTION ON table("+tableName+") in:\nr.db(\""+dbName+"\").table(\""+tableName+"\")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    .getAll(1, 2, 3, {\n    ^^^^^^^^^^^^^^^^^^\n        index: \"foo\"\n        ^^^^^^^^^^^^\n    }).do(function(var_1) {\n    ^^                     \n        return var_1.add(3)\n    })\n") {
-      done()
+  it('Test backtrace for r.db(dbName).table(tableName).getAll(1, 2, 3, { index: "foo"}).do(function(x) { return x.add(3) })', async () => {
+    try {
+      r.nextVarId = 1
+      await r.db(dbName).table(tableName).getAll(1, 2, 3, {index: 'foo'}).do(function (x) { return x.add(3) }).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type DATUM but found SELECTION:\nSELECTION ON table(' + tableName + ') in:\nr.db("' + dbName + '").table("' + tableName + '")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    .getAll(1, 2, 3, {\n    ^^^^^^^^^^^^^^^^^^\n        index: "foo"\n        ^^^^^^^^^^^^\n    }).do(function(var_1) {\n    ^^                     \n        return var_1.add(3)\n    })\n')
     }
-    else {
-      console.log(e.message); done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 [ 1 ]
 
@@ -778,30 +597,21 @@ r.db("8bd65d3ca931f3587cc5f3acee0e9f6d").table("a163b9372202a469fa7485f6c20b9f4f
     index: "foo"
     ^^^^^^^^^^^^
   }).do(function(var_1) {
-  ^^                     
+  ^^
     return var_1.add(3)
   })
 */
-It('Test backtrace for r.db(dbName).table(tableName).between(2, 3, { index: "foo"}).do(function(x) { return x.add(3) })', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.db(dbName).table(tableName).between(2, 3, { index: "foo"}).do(function(x) { return x.add(3) }).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type DATUM but found TABLE_SLICE:\nSELECTION ON table("+tableName+") in:\nr.db(\""+dbName+"\").table(\""+tableName+"\")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    .between(2, 3, {\n    ^^^^^^^^^^^^^^^^\n        index: \"foo\"\n        ^^^^^^^^^^^^\n    }).do(function(var_1) {\n    ^^                     \n        return var_1.add(3)\n    })\n") {
-      done()
+  it('Test backtrace for r.db(dbName).table(tableName).between(2, 3, { index: "foo"}).do(function(x) { return x.add(3) })', async () => {
+    try {
+      r.nextVarId = 1
+      await r.db(dbName).table(tableName).between(2, 3, {index: 'foo'}).do(function (x) { return x.add(3) }).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type DATUM but found TABLE_SLICE:\nSELECTION ON table(' + tableName + ') in:\nr.db("' + dbName + '").table("' + tableName + '")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    .between(2, 3, {\n    ^^^^^^^^^^^^^^^^\n        index: "foo"\n        ^^^^^^^^^^^^\n    }).do(function(var_1) {\n    ^^                     \n        return var_1.add(3)\n    })\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-
-
-/*
+  /*
 Frames:
 [ 1 ]
 
@@ -815,29 +625,21 @@ r.db("39ae0baa00e8cb2da57783c544f569d3").table("775cb364800937836f7ecaafc6405cf0
     foo: "bar"
     ^^^^^^^^^^
   }).do(function(var_1) {
-  ^^                     
+  ^^
     return var_1.add(3)
   })
 */
-It('Test backtrace for r.db(dbName).table(tableName).filter({foo: "bar"}).do(function(x) { return x.add(3) })', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.db(dbName).table(tableName).filter({foo: "bar"}).do(function(x) { return x.add(3) }).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type DATUM but found SELECTION:\nSELECTION ON table("+tableName+") in:\nr.db(\""+dbName+"\").table(\""+tableName+"\")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    .filter({\n    ^^^^^^^^^\n        foo: \"bar\"\n        ^^^^^^^^^^\n    }).do(function(var_1) {\n    ^^                     \n        return var_1.add(3)\n    })\n") {
-      done()
+  it('Test backtrace for r.db(dbName).table(tableName).filter({foo: "bar"}).do(function(x) { return x.add(3) })', async () => {
+    try {
+      r.nextVarId = 1
+      await r.db(dbName).table(tableName).filter({foo: 'bar'}).do(function (x) { return x.add(3) }).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type DATUM but found SELECTION:\nSELECTION ON table(' + tableName + ') in:\nr.db("' + dbName + '").table("' + tableName + '")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    .filter({\n    ^^^^^^^^^\n        foo: "bar"\n        ^^^^^^^^^^\n    }).do(function(var_1) {\n    ^^                     \n        return var_1.add(3)\n    })\n')
     }
-    else {
-      console.log(e.message); done(e);
-    }
-  }
-})
-  
+  })
 
-
-/*
+  /*
 Frames:
 [ { type: 'POS', pos: 1 } ]
 
@@ -851,24 +653,17 @@ r.expr([1, 2, 3]).innerJoin(function(var_1, var_2) {
 }, r.db("3fdf480de398b8b0c5dee11b4594a38d").table("5f728046b728da8d63ace65a40aca6a6"))
 ^
 */
-It('Test backtrace for r.expr([1,2,3]).innerJoin( function(left, right) { return left.eq(right("bar").add(1)) }, r.db(dbName).table(tableName))', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr([1,2,3]).innerJoin( function(left, right) { return left.eq(right("bar").add(1)) }, r.db(dbName).table(tableName)).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type SEQUENCE but found FUNCTION:\nVALUE FUNCTION in:\nr.expr([1, 2, 3]).innerJoin(function(var_1, var_2) {\n                            ^^^^^^^^^^^^^^^^^^^^^^^^\n    return var_1.eq(var_2(\"bar\").add(1))\n    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n}, r.db(\""+dbName+"\").table(\""+tableName+"\"))\n^                                                                                     \n") {
-      done()
+  it('Test backtrace for r.expr([1,2,3]).innerJoin( function(left, right) { return left.eq(right("bar").add(1)) }, r.db(dbName).table(tableName))', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr([1, 2, 3]).innerJoin(function (left, right) { return left.eq(right('bar').add(1)) }, r.db(dbName).table(tableName)).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type SEQUENCE but found FUNCTION:\nVALUE FUNCTION in:\nr.expr([1, 2, 3]).innerJoin(function(var_1, var_2) {\n                            ^^^^^^^^^^^^^^^^^^^^^^^^\n    return var_1.eq(var_2("bar").add(1))\n    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n}, r.db("' + dbName + '").table("' + tableName + '"))\n^                                                                                     \n')
     }
-    else {
-      console.log(e.message); done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 [ { type: 'POS', pos: 2 },
   { type: 'POS', pos: 1 },
@@ -878,28 +673,20 @@ Error:
 Expected type NUMBER but found STRING in:
 r.expr([1, 2, 3]).innerJoin([1, 2, 3], function(var_1, var_2) {
   return r.expr(1).add("str").add(var_1.eq(var_2("bar").add(1)))
-       ^^^^^^^^^^^^^^^^^^^^                                   
+       ^^^^^^^^^^^^^^^^^^^^
 })
 */
-It('Test backtrace for r.expr([1,2,3]).innerJoin(r.expr([1,2,3]), function(left, right) { return r.expr(1).add("str").add(left.eq(right("bar").add(1))) })', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr([1,2,3]).innerJoin(r.expr([1,2,3]), function(left, right) { return r.expr(1).add("str").add(left.eq(right("bar").add(1))) }).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found STRING in:\nr.expr([1, 2, 3]).innerJoin([1, 2, 3], function(var_1, var_2) {\n    return r.expr(1).add(\"str\").add(var_1.eq(var_2(\"bar\").add(1)))\n           ^^^^^^^^^^^^^^^^^^^^                                   \n})\n") {
-      done()
+  it('Test backtrace for r.expr([1,2,3]).innerJoin(r.expr([1,2,3]), function(left, right) { return r.expr(1).add("str").add(left.eq(right("bar").add(1))) })', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr([1, 2, 3]).innerJoin(r.expr([1, 2, 3]), function (left, right) { return r.expr(1).add('str').add(left.eq(right('bar').add(1))) }).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found STRING in:\nr.expr([1, 2, 3]).innerJoin([1, 2, 3], function(var_1, var_2) {\n    return r.expr(1).add("str").add(var_1.eq(var_2("bar").add(1)))\n           ^^^^^^^^^^^^^^^^^^^^                                   \n})\n')
     }
-    else {
-      console.log(e.message); done(e);
-    }
-  }
-})
+  })
 
-
-
-/*
+  /*
 Frames:
 [ { type: 'POS', pos: 1 } ]
 
@@ -913,58 +700,41 @@ r.expr([1, 2, 3]).outerJoin(function(var_1, var_2) {
 }, r.db("5f21a25338fff022c0f698f8681c03c0").table("1653b107790bf38e48448f3db99ab776"))
 ^
 */
-It('Test backtrace for r.expr([1,2,3]).outerJoin( function(left, right) { return left.eq(right("bar").add(1)) }, r.db(dbName).table(tableName))', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr([1,2,3]).outerJoin( function(left, right) { return left.eq(right("bar").add(1)) }, r.db(dbName).table(tableName)).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type SEQUENCE but found FUNCTION:\nVALUE FUNCTION in:\nr.expr([1, 2, 3]).outerJoin(function(var_1, var_2) {\n                            ^^^^^^^^^^^^^^^^^^^^^^^^\n    return var_1.eq(var_2(\"bar\").add(1))\n    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n}, r.db(\""+dbName+"\").table(\""+tableName+"\"))\n^                                                                                     \n") {
-      done()
+  it('Test backtrace for r.expr([1,2,3]).outerJoin( function(left, right) { return left.eq(right("bar").add(1)) }, r.db(dbName).table(tableName))', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr([1, 2, 3]).outerJoin(function (left, right) { return left.eq(right('bar').add(1)) }, r.db(dbName).table(tableName)).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type SEQUENCE but found FUNCTION:\nVALUE FUNCTION in:\nr.expr([1, 2, 3]).outerJoin(function(var_1, var_2) {\n                            ^^^^^^^^^^^^^^^^^^^^^^^^\n    return var_1.eq(var_2("bar").add(1))\n    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n}, r.db("' + dbName + '").table("' + tableName + '"))\n^                                                                                     \n')
     }
-    else {
-      console.log(e.message); done(e);
-    }
-  }
-})
+  })
 
-
-
-/*
+  /*
 Frames:
 [ { type: 'POS', pos: 0 }, { type: 'POS', pos: 1 } ]
 
 Error:
 Cannot perform get_field on a non-object non-sequence `1` in:
 r.expr([1, 2, 3]).eqJoin("id", r.db("5500af7b5c2c94b2672a5f0029512757").table("85bbcc72331aa82bfe0306204997613e"))
-             ^^^^                                                                                     
+             ^^^^
   .add(1)
 */
-It('Test backtrace for r.expr([1,2,3]).eqJoin("id", r.db(dbName).table(tableName)).add(1)', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr([1,2,3]).eqJoin("id", r.db(dbName).table(tableName)).add(1).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if(e.message === `Cannot perform get_field on a non-object non-sequence \`1\` in:
+  it('Test backtrace for r.expr([1,2,3]).eqJoin("id", r.db(dbName).table(tableName)).add(1)', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr([1, 2, 3]).eqJoin('id', r.db(dbName).table(tableName)).add(1).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === `Cannot perform get_field on a non-object non-sequence \`1\` in:
 r.expr([1, 2, 3]).eqJoin("id", r.db("${dbName}").table("${tableName}"))
                          ^^^^                                                                                     
     .add(1)
-`) {
-      done()
+`)
     }
-    else {
-      console.log(e.message + 'great');
-      done(e);
-    }
-  }
-})
+  })
 
-
-
-/*
+  /*
 Frames:
 [ { type: 'POS', pos: 0 },
   { type: 'POS', pos: 0 },
@@ -973,27 +743,20 @@ Frames:
 Error:
 Cannot perform get_field on a non-object non-sequence `1` in:
 r.expr([1, 2, 3]).eqJoin("id", r.db("2c1030e5160e4af3bb19923d43fe7d6c").table("8895da1f043cb7443f322ce849d7fced"))
-             ^^^^                                                                                     
+             ^^^^
   .zip().add(1)
 */
-It('Test backtrace for r.expr([1,2,3]).eqJoin("id", r.db(dbName).table(tableName)).zip().add(1)', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr([1,2,3]).eqJoin("id", r.db(dbName).table(tableName)).zip().add(1).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Cannot perform get_field on a non-object non-sequence `1` in:\nr.expr([1, 2, 3]).eqJoin(\"id\", r.db(\""+dbName+"\").table(\""+tableName+"\"))\n                         ^^^^                                                                                     \n    .zip().add(1)\n") {
-      done()
+  it('Test backtrace for r.expr([1,2,3]).eqJoin("id", r.db(dbName).table(tableName)).zip().add(1)', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr([1, 2, 3]).eqJoin('id', r.db(dbName).table(tableName)).zip().add(1).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Cannot perform get_field on a non-object non-sequence `1` in:\nr.expr([1, 2, 3]).eqJoin("id", r.db("' + dbName + '").table("' + tableName + '"))\n                         ^^^^                                                                                     \n    .zip().add(1)\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 []
 
@@ -1006,24 +769,17 @@ r.expr([1, 2, 3]).map(function(var_1) {
 }).add(1)
 ^^^^^^^^^
 */
-It('Test backtrace for r.expr([1,2,3]).map(function(v) { return v}).add(1)', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr([1,2,3]).map(function(v) { return v}).add(1).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type ARRAY but found NUMBER in:\nr.expr([1, 2, 3]).map(function(var_1) {\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    return var_1\n    ^^^^^^^^^^^^\n}).add(1)\n^^^^^^^^^\n") {
-      done()
+  it('Test backtrace for r.expr([1,2,3]).map(function(v) { return v}).add(1)', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr([1, 2, 3]).map(function (v) { return v }).add(1).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type ARRAY but found NUMBER in:\nr.expr([1, 2, 3]).map(function(var_1) {\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    return var_1\n    ^^^^^^^^^^^^\n}).add(1)\n^^^^^^^^^\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 [ { type: 'POS', pos: 0 } ]
 
@@ -1032,24 +788,17 @@ Cannot perform has_fields on a non-object non-sequence `1` in:
 r.expr([1, 2, 3]).withFields("foo", "bar").add(1)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.expr([1,2,3]).withFields("foo", "bar").add(1)', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr([1,2,3]).withFields("foo", "bar").add(1).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Cannot perform has_fields on a non-object non-sequence `1` in:\nr.expr([1, 2, 3]).withFields(\"foo\", \"bar\").add(1)\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^       \n") {
-      done()
+  it('Test backtrace for r.expr([1,2,3]).withFields("foo", "bar").add(1)', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr([1, 2, 3]).withFields('foo', 'bar').add(1).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Cannot perform has_fields on a non-object non-sequence `1` in:\nr.expr([1, 2, 3]).withFields("foo", "bar").add(1)\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^       \n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 [ 0, 1 ]
 
@@ -1062,24 +811,17 @@ r.expr([1, 2, 3]).concatMap(function(var_1) {
 }).add(1)
 ^
 */
-It('Test backtrace for r.expr([1,2,3]).concatMap(function(v) { return v}).add(1)', function* (done) {
+  it('Test backtrace for r.expr([1,2,3]).concatMap(function(v) { return v}).add(1)', async () => {
     try {
-        r.nextVarId=1;
-        yield r.expr([1,2,3]).concatMap(function(v) { return v}).add(1).run()
-        done(new Error("Should have thrown an error"))
+      r.nextVarId = 1
+      await r.expr([1, 2, 3]).concatMap(function (v) { return v }).add(1).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Cannot convert NUMBER to SEQUENCE in:\nr.expr([1, 2, 3]).concatMap(function(var_1) {\n                            ^^^^^^^^^^^^^^^^^\n    return var_1\n    ^^^^^^^^^^^^\n}).add(1)\n^        \n')
     }
-    catch(e) {
-        if (e.message === "Cannot convert NUMBER to SEQUENCE in:\nr.expr([1, 2, 3]).concatMap(function(var_1) {\n                            ^^^^^^^^^^^^^^^^^\n    return var_1\n    ^^^^^^^^^^^^\n}).add(1)\n^        \n") {
-            done()
-        }
-        else {
-          done(e);
-        }
-    }
-})
+  })
 
-
-/*
+  /*
 Frames:
 [ { type: 'POS', pos: 0 }, { type: 'POS', pos: 1 } ]
 
@@ -1088,28 +830,20 @@ Cannot perform get_field on a non-object non-sequence `2` in:
 r.expr([1, 2, 3]).orderBy("foo").add(1)
               ^^^^^
 */
-It('Test backtrace for r.expr([1,2,3]).orderBy("foo").add(1)', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr([1,2,3]).orderBy("foo").add(1).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if(e.message === `Cannot perform get_field on a non-object non-sequence \`2\` in:
+  it('Test backtrace for r.expr([1,2,3]).orderBy("foo").add(1)', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr([1, 2, 3]).orderBy('foo').add(1).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === `Cannot perform get_field on a non-object non-sequence \`2\` in:
 r.expr([1, 2, 3]).orderBy("foo").add(1)
                           ^^^^^        
-`) {
-      done()
+`)
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-
-/*
+  /*
 Frames:
 [ { type: 'POS', pos: 0 }, { type: 'POS', pos: 1 } ]
 
@@ -1118,25 +852,17 @@ Expected type NUMBER but found STRING in:
 r.expr([1, 2, 3]).skip("foo").add(1)
              ^^^^^
 */
-It('Test backtrace for r.expr([1,2,3]).skip("foo").add(1)', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr([1,2,3]).skip("foo").add(1).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found STRING in:\nr.expr([1, 2, 3]).skip(\"foo\").add(1)\n                       ^^^^^        \n") {
-      done()
+  it('Test backtrace for r.expr([1,2,3]).skip("foo").add(1)', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr([1, 2, 3]).skip('foo').add(1).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found STRING in:\nr.expr([1, 2, 3]).skip("foo").add(1)\n                       ^^^^^        \n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-
-/*
+  /*
 Frames:
 [ { type: 'POS', pos: 0 }, { type: 'POS', pos: 1 } ]
 
@@ -1145,24 +871,17 @@ Expected type NUMBER but found STRING in:
 r.expr([1, 2, 3]).limit("foo").add(1)
             ^^^^^
 */
-It('Test backtrace for r.expr([1,2,3]).limit("foo").add(1)', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr([1,2,3]).limit("foo").add(1).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found STRING in:\nr.expr([1, 2, 3]).limit(\"foo\").add(1)\n                        ^^^^^        \n") {
-      done()
+  it('Test backtrace for r.expr([1,2,3]).limit("foo").add(1)', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr([1, 2, 3]).limit('foo').add(1).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found STRING in:\nr.expr([1, 2, 3]).limit("foo").add(1)\n                        ^^^^^        \n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 [ { type: 'POS', pos: 0 }, { type: 'POS', pos: 1 } ]
 
@@ -1171,25 +890,17 @@ Expected type NUMBER but found STRING in:
 r.expr([1, 2, 3]).slice("foo", "bar").add(1)
             ^^^^^
 */
-It('Test backtrace for r.expr([1,2,3]).slice("foo", "bar").add(1)', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr([1,2,3]).slice("foo", "bar").add(1).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found STRING in:\nr.expr([1, 2, 3]).slice(\"foo\", \"bar\").add(1)\n                        ^^^^^               \n") {
-      done()
+  it('Test backtrace for r.expr([1,2,3]).slice("foo", "bar").add(1)', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr([1, 2, 3]).slice('foo', 'bar').add(1).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found STRING in:\nr.expr([1, 2, 3]).slice("foo", "bar").add(1)\n                        ^^^^^               \n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-
-/*
+  /*
 Frames:
 [ { type: 'POS', pos: 0 }, { type: 'POS', pos: 1 } ]
 
@@ -1198,24 +909,17 @@ Expected type NUMBER but found STRING in:
 r.expr([1, 2, 3]).nth("bar").add(1)
             ^^^^^
 */
-It('Test backtrace for r.expr([1,2,3]).nth("bar").add(1)', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr([1,2,3]).nth("bar").add(1).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found STRING in:\nr.expr([1, 2, 3]).nth(\"bar\").add(1)\n                      ^^^^^        \n") {
-      done()
+  it('Test backtrace for r.expr([1,2,3]).nth("bar").add(1)', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr([1, 2, 3]).nth('bar').add(1).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found STRING in:\nr.expr([1, 2, 3]).nth("bar").add(1)\n                      ^^^^^        \n')
     }
-    else {
-      console.log(e.message); done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 []
 
@@ -1224,25 +928,17 @@ Expected type ARRAY but found STRING in:
 r.expr([1, 2, 3]).offsetsOf("bar").add("Hello")
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.expr([1, 2, 3]).offsetsOf("bar").add("Hello")', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr([1, 2, 3]).offsetsOf("bar").add("Hello").run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type ARRAY but found STRING in:\nr.expr([1, 2, 3]).offsetsOf(\"bar\").add(\"Hello\")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n") {
-      done()
+  it('Test backtrace for r.expr([1, 2, 3]).offsetsOf("bar").add("Hello")', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr([1, 2, 3]).offsetsOf('bar').add('Hello').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type ARRAY but found STRING in:\nr.expr([1, 2, 3]).offsetsOf("bar").add("Hello")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-
-/*
+  /*
 Frames:
 []
 
@@ -1251,24 +947,17 @@ Expected type NUMBER but found BOOL in:
 r.expr([1, 2, 3]).isEmpty().add("Hello")
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.expr([1,2,3]).isEmpty().add("Hello")', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr([1,2,3]).isEmpty().add("Hello").run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found BOOL in:\nr.expr([1, 2, 3]).isEmpty().add(\"Hello\")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n") {
-      done()
+  it('Test backtrace for r.expr([1,2,3]).isEmpty().add("Hello")', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr([1, 2, 3]).isEmpty().add('Hello').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found BOOL in:\nr.expr([1, 2, 3]).isEmpty().add("Hello")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 []
 
@@ -1277,25 +966,17 @@ Expected type ARRAY but found STRING in:
 r.expr([1, 2, 3]).union([5, 6]).add("Hello")
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.expr([1,2,3]).union([5,6]).add("Hello")', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr([1,2,3]).union([5,6]).add("Hello").run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type ARRAY but found STRING in:\nr.expr([1, 2, 3]).union([5, 6]).add(\"Hello\")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n") {
-      done()
+  it('Test backtrace for r.expr([1,2,3]).union([5,6]).add("Hello")', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr([1, 2, 3]).union([5, 6]).add('Hello').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type ARRAY but found STRING in:\nr.expr([1, 2, 3]).union([5, 6]).add("Hello")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-
-/*
+  /*
 Frames:
 [ { type: 'POS', pos: 1 } ]
 
@@ -1304,25 +985,17 @@ Expected type NUMBER but found STRING in:
 r.expr([1, 2, 3]).sample("Hello")
              ^^^^^^^
 */
-It('Test backtrace for r.expr([1,2,3]).sample("Hello")', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr([1,2,3]).sample("Hello").run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found STRING in:\nr.expr([1, 2, 3]).sample(\"Hello\")\n                         ^^^^^^^ \n") {
-      done()
+  it('Test backtrace for r.expr([1,2,3]).sample("Hello")', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr([1, 2, 3]).sample('Hello').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found STRING in:\nr.expr([1, 2, 3]).sample("Hello")\n                         ^^^^^^^ \n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-
-/*
+  /*
 Frames:
 []
 
@@ -1335,25 +1008,17 @@ r.expr([1, 2, 3]).count(function() {
 }).add("Hello")
 ^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.expr([1,2,3]).count(function() { return true}).add("Hello")', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr([1,2,3]).count(function() { return true}).add("Hello").run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found STRING in:\nr.expr([1, 2, 3]).count(function() {\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    return true\n    ^^^^^^^^^^^\n}).add(\"Hello\")\n^^^^^^^^^^^^^^^\n") {
-      done()
+  it('Test backtrace for r.expr([1,2,3]).count(function() { return true}).add("Hello")', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr([1, 2, 3]).count(function () { return true }).add('Hello').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found STRING in:\nr.expr([1, 2, 3]).count(function() {\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    return true\n    ^^^^^^^^^^^\n}).add("Hello")\n^^^^^^^^^^^^^^^\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-
-/*
+  /*
 Frames:
 []
 
@@ -1362,25 +1027,17 @@ Expected type ARRAY but found STRING in:
 r.expr([1, 2, 3]).distinct().add("Hello")
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.expr([1,2,3]).distinct().add("Hello")', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr([1,2,3]).distinct().add("Hello").run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type ARRAY but found STRING in:\nr.expr([1, 2, 3]).distinct().add(\"Hello\")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n") {
-      done()
+  it('Test backtrace for r.expr([1,2,3]).distinct().add("Hello")', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr([1, 2, 3]).distinct().add('Hello').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type ARRAY but found STRING in:\nr.expr([1, 2, 3]).distinct().add("Hello")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-
-/*
+  /*
 Frames:
 []
 
@@ -1389,24 +1046,17 @@ Expected type NUMBER but found BOOL in:
 r.expr([1, 2, 3]).contains("foo", "bar").add("Hello")
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.expr([1,2,3]).contains("foo", "bar").add("Hello")', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr([1,2,3]).contains("foo", "bar").add("Hello").run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found BOOL in:\nr.expr([1, 2, 3]).contains(\"foo\", \"bar\").add(\"Hello\")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n") {
-      done()
+  it('Test backtrace for r.expr([1,2,3]).contains("foo", "bar").add("Hello")', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr([1, 2, 3]).contains('foo', 'bar').add('Hello').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found BOOL in:\nr.expr([1, 2, 3]).contains("foo", "bar").add("Hello")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 [ 0, 0 ]
 
@@ -1420,24 +1070,17 @@ Expected type SELECTION but found DATUM:
 r.expr([1, 2, 3]).update(r.row("foo")).add("Hello")
 ^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.expr([1,2,3]).update(r.row("foo")).add("Hello")', function* (done) {
+  it('Test backtrace for r.expr([1,2,3]).update(r.row("foo")).add("Hello")', async () => {
     try {
-        r.nextVarId=1;
-        yield r.expr([1,2,3]).update(r.row("foo")).add("Hello").run()
-        done(new Error("Should have thrown an error"))
+      r.nextVarId = 1
+      await r.expr([1, 2, 3]).update(r.row('foo')).add('Hello').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type SELECTION but found DATUM:\n[\n\t1,\n\t2,\n\t3\n] in:\nr.expr([1, 2, 3]).update(r.row("foo")).add("Hello")\n^^^^^^^^^^^^^^^^^                                  \n')
     }
-    catch(e) {
-        if (e.message === "Expected type SELECTION but found DATUM:\n[\n\t1,\n\t2,\n\t3\n] in:\nr.expr([1, 2, 3]).update(r.row(\"foo\")).add(\"Hello\")\n^^^^^^^^^^^^^^^^^                                  \n") {
-            done()
-        }
-        else {
-            done(e);
-        }
-    }
-})
+  })
 
-
-/*
+  /*
 Frames:
 [ { type: 'POS', pos: 0 } ]
 
@@ -1446,25 +1089,17 @@ Cannot perform pluck on a non-object non-sequence `1` in:
 r.expr([1, 2, 3]).pluck("foo").add("Hello")
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.expr([1,2,3]).pluck("foo").add("Hello")', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr([1,2,3]).pluck("foo").add("Hello").run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Cannot perform pluck on a non-object non-sequence `1` in:\nr.expr([1, 2, 3]).pluck(\"foo\").add(\"Hello\")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^             \n") {
-      done()
+  it('Test backtrace for r.expr([1,2,3]).pluck("foo").add("Hello")', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr([1, 2, 3]).pluck('foo').add('Hello').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Cannot perform pluck on a non-object non-sequence `1` in:\nr.expr([1, 2, 3]).pluck("foo").add("Hello")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^             \n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-
-/*
+  /*
 Frames:
 [ { type: 'POS', pos: 0 } ]
 
@@ -1473,25 +1108,17 @@ Cannot perform without on a non-object non-sequence `1` in:
 r.expr([1, 2, 3]).without("foo").add("Hello")
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.expr([1,2,3]).without("foo").add("Hello")', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr([1,2,3]).without("foo").add("Hello").run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Cannot perform without on a non-object non-sequence `1` in:\nr.expr([1, 2, 3]).without(\"foo\").add(\"Hello\")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^             \n") {
-      done()
+  it('Test backtrace for r.expr([1,2,3]).without("foo").add("Hello")', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr([1, 2, 3]).without('foo').add('Hello').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Cannot perform without on a non-object non-sequence `1` in:\nr.expr([1, 2, 3]).without("foo").add("Hello")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^             \n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-
-/*
+  /*
 Frames:
 [ { type: 'POS', pos: 0 } ]
 
@@ -1500,25 +1127,17 @@ Cannot perform merge on a non-object non-sequence `1` in:
 r.expr([1, 2, 3]).merge("foo").add("Hello")
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.expr([1,2,3]).merge("foo").add("Hello")', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr([1,2,3]).merge("foo").add("Hello").run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Cannot perform merge on a non-object non-sequence `1` in:\nr.expr([1, 2, 3]).merge(\"foo\").add(\"Hello\")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^             \n") {
-      done()
+  it('Test backtrace for r.expr([1,2,3]).merge("foo").add("Hello")', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr([1, 2, 3]).merge('foo').add('Hello').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Cannot perform merge on a non-object non-sequence `1` in:\nr.expr([1, 2, 3]).merge("foo").add("Hello")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^             \n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-
-/*
+  /*
 Frames:
 []
 
@@ -1527,25 +1146,17 @@ Expected type ARRAY but found STRING in:
 r.expr([1, 2, 3]).append("foo").add("Hello")
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.expr([1,2,3]).append("foo").add("Hello")', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr([1,2,3]).append("foo").add("Hello").run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type ARRAY but found STRING in:\nr.expr([1, 2, 3]).append(\"foo\").add(\"Hello\")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n") {
-      done()
+  it('Test backtrace for r.expr([1,2,3]).append("foo").add("Hello")', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr([1, 2, 3]).append('foo').add('Hello').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type ARRAY but found STRING in:\nr.expr([1, 2, 3]).append("foo").add("Hello")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-
-/*
+  /*
 Frames:
 []
 
@@ -1554,25 +1165,17 @@ Expected type ARRAY but found STRING in:
 r.expr([1, 2, 3]).prepend("foo").add("Hello")
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.expr([1,2,3]).prepend("foo").add("Hello")', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr([1,2,3]).prepend("foo").add("Hello").run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type ARRAY but found STRING in:\nr.expr([1, 2, 3]).prepend(\"foo\").add(\"Hello\")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n") {
-      done()
+  it('Test backtrace for r.expr([1,2,3]).prepend("foo").add("Hello")', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr([1, 2, 3]).prepend('foo').add('Hello').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type ARRAY but found STRING in:\nr.expr([1, 2, 3]).prepend("foo").add("Hello")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-
-/*
+  /*
 Frames:
 [ { type: 'POS', pos: 0 } ]
 
@@ -1581,24 +1184,17 @@ Cannot convert STRING to SEQUENCE in:
 r.expr([1, 2, 3]).difference("foo").add("Hello")
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.expr([1,2,3]).difference("foo").add("Hello")', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr([1,2,3]).difference("foo").add("Hello").run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Cannot convert STRING to SEQUENCE in:\nr.expr([1, 2, 3]).difference(\"foo\").add(\"Hello\")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^             \n") {
-      done()
+  it('Test backtrace for r.expr([1,2,3]).difference("foo").add("Hello")', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr([1, 2, 3]).difference('foo').add('Hello').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Cannot convert STRING to SEQUENCE in:\nr.expr([1, 2, 3]).difference("foo").add("Hello")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^             \n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 []
 
@@ -1607,24 +1203,17 @@ Expected type ARRAY but found STRING in:
 r.expr([1, 2, 3]).setInsert("foo").add("Hello")
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.expr([1,2,3]).setInsert("foo").add("Hello")', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr([1,2,3]).setInsert("foo").add("Hello").run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type ARRAY but found STRING in:\nr.expr([1, 2, 3]).setInsert(\"foo\").add(\"Hello\")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n") {
-      done()
+  it('Test backtrace for r.expr([1,2,3]).setInsert("foo").add("Hello")', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr([1, 2, 3]).setInsert('foo').add('Hello').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type ARRAY but found STRING in:\nr.expr([1, 2, 3]).setInsert("foo").add("Hello")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 [ { type: 'POS', pos: 0 } ]
 
@@ -1633,24 +1222,17 @@ Expected type ARRAY but found STRING in:
 r.expr([1, 2, 3]).setUnion("foo").add("Hello")
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.expr([1,2,3]).setUnion("foo").add("Hello")', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr([1,2,3]).setUnion("foo").add("Hello").run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type ARRAY but found STRING in:\nr.expr([1, 2, 3]).setUnion(\"foo\").add(\"Hello\")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^             \n") {
-      done()
+  it('Test backtrace for r.expr([1,2,3]).setUnion("foo").add("Hello")', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr([1, 2, 3]).setUnion('foo').add('Hello').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type ARRAY but found STRING in:\nr.expr([1, 2, 3]).setUnion("foo").add("Hello")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^             \n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 [ { type: 'POS', pos: 0 } ]
 
@@ -1659,24 +1241,17 @@ Expected type ARRAY but found STRING in:
 r.expr([1, 2, 3]).setIntersection("foo").add("Hello")
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.expr([1,2,3]).setIntersection("foo").add("Hello")', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr([1,2,3]).setIntersection("foo").add("Hello").run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type ARRAY but found STRING in:\nr.expr([1, 2, 3]).setIntersection(\"foo\").add(\"Hello\")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^             \n") {
-      done()
+  it('Test backtrace for r.expr([1,2,3]).setIntersection("foo").add("Hello")', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr([1, 2, 3]).setIntersection('foo').add('Hello').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type ARRAY but found STRING in:\nr.expr([1, 2, 3]).setIntersection("foo").add("Hello")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^             \n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 [ 0 ]
 
@@ -1685,25 +1260,17 @@ Cannot perform bracket on a non-object non-sequence `1` in:
 r.expr([1, 2, 3])("foo").add("Hello")
 ^^^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.expr([1, 2, 3])("foo").add("Hello")', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr([1, 2, 3])("foo").add("Hello").run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Cannot perform bracket on a non-object non-sequence `1` in:\nr.expr([1, 2, 3])(\"foo\").add(\"Hello\")\n^^^^^^^^^^^^^^^^^^^^^^^^             \n") {
-      done()
+  it('Test backtrace for r.expr([1, 2, 3])("foo").add("Hello")', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr([1, 2, 3])('foo').add('Hello').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Cannot perform bracket on a non-object non-sequence `1` in:\nr.expr([1, 2, 3])("foo").add("Hello")\n^^^^^^^^^^^^^^^^^^^^^^^^             \n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-
-/*
+  /*
 Frames:
 [ { type: 'POS', pos: 0 } ]
 
@@ -1712,24 +1279,17 @@ Cannot perform has_fields on a non-object non-sequence `1` in:
 r.expr([1, 2, 3]).hasFields("foo").add("Hello")
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.expr([1,2,3]).hasFields("foo").add("Hello")', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr([1,2,3]).hasFields("foo").add("Hello").run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Cannot perform has_fields on a non-object non-sequence `1` in:\nr.expr([1, 2, 3]).hasFields(\"foo\").add(\"Hello\")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^             \n") {
-      done()
+  it('Test backtrace for r.expr([1,2,3]).hasFields("foo").add("Hello")', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr([1, 2, 3]).hasFields('foo').add('Hello').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Cannot perform has_fields on a non-object non-sequence `1` in:\nr.expr([1, 2, 3]).hasFields("foo").add("Hello")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^             \n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 [ { type: 'POS', pos: 0 } ]
 
@@ -1738,24 +1298,17 @@ Expected type NUMBER but found STRING in:
 r.expr([1, 2, 3]).insertAt("foo", 2).add("Hello")
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.expr([1,2,3]).insertAt("foo", 2).add("Hello")', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr([1,2,3]).insertAt("foo", 2).add("Hello").run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found STRING in:\nr.expr([1, 2, 3]).insertAt(\"foo\", 2).add(\"Hello\")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^             \n") {
-      done()
+  it('Test backtrace for r.expr([1,2,3]).insertAt("foo", 2).add("Hello")', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr([1, 2, 3]).insertAt('foo', 2).add('Hello').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found STRING in:\nr.expr([1, 2, 3]).insertAt("foo", 2).add("Hello")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^             \n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 [ { type: 'POS', pos: 0 } ]
 
@@ -1764,25 +1317,17 @@ Expected type NUMBER but found STRING in:
 r.expr([1, 2, 3]).spliceAt("foo", 2).add("Hello")
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.expr([1,2,3]).spliceAt("foo", 2).add("Hello")', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr([1,2,3]).spliceAt("foo", 2).add("Hello").run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found STRING in:\nr.expr([1, 2, 3]).spliceAt(\"foo\", 2).add(\"Hello\")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^             \n") {
-      done()
+  it('Test backtrace for r.expr([1,2,3]).spliceAt("foo", 2).add("Hello")', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr([1, 2, 3]).spliceAt('foo', 2).add('Hello').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found STRING in:\nr.expr([1, 2, 3]).spliceAt("foo", 2).add("Hello")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^             \n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-
-/*
+  /*
 Frames:
 [ { type: 'POS', pos: 0 } ]
 
@@ -1791,25 +1336,17 @@ Expected type NUMBER but found STRING in:
 r.expr([1, 2, 3]).deleteAt("foo", 2).add("Hello")
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.expr([1,2,3]).deleteAt("foo", 2).add("Hello")', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr([1,2,3]).deleteAt("foo", 2).add("Hello").run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found STRING in:\nr.expr([1, 2, 3]).deleteAt(\"foo\", 2).add(\"Hello\")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^             \n") {
-      done()
+  it('Test backtrace for r.expr([1,2,3]).deleteAt("foo", 2).add("Hello")', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr([1, 2, 3]).deleteAt('foo', 2).add('Hello').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found STRING in:\nr.expr([1, 2, 3]).deleteAt("foo", 2).add("Hello")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^             \n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-
-/*
+  /*
 Frames:
 [ { type: 'POS', pos: 0 } ]
 
@@ -1818,24 +1355,17 @@ Expected type NUMBER but found STRING in:
 r.expr([1, 2, 3]).changeAt("foo", 2).add("Hello")
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.expr([1,2,3]).changeAt("foo", 2).add("Hello")', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr([1,2,3]).changeAt("foo", 2).add("Hello").run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found STRING in:\nr.expr([1, 2, 3]).changeAt(\"foo\", 2).add(\"Hello\")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^             \n") {
-      done()
+  it('Test backtrace for r.expr([1,2,3]).changeAt("foo", 2).add("Hello")', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr([1, 2, 3]).changeAt('foo', 2).add('Hello').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found STRING in:\nr.expr([1, 2, 3]).changeAt("foo", 2).add("Hello")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^             \n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 [ 0, 0 ]
 
@@ -1844,25 +1374,17 @@ Cannot call `keys` on objects of type `ARRAY` in:
 r.expr([1, 2, 3]).keys().add("Hello")
 ^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for  r.expr([1,2,3]).keys().add("Hello")', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield  r.expr([1,2,3]).keys().add("Hello").run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Cannot call `keys` on objects of type `ARRAY` in:\nr.expr([1, 2, 3]).keys().add(\"Hello\")\n^^^^^^^^^^^^^^^^^                    \n") {
-      done()
+  it('Test backtrace for  r.expr([1,2,3]).keys().add("Hello")', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr([1, 2, 3]).keys().add('Hello').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Cannot call `keys` on objects of type `ARRAY` in:\nr.expr([1, 2, 3]).keys().add("Hello")\n^^^^^^^^^^^^^^^^^                    \n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-
-/*
+  /*
 Frames:
 [ { type: 'POS', pos: 0 }, { type: 'POS', pos: 0 } ]
 
@@ -1871,25 +1393,17 @@ Expected type STRING but found ARRAY in:
 r.expr([1, 2, 3]).match("foo").add("Hello")
 ^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.expr([1,2,3]).match("foo").add("Hello")', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr([1,2,3]).match("foo").add("Hello").run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type STRING but found ARRAY in:\nr.expr([1, 2, 3]).match(\"foo\").add(\"Hello\")\n^^^^^^^^^^^^^^^^^                          \n") {
-      done()
+  it('Test backtrace for r.expr([1,2,3]).match("foo").add("Hello")', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr([1, 2, 3]).match('foo').add('Hello').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type STRING but found ARRAY in:\nr.expr([1, 2, 3]).match("foo").add("Hello")\n^^^^^^^^^^^^^^^^^                          \n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-
-/*
+  /*
 Frames:
 []
 
@@ -1898,25 +1412,17 @@ Expected type ARRAY but found STRING in:
 r.expr([1, 2, 3]).add("Hello")
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.expr([1,2,3]).add("Hello")', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr([1,2,3]).add("Hello").run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type ARRAY but found STRING in:\nr.expr([1, 2, 3]).add(\"Hello\")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n") {
-      done()
+  it('Test backtrace for r.expr([1,2,3]).add("Hello")', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr([1, 2, 3]).add('Hello').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type ARRAY but found STRING in:\nr.expr([1, 2, 3]).add("Hello")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-
-/*
+  /*
 Frames:
 []
 
@@ -1925,24 +1431,17 @@ Expected type NUMBER but found ARRAY in:
 r.expr([1, 2, 3]).sub("Hello")
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.expr([1,2,3]).sub("Hello")', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr([1,2,3]).sub("Hello").run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found ARRAY in:\nr.expr([1, 2, 3]).sub(\"Hello\")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n") {
-      done()
+  it('Test backtrace for r.expr([1,2,3]).sub("Hello")', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr([1, 2, 3]).sub('Hello').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found ARRAY in:\nr.expr([1, 2, 3]).sub("Hello")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 []
 
@@ -1951,24 +1450,17 @@ Expected type NUMBER but found STRING in:
 r.expr([1, 2, 3]).mul("Hello")
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.expr([1,2,3]).mul("Hello")', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr([1,2,3]).mul("Hello").run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found STRING in:\nr.expr([1, 2, 3]).mul(\"Hello\")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n") {
-      done()
+  it('Test backtrace for r.expr([1,2,3]).mul("Hello")', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr([1, 2, 3]).mul('Hello').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found STRING in:\nr.expr([1, 2, 3]).mul("Hello")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 []
 
@@ -1977,25 +1469,17 @@ Expected type NUMBER but found ARRAY in:
 r.expr([1, 2, 3]).div("Hello")
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.expr([1,2,3]).div("Hello")', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr([1,2,3]).div("Hello").run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found ARRAY in:\nr.expr([1, 2, 3]).div(\"Hello\")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n") {
-      done()
+  it('Test backtrace for r.expr([1,2,3]).div("Hello")', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr([1, 2, 3]).div('Hello').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found ARRAY in:\nr.expr([1, 2, 3]).div("Hello")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-
-/*
+  /*
 Frames:
 [ { type: 'POS', pos: 0 } ]
 
@@ -2004,24 +1488,17 @@ Expected type NUMBER but found ARRAY in:
 r.expr([1, 2, 3]).mod("Hello")
 ^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.expr([1,2,3]).mod("Hello")', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr([1,2,3]).mod("Hello").run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found ARRAY in:\nr.expr([1, 2, 3]).mod(\"Hello\")\n^^^^^^^^^^^^^^^^^             \n") {
-      done()
+  it('Test backtrace for r.expr([1,2,3]).mod("Hello")', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr([1, 2, 3]).mod('Hello').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found ARRAY in:\nr.expr([1, 2, 3]).mod("Hello")\n^^^^^^^^^^^^^^^^^             \n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 [ { type: 'POS', pos: 1 } ]
 
@@ -2030,25 +1507,17 @@ Expected type STRING but found NUMBER in:
 r.expr([1, 2, 3]).and(r.expr("Hello").add(2))
             ^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.expr([1,2,3]).and(r.expr("Hello").add(2))', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr([1,2,3]).and(r.expr("Hello").add(2)).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type STRING but found NUMBER in:\nr.expr([1, 2, 3]).and(r.expr(\"Hello\").add(2))\n                      ^^^^^^^^^^^^^^^^^^^^^^ \n") {
-      done()
+  it('Test backtrace for r.expr([1,2,3]).and(r.expr("Hello").add(2))', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr([1, 2, 3]).and(r.expr('Hello').add(2)).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type STRING but found NUMBER in:\nr.expr([1, 2, 3]).and(r.expr("Hello").add(2))\n                      ^^^^^^^^^^^^^^^^^^^^^^ \n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-
-/*
+  /*
 Frames:
 [ { type: 'POS', pos: 1 } ]
 
@@ -2057,25 +1526,17 @@ Expected type STRING but found NUMBER in:
 r.expr(false).or(r.expr("Hello").add(2))
          ^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.expr(false).or(r.expr("Hello").add(2))', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr(false).or(r.expr("Hello").add(2)).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type STRING but found NUMBER in:\nr.expr(false).or(r.expr(\"Hello\").add(2))\n                 ^^^^^^^^^^^^^^^^^^^^^^ \n") {
-      done()
+  it('Test backtrace for r.expr(false).or(r.expr("Hello").add(2))', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr(false).or(r.expr('Hello').add(2)).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type STRING but found NUMBER in:\nr.expr(false).or(r.expr("Hello").add(2))\n                 ^^^^^^^^^^^^^^^^^^^^^^ \n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-
-/*
+  /*
 Frames:
 [ { type: 'POS', pos: 1 } ]
 
@@ -2084,24 +1545,17 @@ Expected type STRING but found NUMBER in:
 r.expr([1, 2, 3]).eq(r.expr("Hello").add(2))
            ^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.expr([1,2,3]).eq(r.expr("Hello").add(2))', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr([1,2,3]).eq(r.expr("Hello").add(2)).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type STRING but found NUMBER in:\nr.expr([1, 2, 3]).eq(r.expr(\"Hello\").add(2))\n                     ^^^^^^^^^^^^^^^^^^^^^^ \n") {
-      done()
+  it('Test backtrace for r.expr([1,2,3]).eq(r.expr("Hello").add(2))', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr([1, 2, 3]).eq(r.expr('Hello').add(2)).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type STRING but found NUMBER in:\nr.expr([1, 2, 3]).eq(r.expr("Hello").add(2))\n                     ^^^^^^^^^^^^^^^^^^^^^^ \n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 [ { type: 'POS', pos: 1 } ]
 
@@ -2110,24 +1564,17 @@ Expected type STRING but found NUMBER in:
 r.expr([1, 2, 3]).ne(r.expr("Hello").add(2))
            ^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.expr([1,2,3]).ne(r.expr("Hello").add(2))', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr([1,2,3]).ne(r.expr("Hello").add(2)).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type STRING but found NUMBER in:\nr.expr([1, 2, 3]).ne(r.expr(\"Hello\").add(2))\n                     ^^^^^^^^^^^^^^^^^^^^^^ \n") {
-      done()
+  it('Test backtrace for r.expr([1,2,3]).ne(r.expr("Hello").add(2))', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr([1, 2, 3]).ne(r.expr('Hello').add(2)).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type STRING but found NUMBER in:\nr.expr([1, 2, 3]).ne(r.expr("Hello").add(2))\n                     ^^^^^^^^^^^^^^^^^^^^^^ \n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 [ { type: 'POS', pos: 1 } ]
 
@@ -2136,24 +1583,17 @@ Expected type STRING but found NUMBER in:
 r.expr([1, 2, 3]).gt(r.expr("Hello").add(2))
            ^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.expr([1,2,3]).gt(r.expr("Hello").add(2))', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr([1,2,3]).gt(r.expr("Hello").add(2)).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type STRING but found NUMBER in:\nr.expr([1, 2, 3]).gt(r.expr(\"Hello\").add(2))\n                     ^^^^^^^^^^^^^^^^^^^^^^ \n") {
-      done()
+  it('Test backtrace for r.expr([1,2,3]).gt(r.expr("Hello").add(2))', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr([1, 2, 3]).gt(r.expr('Hello').add(2)).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type STRING but found NUMBER in:\nr.expr([1, 2, 3]).gt(r.expr("Hello").add(2))\n                     ^^^^^^^^^^^^^^^^^^^^^^ \n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 [ { type: 'POS', pos: 1 } ]
 
@@ -2162,25 +1602,17 @@ Expected type STRING but found NUMBER in:
 r.expr([1, 2, 3]).lt(r.expr("Hello").add(2))
            ^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.expr([1,2,3]).lt(r.expr("Hello").add(2))', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr([1,2,3]).lt(r.expr("Hello").add(2)).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type STRING but found NUMBER in:\nr.expr([1, 2, 3]).lt(r.expr(\"Hello\").add(2))\n                     ^^^^^^^^^^^^^^^^^^^^^^ \n") {
-      done()
+  it('Test backtrace for r.expr([1,2,3]).lt(r.expr("Hello").add(2))', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr([1, 2, 3]).lt(r.expr('Hello').add(2)).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type STRING but found NUMBER in:\nr.expr([1, 2, 3]).lt(r.expr("Hello").add(2))\n                     ^^^^^^^^^^^^^^^^^^^^^^ \n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-
-/*
+  /*
 Frames:
 [ { type: 'POS', pos: 1 } ]
 
@@ -2189,24 +1621,17 @@ Expected type STRING but found NUMBER in:
 r.expr([1, 2, 3]).le(r.expr("Hello").add(2))
            ^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.expr([1,2,3]).le(r.expr("Hello").add(2))', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr([1,2,3]).le(r.expr("Hello").add(2)).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type STRING but found NUMBER in:\nr.expr([1, 2, 3]).le(r.expr(\"Hello\").add(2))\n                     ^^^^^^^^^^^^^^^^^^^^^^ \n") {
-      done()
+  it('Test backtrace for r.expr([1,2,3]).le(r.expr("Hello").add(2))', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr([1, 2, 3]).le(r.expr('Hello').add(2)).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type STRING but found NUMBER in:\nr.expr([1, 2, 3]).le(r.expr("Hello").add(2))\n                     ^^^^^^^^^^^^^^^^^^^^^^ \n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 [ { type: 'POS', pos: 1 } ]
 
@@ -2215,24 +1640,17 @@ Expected type STRING but found NUMBER in:
 r.expr([1, 2, 3]).ge(r.expr("Hello").add(2))
            ^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.expr([1,2,3]).ge(r.expr("Hello").add(2))', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr([1,2,3]).ge(r.expr("Hello").add(2)).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type STRING but found NUMBER in:\nr.expr([1, 2, 3]).ge(r.expr(\"Hello\").add(2))\n                     ^^^^^^^^^^^^^^^^^^^^^^ \n") {
-      done()
+  it('Test backtrace for r.expr([1,2,3]).ge(r.expr("Hello").add(2))', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr([1, 2, 3]).ge(r.expr('Hello').add(2)).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type STRING but found NUMBER in:\nr.expr([1, 2, 3]).ge(r.expr("Hello").add(2))\n                     ^^^^^^^^^^^^^^^^^^^^^^ \n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 [ { type: 'POS', pos: 1 } ]
 
@@ -2241,24 +1659,17 @@ Expected type STRING but found NUMBER in:
 r.expr([1, 2, 3]).not().add(r.expr("Hello").add(2))
               ^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.expr([1,2,3]).not().add(r.expr("Hello").add(2))', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr([1,2,3]).not().add(r.expr("Hello").add(2)).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type STRING but found NUMBER in:\nr.expr([1, 2, 3]).not().add(r.expr(\"Hello\").add(2))\n                            ^^^^^^^^^^^^^^^^^^^^^^ \n") {
-      done()
+  it('Test backtrace for r.expr([1,2,3]).not().add(r.expr("Hello").add(2))', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr([1, 2, 3]).not().add(r.expr('Hello').add(2)).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type STRING but found NUMBER in:\nr.expr([1, 2, 3]).not().add(r.expr("Hello").add(2))\n                            ^^^^^^^^^^^^^^^^^^^^^^ \n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 []
 
@@ -2267,25 +1678,17 @@ Expected type NUMBER but found STRING in:
 r.now().add("Hello")
 ^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.now().add("Hello")', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.now().add("Hello").run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found STRING in:\nr.now().add(\"Hello\")\n^^^^^^^^^^^^^^^^^^^^\n") {
-      done()
+  it('Test backtrace for r.now().add("Hello")', async () => {
+    try {
+      r.nextVarId = 1
+      await r.now().add('Hello').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found STRING in:\nr.now().add("Hello")\n^^^^^^^^^^^^^^^^^^^^\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-
-/*
+  /*
 Frames:
 [ { type: 'POS', pos: 0 } ]
 
@@ -2294,25 +1697,17 @@ Error in time logic: Year is out of valid range: 1400..10000 in:
 r.time(1023, 11, 3, "Z").add("Hello")
 ^^^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.time(1023, 11, 3, "Z").add("Hello")', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.time(1023, 11, 3, "Z").add("Hello").run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Error in time logic: Year is out of valid range: 1400..10000 in:\nr.time(1023, 11, 3, \"Z\").add(\"Hello\")\n^^^^^^^^^^^^^^^^^^^^^^^^             \n") {
-      done()
+  it('Test backtrace for r.time(1023, 11, 3, "Z").add("Hello")', async () => {
+    try {
+      r.nextVarId = 1
+      await r.time(1023, 11, 3, 'Z').add('Hello').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Error in time logic: Year is out of valid range: 1400..10000 in:\nr.time(1023, 11, 3, "Z").add("Hello")\n^^^^^^^^^^^^^^^^^^^^^^^^             \n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-
-/*
+  /*
 Frames:
 []
 
@@ -2321,24 +1716,17 @@ Expected type NUMBER but found STRING in:
 r.epochTime(12132131).add("Hello")
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.epochTime(12132131).add("Hello")', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.epochTime(12132131).add("Hello").run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found STRING in:\nr.epochTime(12132131).add(\"Hello\")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n") {
-      done()
+  it('Test backtrace for r.epochTime(12132131).add("Hello")', async () => {
+    try {
+      r.nextVarId = 1
+      await r.epochTime(12132131).add('Hello').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found STRING in:\nr.epochTime(12132131).add("Hello")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 [ { type: 'POS', pos: 0 }, { type: 'POS', pos: 0 } ]
 
@@ -2347,24 +1735,17 @@ Invalid date string `UnvalidISO961String` (got `U` but expected a digit) in:
 r.ISO8601("UnvalidISO961String").add("Hello")
       ^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.ISO8601("UnvalidISO961String").add("Hello")', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.ISO8601("UnvalidISO961String").add("Hello").run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Invalid date string `UnvalidISO961String` (got `U` but expected a digit) in:\nr.ISO8601(\"UnvalidISO961String\").add(\"Hello\")\n          ^^^^^^^^^^^^^^^^^^^^^              \n") {
-      done()
+  it('Test backtrace for r.ISO8601("UnvalidISO961String").add("Hello")', async () => {
+    try {
+      r.nextVarId = 1
+      await r.ISO8601('UnvalidISO961String').add('Hello').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Invalid date string `UnvalidISO961String` (got `U` but expected a digit) in:\nr.ISO8601("UnvalidISO961String").add("Hello")\n          ^^^^^^^^^^^^^^^^^^^^^              \n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 [ { type: 'POS', pos: 0 } ]
 
@@ -2373,24 +1754,17 @@ Timezone `noTimezone` does not start with `-` or `+` in:
 r.now().inTimezone("noTimezone").add("Hello")
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.now().inTimezone("noTimezone").add("Hello")', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.now().inTimezone("noTimezone").add("Hello").run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Timezone `noTimezone` does not start with `-` or `+` in:\nr.now().inTimezone(\"noTimezone\").add(\"Hello\")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^             \n") {
-      done()
+  it('Test backtrace for r.now().inTimezone("noTimezone").add("Hello")', async () => {
+    try {
+      r.nextVarId = 1
+      await r.now().inTimezone('noTimezone').add('Hello').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Timezone `noTimezone` does not start with `-` or `+` in:\nr.now().inTimezone("noTimezone").add("Hello")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^             \n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 []
 
@@ -2399,24 +1773,17 @@ Expected type STRING but found BOOL in:
 r.now().timezone().add(true)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.now().timezone().add(true)', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.now().timezone().add(true).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type STRING but found BOOL in:\nr.now().timezone().add(true)\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n") {
-      done()
+  it('Test backtrace for r.now().timezone().add(true)', async () => {
+    try {
+      r.nextVarId = 1
+      await r.now().timezone().add(true).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type STRING but found BOOL in:\nr.now().timezone().add(true)\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 []
 
@@ -2425,24 +1792,17 @@ Expected type NUMBER but found BOOL in:
 r.now().during(r.now(), r.now()).add(true)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.now().during(r.now(), r.now()).add(true)', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.now().during(r.now(), r.now()).add(true).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found BOOL in:\nr.now().during(r.now(), r.now()).add(true)\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n") {
-      done()
+  it('Test backtrace for r.now().during(r.now(), r.now()).add(true)', async () => {
+    try {
+      r.nextVarId = 1
+      await r.now().during(r.now(), r.now()).add(true).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found BOOL in:\nr.now().during(r.now(), r.now()).add(true)\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 []
 
@@ -2451,25 +1811,17 @@ Expected type NUMBER but found BOOL in:
 r.now().timeOfDay().add(true)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.now().timeOfDay().add(true)', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.now().timeOfDay().add(true).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found BOOL in:\nr.now().timeOfDay().add(true)\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n") {
-      done()
+  it('Test backtrace for r.now().timeOfDay().add(true)', async () => {
+    try {
+      r.nextVarId = 1
+      await r.now().timeOfDay().add(true).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found BOOL in:\nr.now().timeOfDay().add(true)\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-
-/*
+  /*
 Frames:
 []
 
@@ -2478,24 +1830,17 @@ Expected type NUMBER but found BOOL in:
 r.now().year().add(true)
 ^^^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.now().year().add(true)', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.now().year().add(true).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found BOOL in:\nr.now().year().add(true)\n^^^^^^^^^^^^^^^^^^^^^^^^\n") {
-      done()
+  it('Test backtrace for r.now().year().add(true)', async () => {
+    try {
+      r.nextVarId = 1
+      await r.now().year().add(true).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found BOOL in:\nr.now().year().add(true)\n^^^^^^^^^^^^^^^^^^^^^^^^\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 []
 
@@ -2504,24 +1849,17 @@ Expected type NUMBER but found BOOL in:
 r.now().month().add(true)
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.now().month().add(true)', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.now().month().add(true).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found BOOL in:\nr.now().month().add(true)\n^^^^^^^^^^^^^^^^^^^^^^^^^\n") {
-      done()
+  it('Test backtrace for r.now().month().add(true)', async () => {
+    try {
+      r.nextVarId = 1
+      await r.now().month().add(true).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found BOOL in:\nr.now().month().add(true)\n^^^^^^^^^^^^^^^^^^^^^^^^^\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 []
 
@@ -2530,24 +1868,17 @@ Expected type NUMBER but found BOOL in:
 r.now().day().add(true)
 ^^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.now().day().add(true)', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.now().day().add(true).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found BOOL in:\nr.now().day().add(true)\n^^^^^^^^^^^^^^^^^^^^^^^\n") {
-      done()
+  it('Test backtrace for r.now().day().add(true)', async () => {
+    try {
+      r.nextVarId = 1
+      await r.now().day().add(true).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found BOOL in:\nr.now().day().add(true)\n^^^^^^^^^^^^^^^^^^^^^^^\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 []
 
@@ -2556,24 +1887,17 @@ Expected type NUMBER but found BOOL in:
 r.now().dayOfWeek().add(true)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.now().dayOfWeek().add(true)', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.now().dayOfWeek().add(true).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found BOOL in:\nr.now().dayOfWeek().add(true)\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n") {
-      done()
+  it('Test backtrace for r.now().dayOfWeek().add(true)', async () => {
+    try {
+      r.nextVarId = 1
+      await r.now().dayOfWeek().add(true).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found BOOL in:\nr.now().dayOfWeek().add(true)\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 []
 
@@ -2582,25 +1906,17 @@ Expected type NUMBER but found BOOL in:
 r.now().dayOfYear().add(true)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.now().dayOfYear().add(true)', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.now().dayOfYear().add(true).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found BOOL in:\nr.now().dayOfYear().add(true)\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n") {
-      done()
+  it('Test backtrace for r.now().dayOfYear().add(true)', async () => {
+    try {
+      r.nextVarId = 1
+      await r.now().dayOfYear().add(true).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found BOOL in:\nr.now().dayOfYear().add(true)\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-
-/*
+  /*
 Frames:
 []
 
@@ -2609,24 +1925,17 @@ Expected type NUMBER but found BOOL in:
 r.now().hours().add(true)
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.now().hours().add(true)', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.now().hours().add(true).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found BOOL in:\nr.now().hours().add(true)\n^^^^^^^^^^^^^^^^^^^^^^^^^\n") {
-      done()
+  it('Test backtrace for r.now().hours().add(true)', async () => {
+    try {
+      r.nextVarId = 1
+      await r.now().hours().add(true).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found BOOL in:\nr.now().hours().add(true)\n^^^^^^^^^^^^^^^^^^^^^^^^^\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 []
 
@@ -2635,24 +1944,17 @@ Expected type NUMBER but found BOOL in:
 r.now().minutes().add(true)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.now().minutes().add(true)', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.now().minutes().add(true).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found BOOL in:\nr.now().minutes().add(true)\n^^^^^^^^^^^^^^^^^^^^^^^^^^^\n") {
-      done()
+  it('Test backtrace for r.now().minutes().add(true)', async () => {
+    try {
+      r.nextVarId = 1
+      await r.now().minutes().add(true).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found BOOL in:\nr.now().minutes().add(true)\n^^^^^^^^^^^^^^^^^^^^^^^^^^^\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 []
 
@@ -2661,24 +1963,17 @@ Expected type NUMBER but found BOOL in:
 r.now().seconds().add(true)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.now().seconds().add(true)', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.now().seconds().add(true).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found BOOL in:\nr.now().seconds().add(true)\n^^^^^^^^^^^^^^^^^^^^^^^^^^^\n") {
-      done()
+  it('Test backtrace for r.now().seconds().add(true)', async () => {
+    try {
+      r.nextVarId = 1
+      await r.now().seconds().add(true).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found BOOL in:\nr.now().seconds().add(true)\n^^^^^^^^^^^^^^^^^^^^^^^^^^^\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 []
 
@@ -2687,24 +1982,17 @@ Expected type STRING but found BOOL in:
 r.now().toISO8601().add(true)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.now().toISO8601().add(true)', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.now().toISO8601().add(true).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type STRING but found BOOL in:\nr.now().toISO8601().add(true)\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n") {
-      done()
+  it('Test backtrace for r.now().toISO8601().add(true)', async () => {
+    try {
+      r.nextVarId = 1
+      await r.now().toISO8601().add(true).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type STRING but found BOOL in:\nr.now().toISO8601().add(true)\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 []
 
@@ -2713,25 +2001,17 @@ Expected type NUMBER but found BOOL in:
 r.now().toEpochTime().add(true)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.now().toEpochTime().add(true)', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.now().toEpochTime().add(true).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found BOOL in:\nr.now().toEpochTime().add(true)\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n") {
-      done()
+  it('Test backtrace for r.now().toEpochTime().add(true)', async () => {
+    try {
+      r.nextVarId = 1
+      await r.now().toEpochTime().add(true).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found BOOL in:\nr.now().toEpochTime().add(true)\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-
-/*
+  /*
 Frames:
 [ 0, 1, 0, 0 ]
 
@@ -2739,28 +2019,21 @@ Error:
 Cannot perform bracket on a non-object non-sequence `1` in:
 r.expr(1).do(function(var_1) {
   return var_1("bah").add(3)
-       ^^^^^              
+       ^^^^^
 })
 */
-It('Test backtrace for r.expr(1).do(function(var_1) { return var_1("bah").add(3) }) ', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr(1).do(function(var_1) { return var_1("bah").add(3) }) .run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Cannot perform bracket on a non-object non-sequence `1` in:\nr.expr(1).do(function(var_1) {\n    return var_1(\"bah\").add(3)\n           ^^^^^              \n})\n") {
-      done()
+  it('Test backtrace for r.expr(1).do(function(var_1) { return var_1("bah").add(3) }) ', async () => {
+    try {
+      r.nextVarId = 1
+
+      await r.expr(1).do(function (var_1) { return var_1('bah').add(3) }).run() // eslint-disable-line camelcase
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Cannot perform bracket on a non-object non-sequence `1` in:\nr.expr(1).do(function(var_1) {\n    return var_1("bah").add(3)\n           ^^^^^              \n})\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-
-/*
+  /*
 Frames:
 [ 0 ]
 
@@ -2769,25 +2042,17 @@ Expected type NUMBER but found STRING in:
 r.branch(r.expr(1).add("hello"), "Hello", "World")
      ^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.branch(r.expr(1).add("hello"), "Hello", "World")', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.branch(r.expr(1).add("hello"), "Hello", "World").run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found STRING in:\nr.branch(r.expr(1).add(\"hello\"), \"Hello\", \"World\")\n         ^^^^^^^^^^^^^^^^^^^^^^                   \n") {
-      done()
+  it('Test backtrace for r.branch(r.expr(1).add("hello"), "Hello", "World")', async () => {
+    try {
+      r.nextVarId = 1
+      await r.branch(r.expr(1).add('hello'), 'Hello', 'World').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found STRING in:\nr.branch(r.expr(1).add("hello"), "Hello", "World")\n         ^^^^^^^^^^^^^^^^^^^^^^                   \n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-
-/*
+  /*
 Frames:
 []
 
@@ -2800,25 +2065,17 @@ r.expr(1).forEach(function(var_1) {
 })
 ^^
 */
-It('Test backtrace for r.expr(1).forEach(function(foo) { return foo("bar") })', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr(1).forEach(function(foo) { return foo("bar") }).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Cannot convert NUMBER to SEQUENCE in:\nr.expr(1).forEach(function(var_1) {\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    return var_1(\"bar\")\n    ^^^^^^^^^^^^^^^^^^^\n})\n^^\n") {
-      done()
+  it('Test backtrace for r.expr(1).forEach(function(foo) { return foo("bar") })', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr(1).forEach(function (foo) { return foo('bar') }).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Cannot convert NUMBER to SEQUENCE in:\nr.expr(1).forEach(function(var_1) {\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    return var_1("bar")\n    ^^^^^^^^^^^^^^^^^^^\n})\n^^\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-
-/*
+  /*
 Frames:
 []
 
@@ -2827,25 +2084,17 @@ foo in:
 r.error("foo")
 ^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.error("foo")', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.error("foo").run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "foo in:\nr.error(\"foo\")\n^^^^^^^^^^^^^^\n") {
-      done()
+  it('Test backtrace for r.error("foo")', async () => {
+    try {
+      r.nextVarId = 1
+      await r.error('foo').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'foo in:\nr.error("foo")\n^^^^^^^^^^^^^^\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-
-/*
+  /*
 Frames:
 []
 
@@ -2858,24 +2107,17 @@ r.expr({
 })("b").default("bar").add(2)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.expr({a:1})("b").default("bar").add(2)', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr({a:1})("b").default("bar").add(2).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type STRING but found NUMBER in:\nr.expr({\n^^^^^^^^\n    a: 1\n    ^^^^\n})(\"b\").default(\"bar\").add(2)\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n") {
-      done()
+  it('Test backtrace for r.expr({a:1})("b").default("bar").add(2)', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr({a: 1})('b').default('bar').add(2).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type STRING but found NUMBER in:\nr.expr({\n^^^^^^^^\n    a: 1\n    ^^^^\n})("b").default("bar").add(2)\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 []
 
@@ -2888,24 +2130,17 @@ r.expr({
 }).add(2)
 ^^^^^^^^^
 */
-It('Test backtrace for r.expr({a:1}).add(2)', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr({a:1}).add(2).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found OBJECT in:\nr.expr({\n^^^^^^^^\n    a: 1\n    ^^^^\n}).add(2)\n^^^^^^^^^\n") {
-      done()
+  it('Test backtrace for r.expr({a:1}).add(2)', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr({a: 1}).add(2).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found OBJECT in:\nr.expr({\n^^^^^^^^\n    a: 1\n    ^^^^\n}).add(2)\n^^^^^^^^^\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 []
 
@@ -2918,24 +2153,17 @@ r.expr({
 }).add(r.js("2"))
 ^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.expr({a:1}).add(r.js("2"))', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr({a:1}).add(r.js("2")).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found OBJECT in:\nr.expr({\n^^^^^^^^\n    a: 1\n    ^^^^\n}).add(r.js(\"2\"))\n^^^^^^^^^^^^^^^^^\n") {
-      done()
+  it('Test backtrace for r.expr({a:1}).add(r.js("2"))', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr({a: 1}).add(r.js('2')).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found OBJECT in:\nr.expr({\n^^^^^^^^\n    a: 1\n    ^^^^\n}).add(r.js("2"))\n^^^^^^^^^^^^^^^^^\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 [ { type: 'POS', pos: 0 } ]
 
@@ -2944,24 +2172,17 @@ Cannot coerce NUMBER to ARRAY in:
 r.expr(2).coerceTo("ARRAY")
 ^^^^^^^^^
 */
-It('Test backtrace for r.expr(2).coerceTo("ARRAY")', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr(2).coerceTo("ARRAY").run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Cannot coerce NUMBER to ARRAY in:\nr.expr(2).coerceTo(\"ARRAY\")\n^^^^^^^^^                  \n") {
-      done()
+  it('Test backtrace for r.expr(2).coerceTo("ARRAY")', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr(2).coerceTo('ARRAY').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Cannot coerce NUMBER to ARRAY in:\nr.expr(2).coerceTo("ARRAY")\n^^^^^^^^^                  \n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 [ { type: 'POS', pos: 0 } ]
 
@@ -2970,24 +2191,17 @@ Expected type NUMBER but found STRING in:
 r.expr(2).add("foo").typeOf()
 ^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.expr(2).add("foo").typeOf()', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr(2).add("foo").typeOf().run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found STRING in:\nr.expr(2).add(\"foo\").typeOf()\n^^^^^^^^^^^^^^^^^^^^         \n") {
-      done()
+  it('Test backtrace for r.expr(2).add("foo").typeOf()', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr(2).add('foo').typeOf().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found STRING in:\nr.expr(2).add("foo").typeOf()\n^^^^^^^^^^^^^^^^^^^^         \n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 [ { type: 'POS', pos: 0 } ]
 
@@ -2996,24 +2210,17 @@ Expected type NUMBER but found STRING in:
 r.expr(2).add("foo").info()
 ^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.expr(2).add("foo").info()', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr(2).add("foo").info().run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found STRING in:\nr.expr(2).add(\"foo\").info()\n^^^^^^^^^^^^^^^^^^^^       \n") {
-      done()
+  it('Test backtrace for r.expr(2).add("foo").info()', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr(2).add('foo').info().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found STRING in:\nr.expr(2).add("foo").info()\n^^^^^^^^^^^^^^^^^^^^       \n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 [ 1 ]
 
@@ -3022,24 +2229,17 @@ Failed to parse "foo" as JSON: Invalid value in:
 r.expr(2).add(r.json("foo"))
               ^^^^^^^^^^^^^
 */
-It('Test backtrace for r.expr(2).add(r.json("foo"))', function* (done) {
+  it('Test backtrace for r.expr(2).add(r.json("foo"))', async () => {
     try {
-        r.nextVarId=1;
-        yield r.expr(2).add(r.json("foo")).run()
-        done(new Error("Should have thrown an error"))
+      r.nextVarId = 1
+      await r.expr(2).add(r.json('foo')).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Failed to parse "foo" as JSON: Invalid value in:\nr.expr(2).add(r.json("foo"))\n              ^^^^^^^^^^^^^ \n')
     }
-    catch(e) {
-        if (e.message === "Failed to parse \"foo\" as JSON: Invalid value in:\nr.expr(2).add(r.json(\"foo\"))\n              ^^^^^^^^^^^^^ \n") {
-            done()
-        }
-        else {
-            done(e);
-        }
-    }
-})
+  })
 
-
-/*
+  /*
 Frames:
 undefined
 
@@ -3048,27 +2248,19 @@ Unrecognized option `nonValid` in `replace` after:
 r.db("791087f7a75b40ba6a89f96cafefa643").table("da63855c1650bdd5e653662750771333")
 Available options are returnChanges <bool>, durability <string>, nonAtomic <bool>
 */
-It('Test backtrace for r.db(dbName).table(tableName).replace({a:1}, {nonValid:true})', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.db(dbName).table(tableName).replace({a:1}, {nonValid:true}).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Unrecognized option `nonValid` in `replace` after:\nr.db(\""+dbName+"\").table(\""+tableName+"\")\nAvailable options are returnChanges <bool>, durability <string>, nonAtomic <bool>") {
-      done()
+  it('Test backtrace for r.db(dbName).table(tableName).replace({a:1}, {nonValid:true})', async () => {
+    try {
+      r.nextVarId = 1
+      await r.db(dbName).table(tableName).replace({a: 1}, {nonValid: true}).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Unrecognized option `nonValid` in `replace` after:\nr.db("' + dbName + '").table("' + tableName + '")\nAvailable options are returnChanges <bool>, durability <string>, nonAtomic <bool>')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 []
-
 
 /*
 Frames:
@@ -3086,25 +2278,17 @@ r.db("0fbd7374d30a23284bc64625f9b6838a").table("5429869da70a92a5e495ed4989e40e30
   })
   ^
 */
-It('Test backtrace for r.db(dbName).table(tableName).replace({a:1}, {durability: "softt"})', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.db(dbName).table(tableName).replace({a:1}, {durability: "softt"}).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Durability option `softt` unrecognized (options are \"hard\" and \"soft\") in:\nr.db(\""+dbName+"\").table(\""+tableName+"\")\n    .replace({\n        a: 1\n    }, {\n       ^\n        durability: \"softt\"\n        ^^^^^^^^^^^^^^^^^^^\n    })\n    ^ \n") {
-      done()
+  it('Test backtrace for r.db(dbName).table(tableName).replace({a:1}, {durability: "softt"})', async () => {
+    try {
+      r.nextVarId = 1
+      await r.db(dbName).table(tableName).replace({a: 1}, {durability: 'softt'}).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Durability option `softt` unrecognized (options are "hard" and "soft") in:\nr.db("' + dbName + '").table("' + tableName + '")\n    .replace({\n        a: 1\n    }, {\n       ^\n        durability: "softt"\n        ^^^^^^^^^^^^^^^^^^^\n    })\n    ^ \n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-
-/*
+  /*
 Frames:
 [ { type: 'POS', pos: 1 }, { type: 'POS', pos: 1 } ]
 
@@ -3113,24 +2297,17 @@ Expected type NUMBER but found STRING in:
 r.expr([1, 2]).map(r.row.add("eh"))
            ^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.expr([1,2]).map(r.row.add("eh"))', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr([1,2]).map(r.row.add("eh")).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found STRING in:\nr.expr([1, 2]).map(r.row.add(\"eh\"))\n                   ^^^^^^^^^^^^^^^ \n") {
-      done()
+  it('Test backtrace for r.expr([1,2]).map(r.row.add("eh"))', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr([1, 2]).map(r.row.add('eh')).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found STRING in:\nr.expr([1, 2]).map(r.row.add("eh"))\n                   ^^^^^^^^^^^^^^^ \n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 [ { type: 'POS', pos: 0 },
   { type: 'POS', pos: 0 },
@@ -3142,7 +2319,7 @@ Frames:
 Error:
 Table `test.foo` does not exist in:
 r.table("foo").add(1).add(1).add("hello-super-long-string").add("another-long-string")
-^^^^^^^^^^^^^^                                                                        
+^^^^^^^^^^^^^^
   .add("one-last-string").map(function(var_1) {
     return r.expr([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]).map(function(var_2) {
       return var_2("b").add("hello-super-long-string").add("another-long-string").add("one-last-string")
@@ -3165,14 +2342,13 @@ r.table("foo").add(1).add(1).add("hello-super-long-string").add("another-long-st
     })
   })
 */
-It('Test backtrace for r.table("foo").add(1).add(1).add("hello-super-long-string").add("another-long-string").add("one-last-string").map( function(doc) { return r.expr([1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16]).map(function(test) { return test("b").add("hello-super-long-string").add("another-long-string").add("one-last-string").add("hello-super-long-string").add("another-long-string").add("one-last-string").add("hello-super-long-string").add("another-long-string").add("one-last-string").add("hello-super-long-string").add("another-long-string").add("one-last-string").add("hello-super-long-string").add("another-long-string").add("one-last-string").mul(test("b")).merge({ firstName: "xxxxxx", lastName: "yyyy", email: "xxxxx@yyyy.com", phone: "xxx-xxx-xxxx" }); }).add(2).map(function(doc) { return doc.add("hello-super-long-string").add("another-long-string").add("one-last-string").add("hello-super-long-string").add("another-long-string").add("one-last-string").add("hello-super-long-string").add("another-long-string").add("one-last-string").add("hello-super-long-string").add("another-long-string").add("one-last-string").add("hello-super-long-string").add("another-long-string").add("one-last-string") }); })', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.table("foo").add(1).add(1).add("hello-super-long-string").add("another-long-string").add("one-last-string").map( function(doc) { return r.expr([1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16]).map(function(test) { return test("b").add("hello-super-long-string").add("another-long-string").add("one-last-string").add("hello-super-long-string").add("another-long-string").add("one-last-string").add("hello-super-long-string").add("another-long-string").add("one-last-string").add("hello-super-long-string").add("another-long-string").add("one-last-string").add("hello-super-long-string").add("another-long-string").add("one-last-string").mul(test("b")).merge({ firstName: "xxxxxx", lastName: "yyyy", email: "xxxxx@yyyy.com", phone: "xxx-xxx-xxxx" }); }).add(2).map(function(doc) { return doc.add("hello-super-long-string").add("another-long-string").add("one-last-string").add("hello-super-long-string").add("another-long-string").add("one-last-string").add("hello-super-long-string").add("another-long-string").add("one-last-string").add("hello-super-long-string").add("another-long-string").add("one-last-string").add("hello-super-long-string").add("another-long-string").add("one-last-string") }); }).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === `Table \`test.foo\` does not exist in:
+  it('Test backtrace for r.table("foo").add(1).add(1).add("hello-super-long-string").add("another-long-string").add("one-last-string").map( function(doc) { return r.expr([1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16]).map(function(test) { return test("b").add("hello-super-long-string").add("another-long-string").add("one-last-string").add("hello-super-long-string").add("another-long-string").add("one-last-string").add("hello-super-long-string").add("another-long-string").add("one-last-string").add("hello-super-long-string").add("another-long-string").add("one-last-string").add("hello-super-long-string").add("another-long-string").add("one-last-string").mul(test("b")).merge({ firstName: "xxxxxx", lastName: "yyyy", email: "xxxxx@yyyy.com", phone: "xxx-xxx-xxxx" }); }).add(2).map(function(doc) { return doc.add("hello-super-long-string").add("another-long-string").add("one-last-string").add("hello-super-long-string").add("another-long-string").add("one-last-string").add("hello-super-long-string").add("another-long-string").add("one-last-string").add("hello-super-long-string").add("another-long-string").add("one-last-string").add("hello-super-long-string").add("another-long-string").add("one-last-string") }); })', async () => {
+    try {
+      r.nextVarId = 1
+      await r.table('foo').add(1).add(1).add('hello-super-long-string').add('another-long-string').add('one-last-string').map(function (doc) { return r.expr([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]).map(function (test) { return test('b').add('hello-super-long-string').add('another-long-string').add('one-last-string').add('hello-super-long-string').add('another-long-string').add('one-last-string').add('hello-super-long-string').add('another-long-string').add('one-last-string').add('hello-super-long-string').add('another-long-string').add('one-last-string').add('hello-super-long-string').add('another-long-string').add('one-last-string').mul(test('b')).merge({ firstName: 'xxxxxx', lastName: 'yyyy', email: 'xxxxx@yyyy.com', phone: 'xxx-xxx-xxxx' }) }).add(2).map(function (doc) { return doc.add('hello-super-long-string').add('another-long-string').add('one-last-string').add('hello-super-long-string').add('another-long-string').add('one-last-string').add('hello-super-long-string').add('another-long-string').add('one-last-string').add('hello-super-long-string').add('another-long-string').add('one-last-string').add('hello-super-long-string').add('another-long-string').add('one-last-string') }) }).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === `Table \`test.foo\` does not exist in:
 r.table("foo").add(1).add(1).add("hello-super-long-string").add("another-long-string")
 ^^^^^^^^^^^^^^                                                                        
     .add("one-last-string").map(function(var_1) {
@@ -3196,17 +2372,11 @@ r.table("foo").add(1).add(1).add("hello-super-long-string").add("another-long-st
                 .add("hello-super-long-string").add("another-long-string").add("one-last-string")
         })
     })
-`) {
-      done()
+`)
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 [ 'b' ]
 
@@ -3218,26 +2388,17 @@ r.expr({
      ^^^^^^^^^^^^^^^^^^^
 })
 */
-It('Test backtrace for r.expr({a:1, b:r.expr(1).add("eh")})', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr({a:1, b:r.expr(1).add("eh")}).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found STRING in:\nr.expr({\n    a: 1,\n    b: r.expr(1).add(\"eh\")\n       ^^^^^^^^^^^^^^^^^^^\n})\n") {
-      done()
+  it('Test backtrace for r.expr({a:1, b:r.expr(1).add("eh")})', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr({a: 1, b: r.expr(1).add('eh')}).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found STRING in:\nr.expr({\n    a: 1,\n    b: r.expr(1).add("eh")\n       ^^^^^^^^^^^^^^^^^^^\n})\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-
-
-/*
+  /*
 Frames:
 []
 
@@ -3256,24 +2417,17 @@ r.db("330a8b0e7ff2501e855f0d45aebe6006").table("80179c85b797f92a3abbb0e40e7b06a3
   }).add(2)
   ^^^^^^^^^
 */
-It('Test backtrace for r.db(dbName).table(tableName).replace({a:1}, {durability:"soft"}).add(2)', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.db(dbName).table(tableName).replace({a:1}, {durability:"soft"}).add(2).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found OBJECT in:\nr.db(\""+dbName+"\").table(\""+tableName+"\")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    .replace({\n    ^^^^^^^^^^\n        a: 1\n        ^^^^\n    }, {\n    ^^^^\n        durability: \"soft\"\n        ^^^^^^^^^^^^^^^^^^\n    }).add(2)\n    ^^^^^^^^^\n") {
-      done()
+  it('Test backtrace for r.db(dbName).table(tableName).replace({a:1}, {durability:"soft"}).add(2)', async () => {
+    try {
+      r.nextVarId = 1
+      await r.db(dbName).table(tableName).replace({a: 1}, {durability: 'soft'}).add(2).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found OBJECT in:\nr.db("' + dbName + '").table("' + tableName + '")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    .replace({\n    ^^^^^^^^^^\n        a: 1\n        ^^^^\n    }, {\n    ^^^^\n        durability: "soft"\n        ^^^^^^^^^^^^^^^^^^\n    }).add(2)\n    ^^^^^^^^^\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 [ { type: 'OPT', opt: 'durability' } ]
 
@@ -3289,24 +2443,17 @@ r.db("83db41722b445306270f0129b6bcbde0").table("1264cb52a222e32026ce2d67ac27bc23
   })
   ^
 */
-It('Test backtrace for r.db(dbName).table(tableName).replace({a:1}, {durability:r.expr(1).add("heloo")})', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.db(dbName).table(tableName).replace({a:1}, {durability:r.expr(1).add("heloo")}).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found STRING in:\nr.db(\""+dbName+"\").table(\""+tableName+"\")\n    .replace({\n        a: 1\n    }, {\n       ^\n        durability: r.expr(1).add(\"heloo\")\n        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    })\n    ^ \n") {
-      done()
+  it('Test backtrace for r.db(dbName).table(tableName).replace({a:1}, {durability:r.expr(1).add("heloo")})', async () => {
+    try {
+      r.nextVarId = 1
+      await r.db(dbName).table(tableName).replace({a: 1}, {durability: r.expr(1).add('heloo')}).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found STRING in:\nr.db("' + dbName + '").table("' + tableName + '")\n    .replace({\n        a: 1\n    }, {\n       ^\n        durability: r.expr(1).add("heloo")\n        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    })\n    ^ \n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 [ { type: 'OPT', opt: 'durability' } ]
 
@@ -3322,23 +2469,17 @@ r.db("6dddeb36901f203298878f980598ce0a").table("5510e0388d908dca1fa4a6dbf00c2852
   })
   ^
 */
-It('Test backtrace for r.db(dbName).table(tableName).replace({a:1}, {durability:r.expr(1).add("heloo")})', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.db(dbName).table(tableName).replace({a:1}, {durability:r.expr(1).add("heloo")}).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found STRING in:\nr.db(\""+dbName+"\").table(\""+tableName+"\")\n    .replace({\n        a: 1\n    }, {\n       ^\n        durability: r.expr(1).add(\"heloo\")\n        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    })\n    ^ \n") {
-      done()
+  it('Test backtrace for r.db(dbName).table(tableName).replace({a:1}, {durability:r.expr(1).add("heloo")})', async () => {
+    try {
+      r.nextVarId = 1
+      await r.db(dbName).table(tableName).replace({a: 1}, {durability: r.expr(1).add('heloo')}).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found STRING in:\nr.db("' + dbName + '").table("' + tableName + '")\n    .replace({\n        a: 1\n    }, {\n       ^\n        durability: r.expr(1).add("heloo")\n        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    })\n    ^ \n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-/*
+  /*
 Frames:
 [ 'a' ]
 
@@ -3346,28 +2487,21 @@ Error:
 Expected type NUMBER but found STRING in:
 r.expr({
   a: r.expr(1).add("eh"),
-     ^^^^^^^^^^^^^^^^^^^ 
+     ^^^^^^^^^^^^^^^^^^^
   b: 2
 })
 */
-It('Test backtrace for r.expr({a:r.expr(1).add("eh"), b: 2})', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr({a:r.expr(1).add("eh"), b: 2}).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found STRING in:\nr.expr({\n    a: r.expr(1).add(\"eh\"),\n       ^^^^^^^^^^^^^^^^^^^ \n    b: 2\n})\n") {
-      done()
+  it('Test backtrace for r.expr({a:r.expr(1).add("eh"), b: 2})', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr({a: r.expr(1).add('eh'), b: 2}).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found STRING in:\nr.expr({\n    a: r.expr(1).add("eh"),\n       ^^^^^^^^^^^^^^^^^^^ \n    b: 2\n})\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 []
 
@@ -3376,25 +2510,17 @@ Expected type ARRAY but found STRING in:
 r.expr([1, 2, 3]).add("eh")
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.expr([1,2,3]).add("eh")', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr([1,2,3]).add("eh").run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type ARRAY but found STRING in:\nr.expr([1, 2, 3]).add(\"eh\")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^\n") {
-      done()
+  it('Test backtrace for r.expr([1,2,3]).add("eh")', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr([1, 2, 3]).add('eh').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type ARRAY but found STRING in:\nr.expr([1, 2, 3]).add("eh")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-
-/*
+  /*
 Frames:
 []
 
@@ -3407,25 +2533,17 @@ r.expr({
 }).add("eh")
 ^^^^^^^^^^^^
 */
-It('Test backtrace for r.expr({a:1}).add("eh")', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr({a:1}).add("eh").run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found OBJECT in:\nr.expr({\n^^^^^^^^\n    a: 1\n    ^^^^\n}).add(\"eh\")\n^^^^^^^^^^^^\n") {
-      done()
+  it('Test backtrace for r.expr({a:1}).add("eh")', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr({a: 1}).add('eh').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found OBJECT in:\nr.expr({\n^^^^^^^^\n    a: 1\n    ^^^^\n}).add("eh")\n^^^^^^^^^^^^\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-
-/*
+  /*
 Frames:
 [ { type: 'POS', pos: 1 } ]
 
@@ -3434,24 +2552,17 @@ Cannot perform get_field on a non-object non-sequence `1` in:
 r.expr([1, 2, 3]).group("foo")
             ^^^^^
 */
-It('Test backtrace for r.expr([1,2,3]).group("foo")', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr([1,2,3]).group("foo").run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Cannot perform get_field on a non-object non-sequence `1` in:\nr.expr([1, 2, 3]).group(\"foo\")\n                        ^^^^^ \n") {
-      done()
+  it('Test backtrace for r.expr([1,2,3]).group("foo")', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr([1, 2, 3]).group('foo').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Cannot perform get_field on a non-object non-sequence `1` in:\nr.expr([1, 2, 3]).group("foo")\n                        ^^^^^ \n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 [ 0 ]
 
@@ -3465,24 +2576,17 @@ Expected type GROUPED_DATA but found DATUM:
 r.expr([1, 2, 3]).ungroup()
 ^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.expr([1,2,3]).ungroup()', function* (done) {
+  it('Test backtrace for r.expr([1,2,3]).ungroup()', async () => {
     try {
-        r.nextVarId=1;
-        yield r.expr([1,2,3]).ungroup().run()
-        done(new Error("Should have thrown an error"))
+      r.nextVarId = 1
+      await r.expr([1, 2, 3]).ungroup().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type GROUPED_DATA but found DATUM:\n[\n\t1,\n\t2,\n\t3\n] in:\nr.expr([1, 2, 3]).ungroup()\n^^^^^^^^^^^^^^^^^          \n')
     }
-    catch(e) {
-        if (e.message === "Expected type GROUPED_DATA but found DATUM:\n[\n\t1,\n\t2,\n\t3\n] in:\nr.expr([1, 2, 3]).ungroup()\n^^^^^^^^^^^^^^^^^          \n") {
-            done()
-        }
-        else {
-            done(e);
-        }
-    }
-})
+  })
 
-
-/*
+  /*
 Frames:
 []
 
@@ -3491,24 +2595,17 @@ Expected type NUMBER but found STRING in:
 r.expr([1, 2, 3, "hello"]).sum()
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.expr([1,2,3,"hello"]).sum()', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr([1,2,3,"hello"]).sum().run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found STRING in:\nr.expr([1, 2, 3, \"hello\"]).sum()\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n") {
-      done()
+  it('Test backtrace for r.expr([1,2,3,"hello"]).sum()', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr([1, 2, 3, 'hello']).sum().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found STRING in:\nr.expr([1, 2, 3, "hello"]).sum()\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 []
 
@@ -3517,24 +2614,17 @@ Expected type NUMBER but found STRING in:
 r.expr([1, 2, 3, "hello"]).avg()
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.expr([1,2,3,"hello"]).avg()', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr([1,2,3,"hello"]).avg().run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found STRING in:\nr.expr([1, 2, 3, \"hello\"]).avg()\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n") {
-      done()
+  it('Test backtrace for r.expr([1,2,3,"hello"]).avg()', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr([1, 2, 3, 'hello']).avg().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found STRING in:\nr.expr([1, 2, 3, "hello"]).avg()\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 []
 
@@ -3543,23 +2633,17 @@ Cannot take the min of an empty stream.  (If you passed `min` a field name, it m
 r.expr([]).min()
 ^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.expr([]).min()', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr([]).min().run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Cannot take the min of an empty stream.  (If you passed `min` a field name, it may be that no elements of the stream had that field.) in:\nr.expr([]).min()\n^^^^^^^^^^^^^^^^\n") {
-      done()
+  it('Test backtrace for r.expr([]).min()', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr([]).min().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Cannot take the min of an empty stream.  (If you passed `min` a field name, it may be that no elements of the stream had that field.) in:\nr.expr([]).min()\n^^^^^^^^^^^^^^^^\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-/*
+  /*
 Frames:
 []
 
@@ -3568,23 +2652,17 @@ Cannot take the max of an empty stream.  (If you passed `max` a field name, it m
 r.expr([]).max()
 ^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.expr([]).max()', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr([]).max().run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Cannot take the max of an empty stream.  (If you passed `max` a field name, it may be that no elements of the stream had that field.) in:\nr.expr([]).max()\n^^^^^^^^^^^^^^^^\n") {
-      done()
+  it('Test backtrace for r.expr([]).max()', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr([]).max().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Cannot take the max of an empty stream.  (If you passed `max` a field name, it may be that no elements of the stream had that field.) in:\nr.expr([]).max()\n^^^^^^^^^^^^^^^^\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-/*
+  /*
 Frames:
 []
 
@@ -3593,24 +2671,17 @@ Cannot take the average of an empty stream.  (If you passed `avg` a field name, 
 r.expr([]).avg()
 ^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.expr([]).avg()', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr([]).avg().run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Cannot take the average of an empty stream.  (If you passed `avg` a field name, it may be that no elements of the stream had that field.) in:\nr.expr([]).avg()\n^^^^^^^^^^^^^^^^\n") {
-      done()
+  it('Test backtrace for r.expr([]).avg()', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr([]).avg().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Cannot take the average of an empty stream.  (If you passed `avg` a field name, it may be that no elements of the stream had that field.) in:\nr.expr([]).avg()\n^^^^^^^^^^^^^^^^\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 [ { type: 'POS', pos: 0 } ]
 
@@ -3619,23 +2690,17 @@ Expected type STRING but found NUMBER in:
 r.expr(1).upcase()
 ^^^^^^^^^
 */
-It('Test backtrace for r.expr(1).upcase()', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr(1).upcase().run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type STRING but found NUMBER in:\nr.expr(1).upcase()\n^^^^^^^^^         \n") {
-      done()
+  it('Test backtrace for r.expr(1).upcase()', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr(1).upcase().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type STRING but found NUMBER in:\nr.expr(1).upcase()\n^^^^^^^^^         \n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-/*
+  /*
 Frames:
 [ { type: 'POS', pos: 0 } ]
 
@@ -3644,24 +2709,17 @@ Expected type STRING but found NUMBER in:
 r.expr(1).downcase()
 ^^^^^^^^^
 */
-It('Test backtrace for r.expr(1).downcase()', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr(1).downcase().run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type STRING but found NUMBER in:\nr.expr(1).downcase()\n^^^^^^^^^           \n") {
-      done()
+  it('Test backtrace for r.expr(1).downcase()', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr(1).downcase().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type STRING but found NUMBER in:\nr.expr(1).downcase()\n^^^^^^^^^           \n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 [ 0, 1, 0 ]
 
@@ -3669,27 +2727,20 @@ Error:
 Expected type STRING but found NUMBER in:
 r.expr(1).do(function(var_1) {
   return r.object(1, 2)
-          ^    
+          ^
 })
 */
-It('Test backtrace for r.expr(1).do(function(v) { return r.object(1, 2) })', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr(1).do(function(v) { return r.object(1, 2) }).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type STRING but found NUMBER in:\nr.expr(1).do(function(var_1) {\n    return r.object(1, 2)\n                    ^    \n})\n") {
-      done()
+  it('Test backtrace for r.expr(1).do(function(v) { return r.object(1, 2) })', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr(1).do(function (v) { return r.object(1, 2) }).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type STRING but found NUMBER in:\nr.expr(1).do(function(var_1) {\n    return r.object(1, 2)\n                    ^    \n})\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 [ 0, 1 ]
 
@@ -3700,24 +2751,17 @@ r.expr(1).do(function(var_1) {
        ^^^^^^^^^^^^^
 })
 */
-It('Test backtrace for r.expr(1).do(function(v) { return r.object("a") })', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr(1).do(function(v) { return r.object("a") }).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "OBJECT expects an even number of arguments (but found 1) in:\nr.expr(1).do(function(var_1) {\n    return r.object(\"a\")\n           ^^^^^^^^^^^^^\n})\n") {
-      done()
+  it('Test backtrace for r.expr(1).do(function(v) { return r.object("a") })', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr(1).do(function (v) { return r.object('a') }).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'OBJECT expects an even number of arguments (but found 1) in:\nr.expr(1).do(function(var_1) {\n    return r.object("a")\n           ^^^^^^^^^^^^^\n})\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 []
 
@@ -3730,24 +2774,17 @@ r.random(1, 2, {
 }).sub("foo")
 ^^^^^^^^^^^^^
 */
-It('Test backtrace for r.random(1,2,{float: true}).sub("foo")', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.random(1,2,{float: true}).sub("foo").run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found STRING in:\nr.random(1, 2, {\n^^^^^^^^^^^^^^^^\n    float: true\n    ^^^^^^^^^^^\n}).sub(\"foo\")\n^^^^^^^^^^^^^\n") {
-      done()
+  it('Test backtrace for r.random(1,2,{float: true}).sub("foo")', async () => {
+    try {
+      r.nextVarId = 1
+      await r.random(1, 2, {float: true}).sub('foo').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found STRING in:\nr.random(1, 2, {\n^^^^^^^^^^^^^^^^\n    float: true\n    ^^^^^^^^^^^\n}).sub("foo")\n^^^^^^^^^^^^^\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 [ 0 ]
 
@@ -3756,48 +2793,34 @@ Expected type NUMBER but found STRING in:
 r.random("foo", "bar")
      ^^^^^
 */
-It('Test backtrace for r.random("foo", "bar")', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.random("foo", "bar").run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found STRING in:\nr.random(\"foo\", \"bar\")\n         ^^^^^        \n") {
-      done()
+  it('Test backtrace for r.random("foo", "bar")', async () => {
+    try {
+      r.nextVarId = 1
+      await r.random('foo', 'bar').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found STRING in:\nr.random("foo", "bar")\n         ^^^^^        \n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 undefined
 
 Error:
 `random` takes at most 3 arguments, 4 provided.
 */
-It('Test backtrace for r.random("foo", "bar", "buzz", "lol")', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.random("foo", "bar", "buzz", "lol").run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "`random` takes at most 3 arguments, 4 provided.") {
-      done()
+  it('Test backtrace for r.random("foo", "bar", "buzz", "lol")', async () => {
+    try {
+      r.nextVarId = 1
+      await r.random('foo', 'bar', 'buzz', 'lol').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === '`random` takes at most 3 arguments, 4 provided.')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 [ 0 ]
 
@@ -3809,24 +2832,17 @@ r.db("bd98452de5ea16f3572ed0d404a2e99c").table("c966dac895ef558f3dfdbfb8be003374
   .changes().add(2)
   ^^^^^^^^^^
 */
-It('Test backtrace for r.db(dbName).table(tableName).changes().add(2)', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.db(dbName).table(tableName).changes().add(2).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type DATUM but found SEQUENCE:\nVALUE SEQUENCE in:\nr.db(\""+dbName+"\").table(\""+tableName+"\")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    .changes().add(2)\n    ^^^^^^^^^^       \n") {
-      done()
+  it('Test backtrace for r.db(dbName).table(tableName).changes().add(2)', async () => {
+    try {
+      r.nextVarId = 1
+      await r.db(dbName).table(tableName).changes().add(2).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type DATUM but found SEQUENCE:\nVALUE SEQUENCE in:\nr.db("' + dbName + '").table("' + tableName + '")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    .changes().add(2)\n    ^^^^^^^^^^       \n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 [ 0 ]
 
@@ -3839,25 +2855,17 @@ null in:
 r.http("").add(2)
 ^^^^^^^^^^
 */
-It('Test backtrace for r.http("").add(2)', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.http("").add(2).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Error in HTTP GET of ``: URL using bad/illegal format or missing URL.\nheader:\nnull\nbody:\nnull in:\nr.http(\"\").add(2)\n^^^^^^^^^^       \n") {
-      done()
+  it('Test backtrace for r.http("").add(2)', async () => {
+    try {
+      r.nextVarId = 1
+      await r.http('').add(2).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Error in HTTP GET of ``: URL using bad/illegal format or missing URL.\nheader:\nnull\nbody:\nnull in:\nr.http("").add(2)\n^^^^^^^^^^       \n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-
-/*
+  /*
 Frames:
 []
 
@@ -3866,23 +2874,17 @@ Expected type STRING but found NUMBER in:
 r.args(["foo", "bar"]).add(2)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.args(["foo", "bar"]).add(2)', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.args(["foo", "bar"]).add(2).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type STRING but found NUMBER in:\nr.args([\"foo\", \"bar\"]).add(2)\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n") {
-      done()
+  it('Test backtrace for r.args(["foo", "bar"]).add(2)', async () => {
+    try {
+      r.nextVarId = 1
+      await r.args(['foo', 'bar']).add(2).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type STRING but found NUMBER in:\nr.args(["foo", "bar"]).add(2)\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-/*
+  /*
 Frames:
 [ { type: 'POS', pos: 0 }, { type: 'POS', pos: 1 } ]
 
@@ -3893,24 +2895,17 @@ r.expr(1).do(function(var_1) {
        ^^^^^^^^^^^^^^^^
 })
 */
-It('Test backtrace for r.do(1,function( b) { return b.add("foo") })', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.do(1,function( b) { return b.add("foo") }).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found STRING in:\nr.expr(1).do(function(var_1) {\n    return var_1.add(\"foo\")\n           ^^^^^^^^^^^^^^^^\n})\n") {
-      done()
+  it('Test backtrace for r.do(1,function( b) { return b.add("foo") })', async () => {
+    try {
+      r.nextVarId = 1
+      await r.do(1, function (b) { return b.add('foo') }).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found STRING in:\nr.expr(1).do(function(var_1) {\n    return var_1.add("foo")\n           ^^^^^^^^^^^^^^^^\n})\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 [ 0 ]
 
@@ -3926,24 +2921,17 @@ r.db("0c24bc6421463a0da33452e38a842f20").table("e1bf8f82ad33ed56f7e04e0c2ba97fcc
   }).add(1)
   ^^
 */
-It('Test backtrace for r.db(dbName).table(tableName).between("foo", "bar", {index: "id"}).add(1)', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.db(dbName).table(tableName).between("foo", "bar", {index: "id"}).add(1).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type DATUM but found TABLE_SLICE:\nSELECTION ON table("+tableName+") in:\nr.db(\""+dbName+"\").table(\""+tableName+"\")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    .between(\"foo\", \"bar\", {\n    ^^^^^^^^^^^^^^^^^^^^^^^^\n        index: \"id\"\n        ^^^^^^^^^^^\n    }).add(1)\n    ^^       \n") {
-      done()
+  it('Test backtrace for r.db(dbName).table(tableName).between("foo", "bar", {index: "id"}).add(1)', async () => {
+    try {
+      r.nextVarId = 1
+      await r.db(dbName).table(tableName).between('foo', 'bar', {index: 'id'}).add(1).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type DATUM but found TABLE_SLICE:\nSELECTION ON table(' + tableName + ') in:\nr.db("' + dbName + '").table("' + tableName + '")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    .between("foo", "bar", {\n    ^^^^^^^^^^^^^^^^^^^^^^^^\n        index: "id"\n        ^^^^^^^^^^^\n    }).add(1)\n    ^^       \n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 // Note: Buggy? It should be SELECTION, not TABLE_SLICE
 Frames:
 [ 0 ]
@@ -3960,25 +2948,17 @@ r.db("bdff9659bb18007d268d810929df5d90").table("d6063464b40e094f48ec13bbee46d457
   }).add(1)
   ^^
 */
-It('Test backtrace for r.db(dbName).table(tableName).orderBy({index: "id"}).add(1)', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.db(dbName).table(tableName).orderBy({index: "id"}).add(1).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type DATUM but found TABLE_SLICE:\nSELECTION ON table("+tableName+") in:\nr.db(\""+dbName+"\").table(\""+tableName+"\")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    .orderBy({\n    ^^^^^^^^^^\n        index: \"id\"\n        ^^^^^^^^^^^\n    }).add(1)\n    ^^       \n") {
-      done()
+  it('Test backtrace for r.db(dbName).table(tableName).orderBy({index: "id"}).add(1)', async () => {
+    try {
+      r.nextVarId = 1
+      await r.db(dbName).table(tableName).orderBy({index: 'id'}).add(1).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type DATUM but found TABLE_SLICE:\nSELECTION ON table(' + tableName + ') in:\nr.db("' + dbName + '").table("' + tableName + '")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    .orderBy({\n    ^^^^^^^^^^\n        index: "id"\n        ^^^^^^^^^^^\n    }).add(1)\n    ^^       \n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-
-/*
+  /*
 Frames:
 []
 
@@ -3987,25 +2967,17 @@ Expected type NUMBER but found PTYPE<BINARY> in:
 r.binary("foo").add(1)
 ^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.binary("foo").add(1)', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.binary("foo").add(1).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found PTYPE<BINARY> in:\nr.binary(\"foo\").add(1)\n^^^^^^^^^^^^^^^^^^^^^^\n") {
-      done()
+  it('Test backtrace for r.binary("foo").add(1)', async () => {
+    try {
+      r.nextVarId = 1
+      await r.binary('foo').add(1).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found PTYPE<BINARY> in:\nr.binary("foo").add(1)\n^^^^^^^^^^^^^^^^^^^^^^\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-
-/*
+  /*
 Frames:
 []
 
@@ -4014,25 +2986,17 @@ Expected type NUMBER but found PTYPE<BINARY> in:
 r.binary(<Buffer>).add(1)
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.binary(new Buffer([0,1,2,3,4])).add(1)', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.binary(new Buffer([0,1,2,3,4])).add(1).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found PTYPE<BINARY> in:\nr.binary(<Buffer>).add(1)\n^^^^^^^^^^^^^^^^^^^^^^^^^\n") {
-      done()
+  it('Test backtrace for r.binary(new Buffer([0,1,2,3,4])).add(1)', async () => {
+    try {
+      r.nextVarId = 1
+      await r.binary(Buffer.from([0, 1, 2, 3, 4])).add(1).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found PTYPE<BINARY> in:\nr.binary(<Buffer>).add(1)\n^^^^^^^^^^^^^^^^^^^^^^^^^\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-
-/*
+  /*
 Frames:
 [ 0, 1 ]
 
@@ -4043,25 +3007,17 @@ r.expr(1).do(function(var_1) {
        ^^^^^^^^^^^^^^^^^^^^^^^^
 })
 */
-It('Test backtrace for r.do(1,function( b) { return r.point(1, 2).add("foo") })', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.do(1,function( b) { return r.point(1, 2).add("foo") }).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found PTYPE<GEOMETRY> in:\nr.expr(1).do(function(var_1) {\n    return r.point(1, 2).add(\"foo\")\n           ^^^^^^^^^^^^^^^^^^^^^^^^\n})\n") {
-      done()
+  it('Test backtrace for r.do(1,function( b) { return r.point(1, 2).add("foo") })', async () => {
+    try {
+      r.nextVarId = 1
+      await r.do(1, function (b) { return r.point(1, 2).add('foo') }).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found PTYPE<GEOMETRY> in:\nr.expr(1).do(function(var_1) {\n    return r.point(1, 2).add("foo")\n           ^^^^^^^^^^^^^^^^^^^^^^^^\n})\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-
-/*
+  /*
 Frames:
 [ 0, 1, 0 ]
 
@@ -4069,29 +3025,20 @@ Error:
 Expected type ARRAY but found NUMBER in:
 r.expr(1).do(function(var_1) {
   return r.line(1, 2).add("foo")
-       ^^^^^^^^^^^^           
+       ^^^^^^^^^^^^
 })
 */
-It('Test backtrace for r.do(1,function( b) { return r.line(1, 2).add("foo") })', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.do(1,function( b) { return r.line(1, 2).add("foo") }).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type ARRAY but found NUMBER in:\nr.expr(1).do(function(var_1) {\n    return r.line(1, 2).add(\"foo\")\n           ^^^^^^^^^^^^           \n})\n") {
-      done()
+  it('Test backtrace for r.do(1,function( b) { return r.line(1, 2).add("foo") })', async () => {
+    try {
+      r.nextVarId = 1
+      await r.do(1, function (b) { return r.line(1, 2).add('foo') }).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type ARRAY but found NUMBER in:\nr.expr(1).do(function(var_1) {\n    return r.line(1, 2).add("foo")\n           ^^^^^^^^^^^^           \n})\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-
-
-/*
+  /*
 Frames:
 [ 0, 1, 0 ]
 
@@ -4099,28 +3046,20 @@ Error:
 Expected type ARRAY but found NUMBER in:
 r.expr(1).do(function(var_1) {
   return r.circle(1, 2).add("foo")
-       ^^^^^^^^^^^^^^           
+       ^^^^^^^^^^^^^^
 })
 */
-It('Test backtrace for r.do(1,function( b) { return r.circle(1, 2).add("foo") })', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.do(1,function( b) { return r.circle(1, 2).add("foo") }).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type ARRAY but found NUMBER in:\nr.expr(1).do(function(var_1) {\n    return r.circle(1, 2).add(\"foo\")\n           ^^^^^^^^^^^^^^           \n})\n") {
-      done()
+  it('Test backtrace for r.do(1,function( b) { return r.circle(1, 2).add("foo") })', async () => {
+    try {
+      r.nextVarId = 1
+      await r.do(1, function (b) { return r.circle(1, 2).add('foo') }).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type ARRAY but found NUMBER in:\nr.expr(1).do(function(var_1) {\n    return r.circle(1, 2).add("foo")\n           ^^^^^^^^^^^^^^           \n})\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-
-/*
+  /*
 Frames:
 [ 0, 1, 0 ]
 
@@ -4128,26 +3067,20 @@ Error:
 Expected type ARRAY but found NUMBER in:
 r.expr(1).do(function(var_1) {
   return r.polygon(1, 2, 3).add("foo")
-       ^^^^^^^^^^^^^^^^^^           
+       ^^^^^^^^^^^^^^^^^^
 })
 */
-It('Test backtrace for r.do(1,function( b) { return r.polygon(1, 2, 3).add("foo") })', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.do(1,function( b) { return r.polygon(1, 2, 3).add("foo") }).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type ARRAY but found NUMBER in:\nr.expr(1).do(function(var_1) {\n    return r.polygon(1, 2, 3).add(\"foo\")\n           ^^^^^^^^^^^^^^^^^^           \n})\n") {
-      done()
+  it('Test backtrace for r.do(1,function( b) { return r.polygon(1, 2, 3).add("foo") })', async () => {
+    try {
+      r.nextVarId = 1
+      await r.do(1, function (b) { return r.polygon(1, 2, 3).add('foo') }).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type ARRAY but found NUMBER in:\nr.expr(1).do(function(var_1) {\n    return r.polygon(1, 2, 3).add("foo")\n           ^^^^^^^^^^^^^^^^^^           \n})\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-/*
+  /*
 Frames:
 [ 0, 1, 0, 1 ]
 
@@ -4155,27 +3088,20 @@ Error:
 Not a GEOMETRY pseudotype: `3` in:
 r.expr(1).do(function(var_1) {
   return r.polygon([0, 0], [1, 1], [2, 3]).polygonSub(3).add("foo")
-                            ^            
+                            ^
 })
 */
-It('Test backtrace for r.do(1,function( b) { return r.polygon([0,0], [1,1], [2,3]).polygonSub(3).add("foo") })', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.do(1,function( b) { return r.polygon([0,0], [1,1], [2,3]).polygonSub(3).add("foo") }).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Not a GEOMETRY pseudotype: `3` in:\nr.expr(1).do(function(var_1) {\n    return r.polygon([0, 0], [1, 1], [2, 3]).polygonSub(3).add(\"foo\")\n                                                        ^            \n})\n") {
-      done()
+  it('Test backtrace for r.do(1,function( b) { return r.polygon([0,0], [1,1], [2,3]).polygonSub(3).add("foo") })', async () => {
+    try {
+      r.nextVarId = 1
+      await r.do(1, function (b) { return r.polygon([0, 0], [1, 1], [2, 3]).polygonSub(3).add('foo') }).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Not a GEOMETRY pseudotype: `3` in:\nr.expr(1).do(function(var_1) {\n    return r.polygon([0, 0], [1, 1], [2, 3]).polygonSub(3).add("foo")\n                                                        ^            \n})\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 [ 0, 1, 0, 0 ]
 
@@ -4183,27 +3109,20 @@ Error:
 Expected geometry of type `LineString` but found `Polygon` in:
 r.expr(1).do(function(var_1) {
   return r.polygon([0, 0], [1, 1], [2, 3]).fill().polygonSub(3).add("foo")
-       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                         
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 })
 */
-It('Test backtrace for r.do(1,function( b) { return r.polygon([0,0], [1,1], [2,3]).fill().polygonSub(3).add("foo") })', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.do(1,function( b) { return r.polygon([0,0], [1,1], [2,3]).fill().polygonSub(3).add("foo") }).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected geometry of type `LineString` but found `Polygon` in:\nr.expr(1).do(function(var_1) {\n    return r.polygon([0, 0], [1, 1], [2, 3]).fill().polygonSub(3).add(\"foo\")\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                         \n})\n") {
-      done()
+  it('Test backtrace for r.do(1,function( b) { return r.polygon([0,0], [1,1], [2,3]).fill().polygonSub(3).add("foo") })', async () => {
+    try {
+      r.nextVarId = 1
+      await r.do(1, function (b) { return r.polygon([0, 0], [1, 1], [2, 3]).fill().polygonSub(3).add('foo') }).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected geometry of type `LineString` but found `Polygon` in:\nr.expr(1).do(function(var_1) {\n    return r.polygon([0, 0], [1, 1], [2, 3]).fill().polygonSub(3).add("foo")\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                         \n})\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 [ 0, 1, 0, 1, 0 ]
 
@@ -4211,26 +3130,20 @@ Error:
 Not a GEOMETRY pseudotype: `"foo"` in:
 r.expr(1).do(function(var_1) {
   return r.polygon([0, 0], [1, 1], [2, 3]).distance(r.expr("foo").polygonSub(3)).add("foo")
-                            ^^^^^^^^^^^^^                          
+                            ^^^^^^^^^^^^^
 })
 */
-It('Test backtrace for r.do(1,function( b) { return r.polygon([0,0], [1,1], [2,3]).distance(r.expr("foo").polygonSub(3)).add("foo") })', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.do(1,function( b) { return r.polygon([0,0], [1,1], [2,3]).distance(r.expr("foo").polygonSub(3)).add("foo") }).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Not a GEOMETRY pseudotype: `\"foo\"` in:\nr.expr(1).do(function(var_1) {\n    return r.polygon([0, 0], [1, 1], [2, 3]).distance(r.expr(\"foo\").polygonSub(3)).add(\"foo\")\n                                                      ^^^^^^^^^^^^^                          \n})\n") {
-      done()
+  it('Test backtrace for r.do(1,function( b) { return r.polygon([0,0], [1,1], [2,3]).distance(r.expr("foo").polygonSub(3)).add("foo") })', async () => {
+    try {
+      r.nextVarId = 1
+      await r.do(1, function (b) { return r.polygon([0, 0], [1, 1], [2, 3]).distance(r.expr('foo').polygonSub(3)).add('foo') }).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Not a GEOMETRY pseudotype: `"foo"` in:\nr.expr(1).do(function(var_1) {\n    return r.polygon([0, 0], [1, 1], [2, 3]).distance(r.expr("foo").polygonSub(3)).add("foo")\n                                                      ^^^^^^^^^^^^^                          \n})\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-/*
+  /*
 Frames:
 [ 1 ]
 
@@ -4240,24 +3153,17 @@ r.db("43d3ef1b574ce3176bd8a6a573be3417").table("4428ef38de9fae93c0ca5f880a296b31
   .getIntersecting(r.circle(0, 1))
            ^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.db(dbName).table(tableName).getIntersecting(r.circle(0, 1), 3)', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.db(dbName).table(tableName).getIntersecting(r.circle(0, 1), 3).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type ARRAY but found NUMBER in:\nr.db(\""+dbName+"\").table(\""+tableName+"\")\n    .getIntersecting(r.circle(0, 1))\n                     ^^^^^^^^^^^^^^ \n") {
-      done()
+  it('Test backtrace for r.db(dbName).table(tableName).getIntersecting(r.circle(0, 1), 3)', async () => {
+    try {
+      r.nextVarId = 1
+      await r.db(dbName).table(tableName).getIntersecting(r.circle(0, 1), 3).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type ARRAY but found NUMBER in:\nr.db("' + dbName + '").table("' + tableName + '")\n    .getIntersecting(r.circle(0, 1))\n                     ^^^^^^^^^^^^^^ \n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 [ 1 ]
 
@@ -4267,24 +3173,17 @@ r.db("9fd8231574663499a11f93d205835f51").table("4463dfde70cea8f03266cd78cfec151d
   .getNearest(r.circle(0, 1))
         ^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.db(dbName).table(tableName).getNearest(r.circle(0, 1), 3)', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.db(dbName).table(tableName).getNearest(r.circle(0, 1), 3).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type ARRAY but found NUMBER in:\nr.db(\""+dbName+"\").table(\""+tableName+"\")\n    .getNearest(r.circle(0, 1))\n                ^^^^^^^^^^^^^^ \n") {
-      done()
+  it('Test backtrace for r.db(dbName).table(tableName).getNearest(r.circle(0, 1), 3)', async () => {
+    try {
+      r.nextVarId = 1
+      await r.db(dbName).table(tableName).getNearest(r.circle(0, 1), 3).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type ARRAY but found NUMBER in:\nr.db("' + dbName + '").table("' + tableName + '")\n    .getNearest(r.circle(0, 1))\n                ^^^^^^^^^^^^^^ \n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 [ 1 ]
 
@@ -4297,26 +3196,17 @@ Not a GEOMETRY pseudotype: `[
 r.polygon([0, 0], [0, 1], [1, 1]).includes([0, 1, 3])
                                            ^^^^^^^^^
 */
-It('Test backtrace for r.polygon([0, 0], [0, 1], [1, 1]).includes(r.expr([0, 1, 3]))', function* (done) {
+  it('Test backtrace for r.polygon([0, 0], [0, 1], [1, 1]).includes(r.expr([0, 1, 3]))', async () => {
     try {
-        r.nextVarId=1;
-        yield r.polygon([0, 0], [0, 1], [1, 1]).includes(r.expr([0, 1, 3])).run()
-        done(new Error("Should have thrown an error"))
+      r.nextVarId = 1
+      await r.polygon([0, 0], [0, 1], [1, 1]).includes(r.expr([0, 1, 3])).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Not a GEOMETRY pseudotype: `[\n\t0,\n\t1,\n\t3\n]` in:\nr.polygon([0, 0], [0, 1], [1, 1]).includes([0, 1, 3])\n                                           ^^^^^^^^^ \n')
     }
-    catch(e) {
-        if (e.message === "Not a GEOMETRY pseudotype: `[\n\t0,\n\t1,\n\t3\n]` in:\nr.polygon([0, 0], [0, 1], [1, 1]).includes([0, 1, 3])\n                                           ^^^^^^^^^ \n") {
-            done()
-        }
-        else {
-            done(e);
-        }
-    }
-})
+  })
 
-
-
-
-/*
+  /*
 Frames:
 [ 1 ]
 
@@ -4329,26 +3219,17 @@ Not a GEOMETRY pseudotype: `[
 r.polygon([0, 0], [0, 1], [1, 1]).intersects([0, 1, 3])
                                              ^^^^^^^^^
 */
-It('Test backtrace for r.polygon([0, 0], [0, 1], [1, 1]).intersects(r.expr([0, 1, 3]))', function* (done) {
+  it('Test backtrace for r.polygon([0, 0], [0, 1], [1, 1]).intersects(r.expr([0, 1, 3]))', async () => {
     try {
-        r.nextVarId=1;
-        yield r.polygon([0, 0], [0, 1], [1, 1]).intersects(r.expr([0, 1, 3])).run()
-        done(new Error("Should have thrown an error"))
+      r.nextVarId = 1
+      await r.polygon([0, 0], [0, 1], [1, 1]).intersects(r.expr([0, 1, 3])).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Not a GEOMETRY pseudotype: `[\n\t0,\n\t1,\n\t3\n]` in:\nr.polygon([0, 0], [0, 1], [1, 1]).intersects([0, 1, 3])\n                                             ^^^^^^^^^ \n')
     }
-    catch(e) {
-        if (e.message === "Not a GEOMETRY pseudotype: `[\n\t0,\n\t1,\n\t3\n]` in:\nr.polygon([0, 0], [0, 1], [1, 1]).intersects([0, 1, 3])\n                                             ^^^^^^^^^ \n") {
-            done()
-        }
-        else {
-            done(e);
-        }
-    }
-})
+  })
 
-
-
-
-/*
+  /*
 Frames:
 [ 1 ]
 
@@ -4361,25 +3242,17 @@ Not a GEOMETRY pseudotype: `[
 r.polygon([0, 0], [0, 1], [1, 1]).includes([0, 1, 3])
                                            ^^^^^^^^^
 */
-It('Test backtrace for r.polygon([0, 0], [0, 1], [1, 1]).includes(r.expr([0, 1, 3]))', function* (done) {
+  it('Test backtrace for r.polygon([0, 0], [0, 1], [1, 1]).includes(r.expr([0, 1, 3]))', async () => {
     try {
-        r.nextVarId=1;
-        yield r.polygon([0, 0], [0, 1], [1, 1]).includes(r.expr([0, 1, 3])).run()
-        done(new Error("Should have thrown an error"))
+      r.nextVarId = 1
+      await r.polygon([0, 0], [0, 1], [1, 1]).includes(r.expr([0, 1, 3])).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Not a GEOMETRY pseudotype: `[\n\t0,\n\t1,\n\t3\n]` in:\nr.polygon([0, 0], [0, 1], [1, 1]).includes([0, 1, 3])\n                                           ^^^^^^^^^ \n')
     }
-    catch(e) {
-        if (e.message === "Not a GEOMETRY pseudotype: `[\n\t0,\n\t1,\n\t3\n]` in:\nr.polygon([0, 0], [0, 1], [1, 1]).includes([0, 1, 3])\n                                           ^^^^^^^^^ \n") {
-            done()
-        }
-        else {
-            done(e);
-        }
-    }
-})
+  })
 
-
-
-/*
+  /*
 Frames:
 [ 0 ]
 
@@ -4391,23 +3264,17 @@ r.db("92cc9fb8833587dcb7e02a62bdf53145").table("bbbe68e9a13071ae0c579471d1e30f45
   .orderBy(r.desc("foo")).add(1)
   ^^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.db(dbName).table(tableName).orderBy(r.desc("foo")).add(1)', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.db(dbName).table(tableName).orderBy(r.desc("foo")).add(1).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type DATUM but found SELECTION:\nSELECTION ON table("+tableName+") in:\nr.db(\""+dbName+"\").table(\""+tableName+"\")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    .orderBy(r.desc(\"foo\")).add(1)\n    ^^^^^^^^^^^^^^^^^^^^^^^       \n") {
-      done()
+  it('Test backtrace for r.db(dbName).table(tableName).orderBy(r.desc("foo")).add(1)', async () => {
+    try {
+      r.nextVarId = 1
+      await r.db(dbName).table(tableName).orderBy(r.desc('foo')).add(1).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type DATUM but found SELECTION:\nSELECTION ON table(' + tableName + ') in:\nr.db("' + dbName + '").table("' + tableName + '")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    .orderBy(r.desc("foo")).add(1)\n    ^^^^^^^^^^^^^^^^^^^^^^^       \n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-/*
+  /*
 Frames:
 [ 0 ]
 
@@ -4419,24 +3286,17 @@ r.db("7af5e5289c00f3ea521a3859c666f03c").table("0488a0abab5f89bd2de2cbf816649aa3
   .orderBy(r.asc("foo")).add(1)
   ^^^^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.db(dbName).table(tableName).orderBy(r.asc("foo")).add(1)', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.db(dbName).table(tableName).orderBy(r.asc("foo")).add(1).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type DATUM but found SELECTION:\nSELECTION ON table("+tableName+") in:\nr.db(\""+dbName+"\").table(\""+tableName+"\")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    .orderBy(r.asc(\"foo\")).add(1)\n    ^^^^^^^^^^^^^^^^^^^^^^       \n") {
-      done()
+  it('Test backtrace for r.db(dbName).table(tableName).orderBy(r.asc("foo")).add(1)', async () => {
+    try {
+      r.nextVarId = 1
+      await r.db(dbName).table(tableName).orderBy(r.asc('foo')).add(1).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type DATUM but found SELECTION:\nSELECTION ON table(' + tableName + ') in:\nr.db("' + dbName + '").table("' + tableName + '")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    .orderBy(r.asc("foo")).add(1)\n    ^^^^^^^^^^^^^^^^^^^^^^       \n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 [ 0 ]
 
@@ -4445,24 +3305,17 @@ Expected type NUMBER but found STRING in:
 r.range("foo")
     ^^^^^
 */
-It('Test backtrace for r.range("foo")', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.range("foo").run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found STRING in:\nr.range(\"foo\")\n        ^^^^^ \n") {
-      done()
+  it('Test backtrace for r.range("foo")', async () => {
+    try {
+      r.nextVarId = 1
+      await r.range('foo').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found STRING in:\nr.range("foo")\n        ^^^^^ \n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 [ 1 ]
 
@@ -4470,29 +3323,21 @@ Error:
 Expected type DATUM but found SEQUENCE:
 VALUE SEQUENCE in:
 r.range(1, 10).do(function(var_1) {
-^^^^^^^^^^^^^^                     
+^^^^^^^^^^^^^^
   return var_1.add(4)
 })
 */
-It('Test backtrace for r.range(1,10).do(function(x) { return x.add(4) })', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.range(1,10).do(function(x) { return x.add(4) }).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type DATUM but found SEQUENCE:\nVALUE SEQUENCE in:\nr.range(1, 10).do(function(var_1) {\n^^^^^^^^^^^^^^                     \n    return var_1.add(4)\n})\n") {
-      done()
+  it('Test backtrace for r.range(1,10).do(function(x) { return x.add(4) })', async () => {
+    try {
+      r.nextVarId = 1
+      await r.range(1, 10).do(function (x) { return x.add(4) }).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type DATUM but found SEQUENCE:\nVALUE SEQUENCE in:\nr.range(1, 10).do(function(var_1) {\n^^^^^^^^^^^^^^                     \n    return var_1.add(4)\n})\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-
-/*
+  /*
 Frames:
 [ 1, 0 ]
 
@@ -4500,28 +3345,21 @@ Error:
 Expected type DATUM but found SEQUENCE:
 VALUE SEQUENCE in:
 r.range(1, 10).toJSON().do(function(var_1) {
-^^^^^^^^^^^^^^                              
+^^^^^^^^^^^^^^
   return var_1.add(4)
 })
 */
-It('Test backtrace for r.range(1,10).toJSON().do(function(x) { return x.add(4) })', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.range(1,10).toJSON().do(function(x) { return x.add(4) }).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type DATUM but found SEQUENCE:\nVALUE SEQUENCE in:\nr.range(1, 10).toJSON().do(function(var_1) {\n^^^^^^^^^^^^^^                              \n    return var_1.add(4)\n})\n") {
-      done()
+  it('Test backtrace for r.range(1,10).toJSON().do(function(x) { return x.add(4) })', async () => {
+    try {
+      r.nextVarId = 1
+      await r.range(1, 10).toJSON().do(function (x) { return x.add(4) }).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type DATUM but found SEQUENCE:\nVALUE SEQUENCE in:\nr.range(1, 10).toJSON().do(function(var_1) {\n^^^^^^^^^^^^^^                              \n    return var_1.add(4)\n})\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 [ 0, 1 ]
 
@@ -4533,25 +3371,17 @@ r.db("0bf896ead3b69f218ceff0de67476afe").table("a382350695a78865de1505c44c481223
          ^^^^^^^^^^^^
   })
 */
-It('Test backtrace for r.db(dbName).table(tableName).config().do(function(x) { return x.add(4) })', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.db(dbName).table(tableName).config().do(function(x) { return x.add(4) }).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found OBJECT in:\nr.db(\""+dbName+"\").table(\""+tableName+"\")\n    .config().do(function(var_1) {\n        return var_1.add(4)\n               ^^^^^^^^^^^^\n    })\n") {
-      done()
+  it('Test backtrace for r.db(dbName).table(tableName).config().do(function(x) { return x.add(4) })', async () => {
+    try {
+      r.nextVarId = 1
+      await r.db(dbName).table(tableName).config().do(function (x) { return x.add(4) }).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found OBJECT in:\nr.db("' + dbName + '").table("' + tableName + '")\n    .config().do(function(var_1) {\n        return var_1.add(4)\n               ^^^^^^^^^^^^\n    })\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-
-/*
+  /*
 Frames:
 [ 0, 1 ]
 
@@ -4563,25 +3393,17 @@ r.db("c38ab783cfde80ea7ecf4db42eb942a0").table("7d81632cf83797a5b65a5f2b2adb2c8a
          ^^^^^^^^^^^^
   })
 */
-It('Test backtrace for r.db(dbName).table(tableName).status().do(function(x) { return x.add(4) })', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.db(dbName).table(tableName).status().do(function(x) { return x.add(4) }).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found OBJECT in:\nr.db(\""+dbName+"\").table(\""+tableName+"\")\n    .status().do(function(var_1) {\n        return var_1.add(4)\n               ^^^^^^^^^^^^\n    })\n") {
-      done()
+  it('Test backtrace for r.db(dbName).table(tableName).status().do(function(x) { return x.add(4) })', async () => {
+    try {
+      r.nextVarId = 1
+      await r.db(dbName).table(tableName).status().do(function (x) { return x.add(4) }).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found OBJECT in:\nr.db("' + dbName + '").table("' + tableName + '")\n    .status().do(function(var_1) {\n        return var_1.add(4)\n               ^^^^^^^^^^^^\n    })\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-
-/*
+  /*
 Frames:
 [ 0, 1 ]
 
@@ -4593,24 +3415,17 @@ r.db("6c42577f50299d1e88bf57acd87ba5ea").table("031bd87d16ecf4b8d295dd6960fd4800
          ^^^^^^^^^^^^
   })
 */
-It('Test backtrace for r.db(dbName).table(tableName).wait().do(function(x) { return x.add(4) })', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.db(dbName).table(tableName).wait().do(function(x) { return x.add(4) }).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found OBJECT in:\nr.db(\""+dbName+"\").table(\""+tableName+"\")\n    .wait().do(function(var_1) {\n        return var_1.add(4)\n               ^^^^^^^^^^^^\n    })\n") {
-      done()
+  it('Test backtrace for r.db(dbName).table(tableName).wait().do(function(x) { return x.add(4) })', async () => {
+    try {
+      r.nextVarId = 1
+      await r.db(dbName).table(tableName).wait().do(function (x) { return x.add(4) }).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found OBJECT in:\nr.db("' + dbName + '").table("' + tableName + '")\n    .wait().do(function(var_1) {\n        return var_1.add(4)\n               ^^^^^^^^^^^^\n    })\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 [ 1 ]
 
@@ -4623,57 +3438,43 @@ r.db("997da59afc784220d0d5093ef2e698cf").table("dd9f7cdc9eb6c2dc21ef3d63d8fea221
     shards: 1
     ^^^^^^^^^
   }).do(function(var_1) {
-  ^^                     
+  ^^
     return var_1.add(4)
   })
 */
-It('Test backtrace for r.db(dbName).table(tableName).reconfigure({ shards: 1 }).do(function(x) { return x.add(4) })', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.db(dbName).table(tableName).reconfigure({ shards: 1 }).do(function(x) { return x.add(4) }).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Missing required argument `replicas` in:\nr.db(\""+dbName+"\").table(\""+tableName+"\")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    .reconfigure({\n    ^^^^^^^^^^^^^^\n        shards: 1\n        ^^^^^^^^^\n    }).do(function(var_1) {\n    ^^                     \n        return var_1.add(4)\n    })\n") {
-      done()
+  it('Test backtrace for r.db(dbName).table(tableName).reconfigure({ shards: 1 }).do(function(x) { return x.add(4) })', async () => {
+    try {
+      r.nextVarId = 1
+      await r.db(dbName).table(tableName).reconfigure({ shards: 1 }).do(function (x) { return x.add(4) }).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Missing required argument `replicas` in:\nr.db("' + dbName + '").table("' + tableName + '")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    .reconfigure({\n    ^^^^^^^^^^^^^^\n        shards: 1\n        ^^^^^^^^^\n    }).do(function(var_1) {\n    ^^                     \n        return var_1.add(4)\n    })\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 [ 0 ]
 
 Error:
 Expected type NUMBER but found STRING in:
 r.expr(1).add("foo").add(r.db("987367b7c251d403119132131f6ba8ae").table("90ff34f973a3f837d1c892027790a95c")
-^^^^^^^^^^^^^^^^^^^^                                                                                       
+^^^^^^^^^^^^^^^^^^^^
   .rebalance().do(function(var_1) {
     return var_1.add(4)
   }))
 */
-It('Test backtrace for r.expr(1).add("foo").add(r.db(dbName).table(tableName).rebalance().do(function(x) { return x.add(4) }))', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr(1).add("foo").add(r.db(dbName).table(tableName).rebalance().do(function(x) { return x.add(4) })).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found STRING in:\nr.expr(1).add(\"foo\").add(r.db(\""+dbName+"\").table(\""+tableName+"\")\n^^^^^^^^^^^^^^^^^^^^                                                                                       \n    .rebalance().do(function(var_1) {\n        return var_1.add(4)\n    }))\n") {
-      done()
+  it('Test backtrace for r.expr(1).add("foo").add(r.db(dbName).table(tableName).rebalance().do(function(x) { return x.add(4) }))', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr(1).add('foo').add(r.db(dbName).table(tableName).rebalance().do(function (x) { return x.add(4) })).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found STRING in:\nr.expr(1).add("foo").add(r.db("' + dbName + '").table("' + tableName + '")\n^^^^^^^^^^^^^^^^^^^^                                                                                       \n    .rebalance().do(function(var_1) {\n        return var_1.add(4)\n    }))\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 []
 
@@ -4686,24 +3487,17 @@ r.map(r.expr([1, 2, 3]), [1, 2, 3], function(var_1) {
 })
 ^^
 */
-It('Test backtrace for r.map([1,2,3], [1,2,3], function(var_1) { return var_1("bah").add(3) })', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.map([1,2,3], [1,2,3], function(var_1) { return var_1("bah").add(3) }).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "The function passed to `map` expects 1 argument, but 2 sequences were found in:\nr.map(r.expr([1, 2, 3]), [1, 2, 3], function(var_1) {\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    return var_1(\"bah\").add(3)\n    ^^^^^^^^^^^^^^^^^^^^^^^^^^\n})\n^^\n") {
-      done()
+  it('Test backtrace for r.map([1,2,3], [1,2,3], function(var_1) { return var_1("bah").add(3) })', async () => {
+    try {
+      r.nextVarId = 1
+      await r.map([1, 2, 3], [1, 2, 3], function (var_1) { return var_1('bah').add(3) }).run() // eslint-disable-line camelcase
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'The function passed to `map` expects 1 argument, but 2 sequences were found in:\nr.map(r.expr([1, 2, 3]), [1, 2, 3], function(var_1) {\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    return var_1("bah").add(3)\n    ^^^^^^^^^^^^^^^^^^^^^^^^^^\n})\n^^\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 [ 2, 1, 0, 0 ]
 
@@ -4711,28 +3505,20 @@ Error:
 Cannot perform bracket on a non-object non-sequence `1` in:
 r.map(r.expr([1, 2, 3]), [1, 2, 3], function(var_1, var_2) {
   return var_1("bah").add(3)
-       ^^^^^              
+       ^^^^^
 })
 */
-It('Test backtrace for r.map([1,2,3], [1,2,3], function(var_1, var_2) { return var_1("bah").add(3) })', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.map([1,2,3], [1,2,3], function(var_1, var_2) { return var_1("bah").add(3) }).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Cannot perform bracket on a non-object non-sequence `1` in:\nr.map(r.expr([1, 2, 3]), [1, 2, 3], function(var_1, var_2) {\n    return var_1(\"bah\").add(3)\n           ^^^^^              \n})\n") {
-      done()
+  it('Test backtrace for r.map([1,2,3], [1,2,3], function(var_1, var_2) { return var_1("bah").add(3) })', async () => {
+    try {
+      r.nextVarId = 1
+      await r.map([1, 2, 3], [1, 2, 3], function (var_1, var_2) { return var_1('bah').add(3) }).run() // eslint-disable-line camelcase
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Cannot perform bracket on a non-object non-sequence `1` in:\nr.map(r.expr([1, 2, 3]), [1, 2, 3], function(var_1, var_2) {\n    return var_1("bah").add(3)\n           ^^^^^              \n})\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-
-/*
+  /*
 Frames:
 [ 0, 0 ]
 
@@ -4741,24 +3527,17 @@ Expected type STRING but found ARRAY in:
 r.expr([1, 2, 3]).split(",", 3).add(3)
 ^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.expr([1,2,3]).split(",", 3).add(3)', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr([1,2,3]).split(",", 3).add(3).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type STRING but found ARRAY in:\nr.expr([1, 2, 3]).split(\",\", 3).add(3)\n^^^^^^^^^^^^^^^^^                     \n") {
-      done()
+  it('Test backtrace for r.expr([1,2,3]).split(",", 3).add(3)', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr([1, 2, 3]).split(',', 3).add(3).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type STRING but found ARRAY in:\nr.expr([1, 2, 3]).split(",", 3).add(3)\n^^^^^^^^^^^^^^^^^                     \n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 []
 
@@ -4775,23 +3554,17 @@ r.expr({}).merge({
 }).add(2)
 ^^^^^^^^^
 */
-It('Test backtrace for r.expr({}).merge({a: r.literal({foo: "bar"})}).add(2)', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr({}).merge({a: r.literal({foo: "bar"})}).add(2).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found OBJECT in:\nr.expr({}).merge({\n^^^^^^^^^^^^^^^^^^\n    a: r.literal({\n    ^^^^^^^^^^^^^^\n        foo: \"bar\"\n        ^^^^^^^^^^\n    })\n    ^^\n}).add(2)\n^^^^^^^^^\n") {
-      done()
+  it('Test backtrace for r.expr({}).merge({a: r.literal({foo: "bar"})}).add(2)', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr({}).merge({a: r.literal({foo: 'bar'})}).add(2).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found OBJECT in:\nr.expr({}).merge({\n^^^^^^^^^^^^^^^^^^\n    a: r.literal({\n    ^^^^^^^^^^^^^^\n        foo: "bar"\n        ^^^^^^^^^^\n    })\n    ^^\n}).add(2)\n^^^^^^^^^\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-/*
+  /*
 Frames:
 []
 
@@ -4800,24 +3573,17 @@ Expected type NUMBER but found ARRAY in:
 r.monday.add([1])
 ^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.monday.add([1])', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.monday.add([1]).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found ARRAY in:\nr.monday.add([1])\n^^^^^^^^^^^^^^^^^\n") {
-      done()
+  it('Test backtrace for r.monday.add([1])', async () => {
+    try {
+      r.nextVarId = 1
+      await r.monday.add([1]).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found ARRAY in:\nr.monday.add([1])\n^^^^^^^^^^^^^^^^^\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 []
 
@@ -4826,24 +3592,17 @@ Expected type NUMBER but found ARRAY in:
 r.november.add([1])
 ^^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.november.add([1])', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.november.add([1]).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found ARRAY in:\nr.november.add([1])\n^^^^^^^^^^^^^^^^^^^\n") {
-      done()
+  it('Test backtrace for r.november.add([1])', async () => {
+    try {
+      r.nextVarId = 1
+      await r.november.add([1]).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found ARRAY in:\nr.november.add([1])\n^^^^^^^^^^^^^^^^^^^\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 []
 
@@ -4856,24 +3615,17 @@ r.expr({
 }).add([1])
 ^^^^^^^^^^^
 */
-It('Test backtrace for r.expr({a: r.wednesday}).add([1])', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr({a: r.wednesday}).add([1]).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found OBJECT in:\nr.expr({\n^^^^^^^^\n    a: r.wednesday\n    ^^^^^^^^^^^^^^\n}).add([1])\n^^^^^^^^^^^\n") {
-      done()
+  it('Test backtrace for r.expr({a: r.wednesday}).add([1])', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr({a: r.wednesday}).add([1]).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found OBJECT in:\nr.expr({\n^^^^^^^^\n    a: r.wednesday\n    ^^^^^^^^^^^^^^\n}).add([1])\n^^^^^^^^^^^\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 [ 0 ]
 
@@ -4889,51 +3641,38 @@ r.db("d2292d5a5fb3f4780426609087b88fa4").table("0efb72285d551009ac6f2387173b3443
   }).add(1)
   ^^
 */
-It('Test backtrace for r.db(dbName).table(tableName).between(r.minval, r.maxval, {index: "foo"}).add(1)', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.db(dbName).table(tableName).between(r.minval, r.maxval, {index: "foo"}).add(1).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type DATUM but found TABLE_SLICE:\nSELECTION ON table("+tableName+") in:\nr.db(\""+dbName+"\").table(\""+tableName+"\")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    .between(r.minval, r.maxval, {\n    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n        index: \"foo\"\n        ^^^^^^^^^^^^\n    }).add(1)\n    ^^       \n") {
-      done()
+  it('Test backtrace for r.db(dbName).table(tableName).between(r.minval, r.maxval, {index: "foo"}).add(1)', async () => {
+    try {
+      r.nextVarId = 1
+      await r.db(dbName).table(tableName).between(r.minval, r.maxval, {index: 'foo'}).add(1).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type DATUM but found TABLE_SLICE:\nSELECTION ON table(' + tableName + ') in:\nr.db("' + dbName + '").table("' + tableName + '")\n^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    .between(r.minval, r.maxval, {\n    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n        index: "foo"\n        ^^^^^^^^^^^^\n    }).add(1)\n    ^^       \n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-/*
+  /*
 Frames:
 [ 0 ]
 
 Error:
 Expected type NUMBER but found STRING in:
 r.expr(1).add("bar").add(r.ISO8601("dadsa", {
-^^^^^^^^^^^^^^^^^^^^                         
+^^^^^^^^^^^^^^^^^^^^
   defaultTimezone: "dsada"
 }))
 */
-It('Test backtrace for r.expr(1).add("bar").add(r.ISO8601("dadsa",{defaultTimezone: "dsada"}))', function* (done) {
-  try {
-    r.nextVarId=1;
-    yield r.expr(1).add("bar").add(r.ISO8601("dadsa",{defaultTimezone: "dsada"})).run()
-    done(new Error("Should have thrown an error"))
-  }
-  catch(e) {
-    if (e.message === "Expected type NUMBER but found STRING in:\nr.expr(1).add(\"bar\").add(r.ISO8601(\"dadsa\", {\n^^^^^^^^^^^^^^^^^^^^                         \n    defaultTimezone: \"dsada\"\n}))\n") {
-      done()
+  it('Test backtrace for r.expr(1).add("bar").add(r.ISO8601("dadsa",{defaultTimezone: "dsada"}))', async () => {
+    try {
+      r.nextVarId = 1
+      await r.expr(1).add('bar').add(r.ISO8601('dadsa', {defaultTimezone: 'dsada'})).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found STRING in:\nr.expr(1).add("bar").add(r.ISO8601("dadsa", {\n^^^^^^^^^^^^^^^^^^^^                         \n    defaultTimezone: "dsada"\n}))\n')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-/*
+  /*
 Frames:
 [ 1, 'bar' ]
 
@@ -4947,26 +3686,17 @@ r.expr({
          ^^^^^^^^^^^^^^^^^^^^
 })
 */
-It('Test backtrace for r.expr({foo: "bar"}).merge({foo: r.literal(), bar: r.expr("lol").add(1)})', function* (done) {
+  it('Test backtrace for r.expr({foo: "bar"}).merge({foo: r.literal(), bar: r.expr("lol").add(1)})', async () => {
     try {
-        r.nextVarId=1;
-        yield r.expr({foo: "bar"}).merge({foo: r.literal(), bar: r.expr("lol").add(1)}).run()
-        done(new Error("Should have thrown an error"))
+      r.nextVarId = 1
+      await r.expr({foo: 'bar'}).merge({foo: r.literal(), bar: r.expr('lol').add(1)}).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type STRING but found NUMBER in:\nr.expr({\n    foo: "bar"\n}).merge({\n    foo: r.literal(),\n    bar: r.expr("lol").add(1)\n         ^^^^^^^^^^^^^^^^^^^^\n})\n')
     }
-    catch(e) {
-        if (e.message === "Expected type STRING but found NUMBER in:\nr.expr({\n    foo: \"bar\"\n}).merge({\n    foo: r.literal(),\n    bar: r.expr(\"lol\").add(1)\n         ^^^^^^^^^^^^^^^^^^^^\n})\n") {
-            done()
-        }
-        else {
-            done(e);
-        }
-    }
-})
+  })
 
-
-
-
-/*
+  /*
 Frames:
 [ 0 ]
 
@@ -4975,50 +3705,34 @@ Expected type NUMBER but found STRING in:
 r.expr("hello").floor()
 ^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.floor("hello")', function* (done) {
+  it('Test backtrace for r.floor("hello")', async () => {
     try {
-        r.nextVarId=1;
-        yield r.floor("hello").run()
-        done(new Error("Should have thrown an error"))
+      r.nextVarId = 1
+      await r.floor('hello').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found STRING in:\nr.expr("hello").floor()\n^^^^^^^^^^^^^^^        \n')
     }
-    catch(e) {
-        if (e.message === "Expected type NUMBER but found STRING in:\nr.expr(\"hello\").floor()\n^^^^^^^^^^^^^^^        \n") {
-            done()
-        }
-        else {
-            done(e);
-        }
-    }
-})
+  })
 
-
-
-/*
+  /*
 Frames:
 undefined
 
 Error:
 `r.floor` takes 1 argument, 0 provided.
 */
-It('Test backtrace for r.floor()', function* (done) {
+  it('Test backtrace for r.floor()', async () => {
     try {
-        r.nextVarId=1;
-        yield r.floor().run()
-        done(new Error("Should have thrown an error"))
+      r.nextVarId = 1
+      await r.floor().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === '`r.floor` takes 1 argument, 0 provided.')
     }
-    catch(e) {
-        if (e.message === "`r.floor` takes 1 argument, 0 provided.") {
-            done()
-        }
-        else {
-            done(e);
-        }
-    }
-})
+  })
 
-
-
-/*
+  /*
 Frames:
 [ 0 ]
 
@@ -5027,27 +3741,17 @@ Expected type NUMBER but found STRING in:
 r.expr("hello").round()
 ^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.round("hello")', function* (done) {
+  it('Test backtrace for r.round("hello")', async () => {
     try {
-        r.nextVarId=1;
-        yield r.round("hello").run()
-        done(new Error("Should have thrown an error"))
+      r.nextVarId = 1
+      await r.round('hello').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found STRING in:\nr.expr("hello").round()\n^^^^^^^^^^^^^^^        \n')
     }
-    catch(e) {
-        if (e.message === "Expected type NUMBER but found STRING in:\nr.expr(\"hello\").round()\n^^^^^^^^^^^^^^^        \n") {
-            done()
-        }
-        else {
-            done(e);
-        }
-    }
-})
+  })
 
-
-
-
-
-/*
+  /*
 Frames:
 [ 0 ]
 
@@ -5056,24 +3760,17 @@ Expected type NUMBER but found STRING in:
 r.expr("hello").ceil()
 ^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.ceil("hello")', function* (done) {
+  it('Test backtrace for r.ceil("hello")', async () => {
     try {
-        r.nextVarId=1;
-        yield r.ceil("hello").run()
-        done(new Error("Should have thrown an error"))
+      r.nextVarId = 1
+      await r.ceil('hello').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type NUMBER but found STRING in:\nr.expr("hello").ceil()\n^^^^^^^^^^^^^^^       \n')
     }
-    catch(e) {
-        if (e.message === "Expected type NUMBER but found STRING in:\nr.expr(\"hello\").ceil()\n^^^^^^^^^^^^^^^       \n") {
-            done()
-        }
-        else {
-            done(e);
-        }
-    }
-})
+  })
 
-
-/*
+  /*
 Frames:
 []
 
@@ -5090,19 +3787,13 @@ r.expr({
 }).values().add(2)
 ^^^^^^^^^^^^^^^^^^
 */
-It('Test backtrace for r.expr({a:1, b:2, c: 3}).values().add(2)', function* (done) {
+  it('Test backtrace for r.expr({a:1, b:2, c: 3}).values().add(2)', async () => {
     try {
-        r.nextVarId=1;
-        yield r.expr({a:1, b:2, c: 3}).values().add(2).run()
-        done(new Error("Should have thrown an error"))
+      r.nextVarId = 1
+      await r.expr({a: 1, b: 2, c: 3}).values().add(2).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Expected type ARRAY but found NUMBER in:\nr.expr({\n^^^^^^^^\n    a: 1,\n    ^^^^^\n    b: 2,\n    ^^^^^\n    c: 3\n    ^^^^\n}).values().add(2)\n^^^^^^^^^^^^^^^^^^\n')
     }
-    catch(e) {
-        if (e.message === "Expected type ARRAY but found NUMBER in:\nr.expr({\n^^^^^^^^\n    a: 1,\n    ^^^^^\n    b: 2,\n    ^^^^^\n    c: 3\n    ^^^^\n}).values().add(2)\n^^^^^^^^^^^^^^^^^^\n") {
-            done()
-        }
-        else {
-            done(e);
-        }
-    }
+  })
 })
-

--- a/test/client-backtrace.js
+++ b/test/client-backtrace.js
@@ -1,38 +1,36 @@
-var config = require(__dirname+'/config.js');
-var r = require(__dirname+'/../lib')(config);
-var util = require(__dirname+'/util/common.js');
-var assert = require('assert');
+const path = require('path')
+const config = require(path.join(__dirname, '/config.js'))
+const rethinkdbdash = require(path.join(__dirname, '/../lib'))
+const util = require(path.join(__dirname, '/util/common.js'))
+const assert = require('assert')
+const uuid = util.uuid
+const {before, after, describe, it} = require('mocha')
 
-var uuid = util.uuid;
-var It = util.It;
+describe('client backtraces', () => {
+  let r, dbName, tableName, result
 
-var uuid = util.uuid;
-var dbName, tableName, pks, result;
+  before(async () => {
+    r = await rethinkdbdash(config)
 
-It('Init for backtraces', function* (done) {
-  try {
-    dbName = uuid();
-    tableName = uuid();
+    dbName = uuid()
+    tableName = uuid()
 
-    result = yield r.dbCreate(dbName).run();
-    assert.equal(result.dbs_created, 1);
+    result = await r.dbCreate(dbName).run()
+    assert.equal(result.dbs_created, 1)
 
-    result = yield r.db(dbName).tableCreate(tableName).run();
-    assert.equal(result.tables_created, 1);
+    result = await r.db(dbName).tableCreate(tableName).run()
+    assert.equal(result.tables_created, 1)
 
-    result = yield r.db(dbName).table(tableName).insert(eval('['+new Array(100).join('{}, ')+'{}]')).run();
-    assert.equal(result.inserted, 100);
+    result = await r.db(dbName).table(tableName).insert(Array(100).fill({})).run()
+    assert.equal(result.inserted, 100)
+    assert.equal(result.generated_keys.length, 100)
+  })
 
-    done();
-  }
-  catch(e) {
-    console.log(e.message); done(e);
-  }
-})
+  after(async () => {
+    await r.getPoolMaster().drain()
+  })
 
-
-
-/*
+  /*
 Frames:
 [ 1, 1, 1 ]
 
@@ -41,28 +39,20 @@ Cannot convert `NaN` to JSON in:
 r.db("af552fefa372998f05c1dff2fa4c293c").table("89865145147d850616fcbe93011b1d5e")
     .map(function(var_1) {
         return var_1("key").add(NaN)
-                                ^^^ 
+                                ^^^
     })
 */
-It('Test backtrace for r.db(dbName).table(tableName).map(function(doc) { return doc("key").add(NaN)})', function* (done) {
+  it('Test backtrace for r.db(dbName).table(tableName).map(function(doc) { return doc("key").add(NaN)})', async () => {
     try {
-        r.nextVarId=1;
-        yield r.db(dbName).table(tableName).map(function(doc) { return doc("key").add(NaN)}).run()
-        done(new Error("Should have thrown an error"))
+      r.nextVarId = 1
+      await r.db(dbName).table(tableName).map(function (doc) { return doc('key').add(NaN) }).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Cannot convert `NaN` to JSON in:\nr.db("' + dbName + '").table("' + tableName + '")\n    .map(function(var_1) {\n        return var_1("key").add(NaN)\n                                ^^^ \n    })\n')
     }
-    catch(e) {
-        if (e.message === "Cannot convert `NaN` to JSON in:\nr.db(\""+dbName+"\").table(\""+tableName+"\")\n    .map(function(var_1) {\n        return var_1(\"key\").add(NaN)\n                                ^^^ \n    })\n") {
-            done()
-        }
-        else {
-            done(e);
-        }
-    }
-})
+  })
 
-
-
-/*
+  /*
 Frames:
 [ 1, 1, 1 ]
 
@@ -71,27 +61,20 @@ Cannot convert `Infinity` to JSON in:
 r.db("dd054a14db348f5bcb99bbf14615955c").table("2f66694bbfa2a7bd2f0b0ef0460e7178")
     .map(function(var_1) {
         return var_1("key").add(Infinity)
-                                ^^^^^^^^ 
+                                ^^^^^^^^
     })
 */
-It('Test backtrace for r.db(dbName).table(tableName).map(function(doc) { return doc("key").add(Infinity)})', function* (done) {
+  it('Test backtrace for r.db(dbName).table(tableName).map(function(doc) { return doc("key").add(Infinity)})', async () => {
     try {
-        r.nextVarId=1;
-        yield r.db(dbName).table(tableName).map(function(doc) { return doc("key").add(Infinity)}).run()
-        done(new Error("Should have thrown an error"))
+      r.nextVarId = 1
+      await r.db(dbName).table(tableName).map(function (doc) { return doc('key').add(Infinity) }).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Cannot convert `Infinity` to JSON in:\nr.db("' + dbName + '").table("' + tableName + '")\n    .map(function(var_1) {\n        return var_1("key").add(Infinity)\n                                ^^^^^^^^ \n    })\n')
     }
-    catch(e) {
-        if (e.message === "Cannot convert `Infinity` to JSON in:\nr.db(\""+dbName+"\").table(\""+tableName+"\")\n    .map(function(var_1) {\n        return var_1(\"key\").add(Infinity)\n                                ^^^^^^^^ \n    })\n") {
-            done()
-        }
-        else {
-            done(e);
-        }
-    }
-})
+  })
 
-
-/*
+  /*
 Frames:
 [ 1, 1, 1 ]
 
@@ -100,28 +83,20 @@ Cannot convert `undefined` with r.expr() in:
 r.db("28f1684f7a5927ce592bc1641bc0f9ac").table("55e82a8517599394fd96d8fb1acfcdef")
     .map(function(var_1) {
         return var_1("key").add(undefined)
-                                ^^^^^^^^^ 
+                                ^^^^^^^^^
     })
 */
-It('Test backtrace for r.db(dbName).table(tableName).map(function(doc) { return doc("key").add(undefined)})', function* (done) {
+  it('Test backtrace for r.db(dbName).table(tableName).map(function(doc) { return doc("key").add(undefined)})', async () => {
     try {
-        r.nextVarId=1;
-        yield r.db(dbName).table(tableName).map(function(doc) { return doc("key").add(undefined)}).run()
-        done(new Error("Should have thrown an error"))
+      r.nextVarId = 1
+      await r.db(dbName).table(tableName).map(function (doc) { return doc('key').add(undefined) }).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Cannot convert `undefined` with r.expr() in:\nr.db("' + dbName + '").table("' + tableName + '")\n    .map(function(var_1) {\n        return var_1("key").add(undefined)\n                                ^^^^^^^^^ \n    })\n')
     }
-    catch(e) {
-        if (e.message === "Cannot convert `undefined` with r.expr() in:\nr.db(\""+dbName+"\").table(\""+tableName+"\")\n    .map(function(var_1) {\n        return var_1(\"key\").add(undefined)\n                                ^^^^^^^^^ \n    })\n") {
-            done()
-        }
-        else {
-            done(e);
-        }
-    }
-})
+  })
 
-
-
-/*
+  /*
 Frames:
 [ 1, 1, 1, 'adult', 1 ]
 
@@ -131,25 +106,19 @@ r.db("aa802b7a7ec470632ddb3c515e7ab30b").table("fe82af2d2203e8fbed96e0cbbc29e936
     .merge(function(var_1) {
         return r.branch(var_1("location").eq("US"), {
             adult: var_1("age").gt(NaN)
-                                   ^^^ 
+                                   ^^^
         }, {
             radult: var_1("age").gt(18)
         })
     })
 */
-It('Test backtrace for r.db(dbName).table(tableName).merge(function(user) { return r.branch( user("location").eq("US"), { adult: user("age").gt(NaN) }, {radult: user("age").gt(18) }) })', function* (done) {
+  it('Test backtrace for r.db(dbName).table(tableName).merge(function(user) { return r.branch( user("location").eq("US"), { adult: user("age").gt(NaN) }, {radult: user("age").gt(18) }) })', async () => {
     try {
-        r.nextVarId=1;
-        yield r.db(dbName).table(tableName).merge(function(user) { return r.branch( user("location").eq("US"), { adult: user("age").gt(NaN) }, {radult: user("age").gt(18) }) }).run()
-        done(new Error("Should have thrown an error"))
+      r.nextVarId = 1
+      await r.db(dbName).table(tableName).merge(function (user) { return r.branch(user('location').eq('US'), {adult: user('age').gt(NaN)}, {radult: user('age').gt(18)}) }).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Cannot convert `NaN` to JSON in:\nr.db("' + dbName + '").table("' + tableName + '")\n    .merge(function(var_1) {\n        return r.branch(var_1("location").eq("US"), {\n            adult: var_1("age").gt(NaN)\n                                   ^^^ \n        }, {\n            radult: var_1("age").gt(18)\n        })\n    })\n')
     }
-    catch(e) {
-        if (e.message === "Cannot convert `NaN` to JSON in:\nr.db(\""+dbName+"\").table(\""+tableName+"\")\n    .merge(function(var_1) {\n        return r.branch(var_1(\"location\").eq(\"US\"), {\n            adult: var_1(\"age\").gt(NaN)\n                                   ^^^ \n        }, {\n            radult: var_1(\"age\").gt(18)\n        })\n    })\n") {
-            done()
-        }
-        else {
-            done(e);
-        }
-    }
+  })
 })
-

--- a/test/client-backtrace.js
+++ b/test/client-backtrace.js
@@ -7,7 +7,7 @@ const uuid = util.uuid
 const {before, after, describe, it} = require('mocha')
 
 describe('client backtraces', () => {
-  let r, dbName, tableName, result
+  let r, dbName, tableName
 
   before(async () => {
     r = await rethinkdbdash(config)
@@ -15,7 +15,7 @@ describe('client backtraces', () => {
     dbName = uuid()
     tableName = uuid()
 
-    result = await r.dbCreate(dbName).run()
+    let result = await r.dbCreate(dbName).run()
     assert.equal(result.dbs_created, 1)
 
     result = await r.db(dbName).tableCreate(tableName).run()

--- a/test/config.js
+++ b/test/config.js
@@ -6,7 +6,7 @@ module.exports = {
   max: 5,
   fake_server: {
     host: process.env['WERCKER_RETHINKDB_HOST'] || 'localhost',
-    port: parseInt(process.env['WERCKER_RETHINKDB_PORT'], 10)+1 || 28016,
+    port: parseInt(process.env['WERCKER_RETHINKDB_PORT'], 10) + 1 || 28016
   },
   discovery: false,
   silent: true

--- a/test/control-structures.js
+++ b/test/control-structures.js
@@ -7,7 +7,7 @@ const uuid = util.uuid
 const {before, after, describe, it} = require('mocha')
 
 describe('control structures', () => {
-  let r, result
+  let r
 
   before(async () => {
     r = await rethinkdbdash(config)
@@ -18,12 +18,12 @@ describe('control structures', () => {
   })
 
   it('`do` should work', async () => {
-    result = await r.expr({a: 1}).do(function (doc) { return doc('a') }).run()
+    const result = await r.expr({a: 1}).do(function (doc) { return doc('a') }).run()
     assert.equal(result, 1)
   })
 
   it('`r.do` should work', async () => {
-    result = await r.do(1, 2, function (a, b) { return a }).run()
+    let result = await r.do(1, 2, function (a, b) { return a }).run()
     assert.equal(result, 1)
 
     result = await r.do(1, 2, function (a, b) { return b }).run()
@@ -43,7 +43,7 @@ describe('control structures', () => {
   })
 
   it('`branch` should work', async () => {
-    result = await r.branch(true, 1, 2).run()
+    let result = await r.branch(true, 1, 2).run()
     assert.equal(result, 1)
 
     result = await r.branch(false, 1, 2).run()
@@ -61,7 +61,7 @@ describe('control structures', () => {
 
   it('`branch` should throw if no argument has been given', async () => {
     try {
-      result = await r.branch().run()
+      await r.branch().run()
       assert.fail('should throw')
     } catch (e) {
       assert(e.message.match(/^`r.branch` takes at least 3 arguments, 0 provided/))
@@ -70,7 +70,7 @@ describe('control structures', () => {
 
   it('`branch` should throw if just one argument has been given', async () => {
     try {
-      result = await r.branch(true).run()
+      await r.branch(true).run()
       assert.fail('should throw')
     } catch (e) {
       assert(e.message.match(/^`r.branch` takes at least 3 arguments, 1 provided/))
@@ -79,14 +79,14 @@ describe('control structures', () => {
 
   it('`branch` should throw if just two arguments have been given', async () => {
     try {
-      result = await r.branch(true, true).run()
+      await r.branch(true, true).run()
     } catch (e) {
       assert(e.message.match(/^`r.branch` takes at least 3 arguments, 2 provided/))
     }
   })
 
   it('`branch` is defined after a term', async () => {
-    result = await r.expr(true).branch(2, 3).run()
+    let result = await r.expr(true).branch(2, 3).run()
     assert.equal(result, 2)
     result = await r.expr(false).branch(2, 3).run()
     assert.equal(result, 3)
@@ -96,7 +96,7 @@ describe('control structures', () => {
     const dbName = uuid()
     const tableName = uuid()
 
-    result = await r.dbCreate(dbName).run()
+    let result = await r.dbCreate(dbName).run()
     assert.equal(result.dbs_created, 1)
 
     result = await r.db(dbName).tableCreate(tableName).run()
@@ -110,7 +110,7 @@ describe('control structures', () => {
 
   it('`forEach` should throw if not given a function', async () => {
     try {
-      result = await r.expr([{foo: 'bar'}, {foo: 'foo'}]).forEach().run()
+      await r.expr([{foo: 'bar'}, {foo: 'foo'}]).forEach().run()
       assert.fail('should throw')
     } catch (e) {
       assert(e.message.match(/^`forEach` takes 1 argument, 0 provided after/))
@@ -118,18 +118,18 @@ describe('control structures', () => {
   })
 
   it('`r.range(x)` should work', async () => {
-    result = await r.range(10).run()
+    let result = await r.range(10).run()
     assert.deepEqual(result, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
   })
 
   it('`r.range(x, y)` should work', async () => {
-    result = await r.range(3, 10).run()
+    let result = await r.range(3, 10).run()
     assert.deepEqual(result, [3, 4, 5, 6, 7, 8, 9])
   })
 
   it('`r.range(1,2,3)` should throw - arity', async () => {
     try {
-      result = await r.range(1, 2, 3).run()
+      await r.range(1, 2, 3).run()
       assert.fail('should throw')
     } catch (e) {
       assert(e.message.match(/^`r.range` takes at most 2 arguments, 3 provided/) !== null)
@@ -138,7 +138,7 @@ describe('control structures', () => {
 
   it('`r.range()` should throw - arity', async () => {
     try {
-      result = await r.range().run()
+      await r.range().run()
       assert.fail('should throw')
     } catch (e) {
       assert(e.message.match(/^`r.range` takes at least 1 argument, 0 provided/) !== null)
@@ -146,12 +146,12 @@ describe('control structures', () => {
   })
 
   it('`default` should work', async () => {
-    result = await r.expr({a: 1})('b').default('Hello').run()
+    const result = await r.expr({a: 1})('b').default('Hello').run()
     assert.equal(result, 'Hello')
   })
   it('`default` should throw if no argument has been given', async () => {
     try {
-      result = await r.expr({})('').default().run()
+      await r.expr({})('').default().run()
       assert.fail('should throw')
     } catch (e) {
       assert(e.message.match(/^`default` takes 1 argument, 0 provided after/))
@@ -159,13 +159,13 @@ describe('control structures', () => {
   })
 
   it('`r.js` should work', async () => {
-    result = await r.js('1').run()
+    const result = await r.js('1').run()
     assert.equal(result, 1)
   })
 
   it('`js` is not defined after a term', async () => {
     try {
-      result = await r.expr(1).js('foo').run()
+      await r.expr(1).js('foo').run()
       assert.fail('should throw')
     } catch (e) {
       assert(e.message === '`js` is not defined after:\nr.expr(1)')
@@ -174,7 +174,7 @@ describe('control structures', () => {
 
   it('`js` should throw if no argument has been given', async () => {
     try {
-      result = await r.js().run()
+      await r.js().run()
       assert.fail('should throw')
     } catch (e) {
       assert(e.message.match(/^`r.js` takes at least 1 argument, 0 provided/))
@@ -182,13 +182,13 @@ describe('control structures', () => {
   })
 
   it('`coerceTo` should work', async () => {
-    result = await r.expr(1).coerceTo('STRING').run()
+    const result = await r.expr(1).coerceTo('STRING').run()
     assert.equal(result, '1')
   })
 
   it('`coerceTo` should throw if no argument has been given', async () => {
     try {
-      result = await r.expr(1).coerceTo().run()
+      await r.expr(1).coerceTo().run()
       assert.fail('should throw')
     } catch (e) {
       assert(e.message.match(/^`coerceTo` takes 1 argument, 0 provided/))
@@ -196,17 +196,17 @@ describe('control structures', () => {
   })
 
   it('`typeOf` should work', async () => {
-    result = await r.expr(1).typeOf().run()
+    const result = await r.expr(1).typeOf().run()
     assert.equal(result, 'NUMBER')
   })
 
   it('`r.typeOf` should work', async () => {
-    result = await r.typeOf(1).run()
+    const result = await r.typeOf(1).run()
     assert.equal(result, 'NUMBER')
   })
 
   it('`json` should work', async () => {
-    result = await r.json(JSON.stringify({a: 1})).run()
+    let result = await r.json(JSON.stringify({a: 1})).run()
     assert.deepEqual(result, {a: 1})
 
     result = await r.json('{}').run()
@@ -215,7 +215,7 @@ describe('control structures', () => {
 
   it('`json` should throw if no argument has been given', async () => {
     try {
-      result = await r.json().run()
+      await r.json().run()
       assert.fail('throw')
     } catch (e) {
       assert(e.message === '`r.json` takes 1 argument, 0 provided.')
@@ -224,14 +224,14 @@ describe('control structures', () => {
 
   it('`json` is not defined after a term', async () => {
     try {
-      result = await r.expr(1).json('1').run()
+      await r.expr(1).json('1').run()
     } catch (e) {
       assert(e.message.match(/^`json` is not defined after/))
     }
   })
 
   it('`toJSON` and `toJsonString` should work', async () => {
-    result = await r.expr({a: 1}).toJSON().run()
+    let result = await r.expr({a: 1}).toJSON().run()
     assert.equal(result, '{"a":1}')
 
     result = await r.expr({a: 1}).toJsonString().run()
@@ -240,7 +240,7 @@ describe('control structures', () => {
 
   it('`toJSON` should throw if an argument is provided', async () => {
     try {
-      result = await r.expr({a: 1}).toJSON('foo').run()
+      await r.expr({a: 1}).toJSON('foo').run()
       assert.fail('should throw')
     } catch (e) {
       assert(e.message.match(/^`toJSON` takes 0 argument, 1 provided/) !== null)
@@ -248,7 +248,7 @@ describe('control structures', () => {
   })
 
   it('`args` should work', async () => {
-    result = await r.args([10, 20, 30]).run()
+    let result = await r.args([10, 20, 30]).run()
     assert.deepEqual(result, [10, 20, 30])
 
     result = await r.expr({foo: 1, bar: 2, buzz: 3}).pluck(r.args(['foo', 'buzz'])).run()
@@ -265,18 +265,18 @@ describe('control structures', () => {
   })
 
   it('`http` should work', async () => {
-    result = await r.http('http://google.com').run()
+    const result = await r.http('http://google.com').run()
     assert.equal(typeof result, 'string')
   })
 
   it('`http` should work with options', async () => {
-    result = await r.http('http://google.com', {timeout: 60}).run()
+    const result = await r.http('http://google.com', {timeout: 60}).run()
     assert.equal(typeof result, 'string')
   })
 
   it('`http` should throw with an unrecognized option', async () => {
     try {
-      result = await r.http('http://google.com', {foo: 60}).run()
+      await r.http('http://google.com', {foo: 60}).run()
       assert.fail('should throw')
     } catch (e) {
       assert(e.message === 'Unrecognized option `foo` in `http`. Available options are attempts <number>, redirects <number>, verify <boolean>, resultFormat: <string>, method: <string>, auth: <object>, params: <object>, header: <string>, data: <string>, page: <string/function>, pageLimit: <number>.')
@@ -284,12 +284,12 @@ describe('control structures', () => {
   })
 
   it('`r.uuid` should work', async () => {
-    result = await r.uuid().run()
+    const result = await r.uuid().run()
     assert.equal(typeof result, 'string')
   })
 
   it('`r.uuid("foo")` should work', async () => {
-    result = await r.uuid('rethinkdbdash').run()
+    const result = await r.uuid('rethinkdbdash').run()
     assert.equal(result, '291a8039-bc4b-5472-9b2a-f133254e3283')
   })
 })

--- a/test/control-structures.js
+++ b/test/control-structures.js
@@ -1,482 +1,295 @@
-var config = require(__dirname+'/config.js');
-var r = require(__dirname+'/../lib')(config);
-var util = require(__dirname+'/util/common.js');
-var assert = require('assert');
+const path = require('path')
+const config = require(path.join(__dirname, '/config.js'))
+const rethinkdbdash = require(path.join(__dirname, '/../lib'))
+const util = require(path.join(__dirname, '/util/common.js'))
+const assert = require('assert')
+const uuid = util.uuid
+const {before, after, describe, it} = require('mocha')
 
-var uuid = util.uuid;
-var It = util.It;
+describe('control structures', () => {
+  let r, result
 
-var dbName, tableName, result;
+  before(async () => {
+    r = await rethinkdbdash(config)
+  })
 
-It('`do` should work', function* (done) {
-  try {
-    var result = yield r.expr({a: 1}).do( function(doc) { return doc("a") }).run();
-    assert.equal(result, 1);
+  after(async () => {
+    await r.getPoolMaster().drain()
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`r.do` should work', function* (done) {
-  try {
-    result = yield r.do(1, 2, function(a, b) { return a }).run();
-    assert.equal(result, 1);
+  it('`do` should work', async () => {
+    result = await r.expr({a: 1}).do(function (doc) { return doc('a') }).run()
+    assert.equal(result, 1)
+  })
 
-    result = yield r.do(1, 2, function(a, b) { return b }).run();
-    assert.equal(result, 2);
+  it('`r.do` should work', async () => {
+    result = await r.do(1, 2, function (a, b) { return a }).run()
+    assert.equal(result, 1)
 
-    result = yield r.do(3).run();
-    assert.equal(result, 3);
+    result = await r.do(1, 2, function (a, b) { return b }).run()
+    assert.equal(result, 2)
 
-    result = yield r.expr(4).do().run();
-    assert.equal(result, 4);
+    result = await r.do(3).run()
+    assert.equal(result, 3)
 
-    result = yield r.do(1, 2).run()
-    assert.deepEqual(result, 2);
+    result = await r.expr(4).do().run()
+    assert.equal(result, 4)
 
-    result = yield r.do(r.args([ r.expr(3), r.expr(4) ])).run()
-    assert.deepEqual(result, 3);
+    result = await r.do(1, 2).run()
+    assert.deepEqual(result, 2)
 
-    done();
-  }
-  catch(e) {
-    console.log(e)
-    done(e);
-  }
-})
+    result = await r.do(r.args([ r.expr(3), r.expr(4) ])).run()
+    assert.deepEqual(result, 3)
+  })
 
+  it('`branch` should work', async () => {
+    result = await r.branch(true, 1, 2).run()
+    assert.equal(result, 1)
 
-It('`branch` should work', function* (done) {
-  try {
-    var result = yield r.branch(true, 1, 2).run();
-    assert.equal(result, 1);
+    result = await r.branch(false, 1, 2).run()
+    assert.equal(result, 2)
 
-    result = yield r.branch(false, 1, 2).run();
-    assert.equal(result, 2);
+    result = await r.expr(false).branch('foo', false, 'bar', 'lol').run()
+    assert.equal(result, 'lol')
 
-    result = yield r.expr(false).branch('foo', false, 'bar', 'lol').run()
-    assert.equal(result, 'lol');
+    result = await r.expr(true).branch('foo', false, 'bar', 'lol').run()
+    assert.equal(result, 'foo')
 
-    result = yield r.expr(true).branch('foo', false, 'bar', 'lol').run()
-    assert.equal(result, 'foo');
+    result = await r.expr(false).branch('foo', true, 'bar', 'lol').run()
+    assert.equal(result, 'bar')
+  })
 
-    result = yield r.expr(false).branch('foo', true, 'bar', 'lol').run()
-    assert.equal(result, 'bar');
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`branch` should throw if no argument has been given', function* (done) {
-  try{
-    var result = yield r.branch().run();
-  }
-  catch(e) {
-    if (e.message.match(/^`r.branch` takes at least 3 arguments, 0 provided/)) {
-      done()
+  it('`branch` should throw if no argument has been given', async () => {
+    try {
+      result = await r.branch().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message.match(/^`r.branch` takes at least 3 arguments, 0 provided/))
     }
-    else {
-      done(e);
-    }
-  }
-})
-It('`branch` should throw if just one argument has been given', function* (done) {
-  try{
-    var result = yield r.branch(true).run();
-  }
-  catch(e) {
-    if (e.message.match(/^`r.branch` takes at least 3 arguments, 1 provided/)) {
-      done()
-    }
-    else {
-      done(e);
-    }
-  }
-})
-It('`branch` should throw if just two arguments have been given', function* (done) {
-  try{
-    var result = yield r.branch(true, true).run();
-  }
-  catch(e) {
-    if (e.message.match(/^`r.branch` takes at least 3 arguments, 2 provided/)) {
-      done()
-    }
-    else {
-      done(e);
-    }
-  }
-})
-It('`branch` is defined after a term', function* (done) {
-  try {
-    result = yield r.expr(true).branch(2, 3).run();
-    assert.equal(result, 2);
-    result = yield r.expr(false).branch(2, 3).run();
-    assert.equal(result, 3);
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`forEach` should work', function* (done) {
-  try{
-    var dbName = uuid();
-    var tableName = uuid();
+  })
 
-    result = yield r.dbCreate(dbName).run();
-    assert.equal(result.dbs_created, 1) 
+  it('`branch` should throw if just one argument has been given', async () => {
+    try {
+      result = await r.branch(true).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message.match(/^`r.branch` takes at least 3 arguments, 1 provided/))
+    }
+  })
 
-    result = yield r.db(dbName).tableCreate(tableName).run();
-    assert.equal(result.tables_created, 1) 
+  it('`branch` should throw if just two arguments have been given', async () => {
+    try {
+      result = await r.branch(true, true).run()
+    } catch (e) {
+      assert(e.message.match(/^`r.branch` takes at least 3 arguments, 2 provided/))
+    }
+  })
 
-    result = yield r.expr([{foo: "bar"}, {foo: "foo"}]).forEach(function(doc) {
+  it('`branch` is defined after a term', async () => {
+    result = await r.expr(true).branch(2, 3).run()
+    assert.equal(result, 2)
+    result = await r.expr(false).branch(2, 3).run()
+    assert.equal(result, 3)
+  })
+
+  it('`forEach` should work', async () => {
+    const dbName = uuid()
+    const tableName = uuid()
+
+    result = await r.dbCreate(dbName).run()
+    assert.equal(result.dbs_created, 1)
+
+    result = await r.db(dbName).tableCreate(tableName).run()
+    assert.equal(result.tables_created, 1)
+
+    result = await r.expr([{foo: 'bar'}, {foo: 'foo'}]).forEach(function (doc) {
       return r.db(dbName).table(tableName).insert(doc)
-    }).run();
-    assert.equal(result.inserted, 2);
+    }).run()
+    assert.equal(result.inserted, 2)
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`forEach` should throw if not given a function', function* (done) {
-  try{
-    result = yield r.expr([{foo: "bar"}, {foo: "foo"}]).forEach().run();
-  }
-  catch(e) {
-    if (e.message.match(/^`forEach` takes 1 argument, 0 provided after/)) {
-      done();
+  it('`forEach` should throw if not given a function', async () => {
+    try {
+      result = await r.expr([{foo: 'bar'}, {foo: 'foo'}]).forEach().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message.match(/^`forEach` takes 1 argument, 0 provided after/))
     }
-    else {
-      done(e);
+  })
+
+  it('`r.range(x)` should work', async () => {
+    result = await r.range(10).run()
+    assert.deepEqual(result, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+  })
+
+  it('`r.range(x, y)` should work', async () => {
+    result = await r.range(3, 10).run()
+    assert.deepEqual(result, [3, 4, 5, 6, 7, 8, 9])
+  })
+
+  it('`r.range(1,2,3)` should throw - arity', async () => {
+    try {
+      result = await r.range(1, 2, 3).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message.match(/^`r.range` takes at most 2 arguments, 3 provided/) !== null)
     }
-  }
-})
+  })
 
-It('`r.range(x)` should work', function* (done) {
-  try {
-    var result = yield r.range(10).run();
-    assert.deepEqual(result, [0,1,2,3,4,5,6,7,8,9]);
-
-    done();
-  }
-  catch(e) {
-    console.log(e);
-    done(e);
-  }
-})
-It('`r.range(x, y)` should work', function* (done) {
-  try {
-    var result = yield r.range(3,10).run();
-    assert.deepEqual(result, [3,4,5,6,7,8,9]);
-
-    done();
-  }
-  catch(e) {
-    console.log(e);
-    done(e);
-  }
-})
-It('`r.range(1,2,3)` should throw - arity', function* (done) {
-  try {
-    var result = yield r.range(1,2,3).run()
-    done(new Error("Was expecting an error"));
-  }
-  catch(e) {
-    if (e.message.match(/^`r.range` takes at most 2 arguments, 3 provided/) !== null) {
-      done();
+  it('`r.range()` should throw - arity', async () => {
+    try {
+      result = await r.range().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message.match(/^`r.range` takes at least 1 argument, 0 provided/) !== null)
     }
-    else {
-      done(e);
+  })
+
+  it('`default` should work', async () => {
+    result = await r.expr({a: 1})('b').default('Hello').run()
+    assert.equal(result, 'Hello')
+  })
+  it('`default` should throw if no argument has been given', async () => {
+    try {
+      result = await r.expr({})('').default().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message.match(/^`default` takes 1 argument, 0 provided after/))
     }
-  }
-})
-It('`r.range()` should throw - arity', function* (done) {
-  try {
-    var result = yield r.range().run()
-    done(new Error("Was expecting an error"));
-  }
-  catch(e) {
-    if (e.message.match(/^`r.range` takes at least 1 argument, 0 provided/) !== null) {
-      done();
+  })
+
+  it('`r.js` should work', async () => {
+    result = await r.js('1').run()
+    assert.equal(result, 1)
+  })
+
+  it('`js` is not defined after a term', async () => {
+    try {
+      result = await r.expr(1).js('foo').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === '`js` is not defined after:\nr.expr(1)')
     }
-    else {
-      done(e);
+  })
+
+  it('`js` should throw if no argument has been given', async () => {
+    try {
+      result = await r.js().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message.match(/^`r.js` takes at least 1 argument, 0 provided/))
     }
-  }
-})
+  })
 
-It('`default` should work', function* (done) {
-  try {
-    var result = yield r.expr({a:1})("b").default("Hello").run();
-    assert.equal(result, "Hello");
+  it('`coerceTo` should work', async () => {
+    result = await r.expr(1).coerceTo('STRING').run()
+    assert.equal(result, '1')
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`default` should throw if no argument has been given', function* (done) {
-  try{
-    var result = yield r.expr({})("").default().run();
-  }
-  catch(e) {
-    if (e.message.match(/^`default` takes 1 argument, 0 provided after/)) {
-      done()
+  it('`coerceTo` should throw if no argument has been given', async () => {
+    try {
+      result = await r.expr(1).coerceTo().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message.match(/^`coerceTo` takes 1 argument, 0 provided/))
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
+  it('`typeOf` should work', async () => {
+    result = await r.expr(1).typeOf().run()
+    assert.equal(result, 'NUMBER')
+  })
 
-It('`r.js` should work', function* (done) {
-  try {
-    var result = yield r.js("1").run();
-    assert.equal(result, 1);
+  it('`r.typeOf` should work', async () => {
+    result = await r.typeOf(1).run()
+    assert.equal(result, 'NUMBER')
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`js` is not defined after a term', function* (done) {
-  try {
-    result = yield r.expr(1).js("foo").run();
-  }
-  catch(e) {
-    if (e.message === "`js` is not defined after:\nr.expr(1)") {
-      done()
-    }
-    else {
-      done(e)
-    }
-  }
-})
-It('`js` should throw if no argument has been given', function* (done) {
-  try{
-    var result = yield r.js().run();
-  }
-  catch(e) {
-    if (e.message.match(/^`r.js` takes at least 1 argument, 0 provided/)) {
-      done()
-    }
-    else {
-      done(e);
-    }
-  }
-})
+  it('`json` should work', async () => {
+    result = await r.json(JSON.stringify({a: 1})).run()
+    assert.deepEqual(result, {a: 1})
 
-
-It('`coerceTo` should work', function* (done) {
-  try {
-    var result = yield r.expr(1).coerceTo("STRING").run();
-    assert.equal(result, "1");
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`coerceTo` should throw if no argument has been given', function* (done) {
-  try{
-    var result = yield r.expr(1).coerceTo().run();
-  }
-  catch(e) {
-    if (e.message.match(/^`coerceTo` takes 1 argument, 0 provided/)) {
-      done()
-    }
-    else {
-      done(e);
-    }
-  }
-})
-
-It('`typeOf` should work', function* (done) {
-  try {
-    var result = yield r.expr(1).typeOf().run();
-    assert.equal(result, "NUMBER");
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`r.typeOf` should work', function* (done) {
-  try {
-    var result = yield r.typeOf(1).run();
-    assert.equal(result, "NUMBER");
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-
-It('`json` should work', function* (done) {
-  try {
-    var result = yield r.json(JSON.stringify({a:1})).run();
-    assert.deepEqual(result, {a:1});
-
-    result = yield r.json("{}").run();
+    result = await r.json('{}').run()
     assert.deepEqual(result, {})
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`json` should throw if no argument has been given', function* (done) {
-  try{
-    var result = yield r.json().run();
-  }
-  catch(e) {
-    if (e.message === "`r.json` takes 1 argument, 0 provided.") {
-      done()
+  it('`json` should throw if no argument has been given', async () => {
+    try {
+      result = await r.json().run()
+      assert.fail('throw')
+    } catch (e) {
+      assert(e.message === '`r.json` takes 1 argument, 0 provided.')
     }
-    else {
-      done(e);
-    }
-  }
-})
-It('`json` is not defined after a term', function* (done) {
-  try {
-    result = yield r.expr(1).json("1").run();
-  }
-  catch(e) {
-    if (e.message.match(/^`json` is not defined after/)) {
-      done()
-    }
-    else {
-      done(e)
-    }
-  }
-})
-It('`toJSON` and `toJsonString` should work', function* (done) {
-  try {
-    var result = yield r.expr({a:1}).toJSON().run();
-    assert.equal(result, '{"a":1}');
+  })
 
-    var result = yield r.expr({a:1}).toJsonString().run();
-    assert.equal(result, '{"a":1}');
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`toJSON` should throw if an argument is provided', function* (done) {
-  try {
-    var result = yield r.expr({a:1}).toJSON('foo').run();
-    done(new Error("Expecting error..."));
-  }
-  catch(e) {
-    if (e.message.match(/^`toJSON` takes 0 argument, 1 provided/) !== null) {
-      done()
+  it('`json` is not defined after a term', async () => {
+    try {
+      result = await r.expr(1).json('1').run()
+    } catch (e) {
+      assert(e.message.match(/^`json` is not defined after/))
     }
-    else {
-      done(e)
+  })
+
+  it('`toJSON` and `toJsonString` should work', async () => {
+    result = await r.expr({a: 1}).toJSON().run()
+    assert.equal(result, '{"a":1}')
+
+    result = await r.expr({a: 1}).toJsonString().run()
+    assert.equal(result, '{"a":1}')
+  })
+
+  it('`toJSON` should throw if an argument is provided', async () => {
+    try {
+      result = await r.expr({a: 1}).toJSON('foo').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message.match(/^`toJSON` takes 0 argument, 1 provided/) !== null)
     }
-  }
-})
+  })
 
-It('`args` should work', function* (done) {
-  try {
-    var result = yield r.args([10, 20, 30]).run();
-    assert.deepEqual(result, [10, 20, 30]);
+  it('`args` should work', async () => {
+    result = await r.args([10, 20, 30]).run()
+    assert.deepEqual(result, [10, 20, 30])
 
-    result = yield r.expr({foo: 1, bar: 2, buzz: 3}).pluck(r.args(["foo", "buzz"])).run()
-    assert.deepEqual(result, {foo: 1, buzz: 3});
+    result = await r.expr({foo: 1, bar: 2, buzz: 3}).pluck(r.args(['foo', 'buzz'])).run()
+    assert.deepEqual(result, {foo: 1, buzz: 3})
+  })
 
-    done();
-  }
-  catch(e) {
-    console.log(e)
-    done(e)
-  }
-})
-It('`args` should throw if an implicit var is passed inside', function* (done) {
-  try {
-    var cursor = yield r.table("foo").eqJoin(r.args([r.row, r.table("bar")])).run();
-    done();
-  }
-  catch(e) {
-    if (e.message === 'Implicit variable `r.row` cannot be used inside `r.args`.') {
-      done();
+  it('`args` should throw if an implicit var is passed inside', async () => {
+    try {
+      await r.table('foo').eqJoin(r.args([r.row, r.table('bar')])).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Implicit variable `r.row` cannot be used inside `r.args`.')
     }
-    else {
-      done(e);
+  })
+
+  it('`http` should work', async () => {
+    result = await r.http('http://google.com').run()
+    assert.equal(typeof result, 'string')
+  })
+
+  it('`http` should work with options', async () => {
+    result = await r.http('http://google.com', {timeout: 60}).run()
+    assert.equal(typeof result, 'string')
+  })
+
+  it('`http` should throw with an unrecognized option', async () => {
+    try {
+      result = await r.http('http://google.com', {foo: 60}).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'Unrecognized option `foo` in `http`. Available options are attempts <number>, redirects <number>, verify <boolean>, resultFormat: <string>, method: <string>, auth: <object>, params: <object>, header: <string>, data: <string>, page: <string/function>, pageLimit: <number>.')
     }
-  }
-})
-It('`http` should work', function* (done) {
-  try {
-    var result = yield r.http('http://google.com').run();
-    assert.equal(typeof result, 'string');
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e)
-  }
-})
-It('`http` should work with options', function* (done) {
-  try {
-    var result = yield r.http('http://google.com', {timeout: 60}).run();
-    assert.equal(typeof result, 'string');
+  it('`r.uuid` should work', async () => {
+    result = await r.uuid().run()
+    assert.equal(typeof result, 'string')
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e)
-  }
-})
-It('`http` should throw with an unrecognized option', function* (done) {
-  try {
-    var result = yield r.http('http://google.com', {foo: 60}).run();
-    done(new Error("Expecting error..."));
-  }
-  catch(e) {
-    if (e.message === "Unrecognized option `foo` in `http`. Available options are attempts <number>, redirects <number>, verify <boolean>, resultFormat: <string>, method: <string>, auth: <object>, params: <object>, header: <string>, data: <string>, page: <string/function>, pageLimit: <number>.") {
-      done()
-    }
-    else {
-      done(e)
-    }
-  }
-})
-It('`r.uuid` should work', function* (done) {
-  try {
-    var result = yield r.uuid().run();
-    assert.equal(typeof result, 'string');
-
-    done();
-  }
-  catch(e) {
-    done(e)
-  }
-})
-
-It('`r.uuid("foo")` should work', function* (done) {
-  try {
-    var result = yield r.uuid("rethinkdbdash").run();
-    assert.equal(result, '291a8039-bc4b-5472-9b2a-f133254e3283');
-    done();
-  }
-  catch(e) {
-    done(e)
-  }
+  it('`r.uuid("foo")` should work', async () => {
+    result = await r.uuid('rethinkdbdash').run()
+    assert.equal(result, '291a8039-bc4b-5472-9b2a-f133254e3283')
+  })
 })

--- a/test/coverage.js
+++ b/test/coverage.js
@@ -1,61 +1,56 @@
-var util = require(__dirname+'/util/common.js');
-var It = util.It;
+const path = require('path')
+const protodef = require(path.join(__dirname, '/../lib/protodef.js'))
+const fs = require('fs')
+const keys = Object.keys(protodef.Term.TermType)
+const {describe, it} = require('mocha')
+const assert = require('assert')
 
-var protodef = require(__dirname+'/../lib/protodef.js');
-var keys = Object.keys(protodef.Term.TermType);
+describe('coverage', () => {
+  // Test that the term appears somewhere in the file, which find terms that were not implemented
+  it('all terms should be present in term.js', async () => {
+    const str = fs.readFileSync(path.join(__dirname, '/../lib/term.js'), 'utf8')
+    const ignoredKeys = [ // not implemented since we use the JSON protocol
+      'DATUM',
+      'MAKE_OBJ',
+      'BETWEEN_DEPRECATED',
+      'ERROR' // define in index, error is defined for behaving like a promise
+    ]
+    const missing = []
 
-var fs = require('fs');
-
-// Test that the term appears somewhere in the file, which find terms that were not implemented
-It('All terms should be present in term.js', function* (done) {
-  var str = fs.readFileSync(__dirname+'/../lib/term.js', 'utf8');
-  var ignoredKeys = { // not implemented since we use the JSON protocol
-    DATUM: true,
-    MAKE_OBJ: true,
-    BETWEEN_DEPRECATED: true,
-    ERROR: true, // define in index, error is defined for behaving like a promise
-  }
-  var missing = [];
-  for(var i=0; i<keys.length; i++) {
-    if (ignoredKeys[keys[i]] === true) {
-      continue;
+    for (const key of keys) {
+      if (ignoredKeys.includes(key)) {
+        continue
+      }
+      if (str.match(new RegExp(key)) === null) {
+        missing.push(key)
+      }
     }
-    if (str.match(new RegExp(keys[i])) === null) {
-      missing.push(keys[i]);
+
+    if (missing.length > 0) {
+      assert.fail('Some terms were not found:', JSON.stringify(missing))
     }
-  }
+  })
 
-  if (missing.length > 0) {
-    done(new Error('Some terms were not found: '+JSON.stringify(missing)));
-  }
-  else {
-    done();
-  }
+  it('All terms should be present in error.js', async () => {
+    const str = fs.readFileSync(path.join(__dirname, '/../lib/error.js'), 'utf8')
+    const ignoredKeys = [
+      'DATUM',
+      'MAKE_OBJ',
+      'BETWEEN_DEPRECATED'
+    ]
+    const missing = []
 
+    for (const key of keys) {
+      if (ignoredKeys.includes(key)) {
+        continue
+      }
+      if (str.match(new RegExp(key)) === null) {
+        missing.push(key)
+      }
+    }
+
+    if (missing.length > 0) {
+      assert.fail('Some terms were not found: ' + JSON.stringify(missing))
+    }
+  })
 })
-It('All terms should be present in error.js', function* (done) {
-  var str = fs.readFileSync(__dirname+'/../lib/error.js', 'utf8');
-  var ignoredKeys = {
-    DATUM: true,
-    MAKE_OBJ: true,
-    BETWEEN_DEPRECATED: true,
-  }
-  var missing = [];
-  for(var i=0; i<keys.length; i++) {
-    if (ignoredKeys[keys[i]] === true) {
-      continue;
-    }
-    if (str.match(new RegExp(keys[i])) === null) {
-      missing.push(keys[i]);
-    }
-  }
-
-  if (missing.length > 0) {
-    done(new Error('Some terms were not found: '+JSON.stringify(missing)));
-  }
-  else {
-    done();
-  }
-
-})
-

--- a/test/cursor.js
+++ b/test/cursor.js
@@ -443,7 +443,7 @@ describe('administration', () => {
         feed.next().then(assert)
         i++
         if (i === smallNumDocs) {
-          return feed.close().then(resolve).catch(reject)
+          return feed.close().then(resolve).error(reject)
         }
       }
     })

--- a/test/cursor.js
+++ b/test/cursor.js
@@ -21,19 +21,6 @@ describe('cursor', () => {
     tableName = uuid() // Big table to test partial sequence
     tableName2 = uuid() // small table to test success sequence
 
-    // delete all but the system dbs
-    for (let db of await r.dbList().run()) {
-      if (db === 'rethinkdb' || db === 'test') {
-        continue
-      } else {
-        try {
-          await r.dbDrop(db).run()
-        } catch (error) {
-          assert.fail(error)
-        }
-      }
-    }
-
     let result = await r.dbCreate(dbName).run()
     assert.equal(result.dbs_created, 1)
     result = await r.db(dbName).tableCreate(tableName).run()

--- a/test/cursor.js
+++ b/test/cursor.js
@@ -543,7 +543,9 @@ describe('cursor', () => {
 
     cursor = await r1.db(dbName).table(tableName).run()
     assert.equal(cursor.toString(), '[object Cursor]')
-    await cursor.close().then().catch(assert.fail)
+
+    await cursor.close()
+    await r1.getPoolMaster().drain()
   })
 
   it('`each` should not return an error if the feed is closed - 1', async () => {

--- a/test/cursor.js
+++ b/test/cursor.js
@@ -8,7 +8,7 @@ const assert = require('assert')
 const iterall = require('iterall')
 const {before, after, describe, it} = require('mocha')
 
-describe('administration', () => {
+describe('cursor', () => {
   let r, connection, dbName, tableName, tableName2, cursor, result, feed
 
   const numDocs = 100 // Number of documents in the "big table" used to test the SUCCESS_PARTIAL

--- a/test/cursor.js
+++ b/test/cursor.js
@@ -1,877 +1,700 @@
-var config = require('./config.js');
-var r = require('../lib')(config);
-var util = require(__dirname+'/util/common.js');
-var assert = require('assert');
-var iterall = require('iterall');
+const path = require('path')
+const config = require('./config.js')
+const rethinkdbdash = require(path.join(__dirname, '/../lib'))
+const util = require(path.join(__dirname, '/util/common.js'))
+const uuid = util.uuid
+const assert = require('assert')
 
-var uuid = util.uuid;
-var It = util.It
+const iterall = require('iterall')
+const {before, after, describe, it} = require('mocha')
 
-var dbName, tableName, tableName2, cursor, result, pks, feed;
+describe('administration', () => {
+  let r, connection, dbName, tableName, tableName2, cursor, result, feed
 
-var numDocs = 100; // Number of documents in the "big table" used to test the SUCCESS_PARTIAL 
-var smallNumDocs = 5; // Number of documents in the "small table"
+  const numDocs = 100 // Number of documents in the "big table" used to test the SUCCESS_PARTIAL
+  const smallNumDocs = 5 // Number of documents in the "small table"
 
-It('Init for `cursor.js`', function* (done) {
-  try {
-    dbName = uuid();
-    tableName = uuid(); // Big table to test partial sequence
-    tableName2 = uuid(); // small table to test success sequence
+  before(async () => {
+    r = await rethinkdbdash(config)
 
-    result = yield r.dbCreate(dbName).run()
-    assert.equal(result.dbs_created, 1);
-    result = yield [r.db(dbName).tableCreate(tableName)('tables_created').run(), r.db(dbName).tableCreate(tableName2)('tables_created').run()]
-    assert.deepEqual(result, [1, 1]);
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('Inserting batch - table 1', function* (done) {
-  try {
-    result = yield r.db(dbName).table(tableName).insert(eval('['+new Array(numDocs).join('{}, ')+'{}]')).run();
-    assert.equal(result.inserted, numDocs);
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('Inserting batch - table 2', function* (done) {
-  try {
-    result = yield r.db(dbName).table(tableName2).insert(eval('['+new Array(smallNumDocs).join('{}, ')+'{}]')).run();
-    assert.equal(result.inserted, smallNumDocs);
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('Updating batch', function* (done) {
-  try {
-    // Add a date
-    result = yield r.db(dbName).table(tableName).update({
+    dbName = uuid()
+    tableName = uuid() // Big table to test partial sequence
+    tableName2 = uuid() // small table to test success sequence
+
+    // delete all but the system dbs
+    for (let db of await r.dbList().run()) {
+      if (db === 'rethinkdb' || db === 'test') {
+        continue
+      } else {
+        try {
+          await r.dbDrop(db).run()
+        } catch (error) {
+          assert.fail(error)
+        }
+      }
+    }
+
+    result = await r.dbCreate(dbName).run()
+    assert.equal(result.dbs_created, 1)
+
+    result = await r.db(dbName).tableCreate(tableName).run()
+    assert.equal(result.tables_created, 1)
+
+    result = await r.db(dbName).tableCreate(tableName2).run()
+    assert.equal(result.tables_created, 1)
+  })
+
+  after(async () => {
+    await r.getPoolMaster().drain()
+  })
+
+  it('Inserting batch - table 1', async () => {
+    result = await r.db(dbName).table(tableName).insert(r.expr(Array(numDocs).fill({}))).run()
+    assert.equal(result.inserted, numDocs)
+  })
+
+  it('Inserting batch - table 2', async () => {
+    result = await r.db(dbName).table(tableName2).insert(r.expr(Array(smallNumDocs).fill({}))).run()
+    assert.equal(result.inserted, smallNumDocs)
+  })
+
+  it('Updating batch', async () => {
+    result = await r.db(dbName).table(tableName).update({
       date: r.now().sub(r.random().mul(1000000)),
       value: r.random()
-    }, {nonAtomic: true}).run();
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`table` should return a cursor', function* (done) {
-  try {
-    cursor = yield r.db(dbName).table(tableName).run({cursor: true});
-    assert(cursor);
-    assert.equal(cursor.toString(), '[object Cursor]');
+    }, {nonAtomic: true}).run()
+    assert.equal(result.replaced, 100)
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+  it('`table` should return a cursor', async () => {
+    cursor = await r.db(dbName).table(tableName).run({cursor: true})
+    assert(cursor)
+    assert.equal(cursor.toString(), '[object Cursor]')
+  })
 
-It('`next` should return a document', function* (done) {
-  try {
-    result = yield cursor.next();
-    assert(result);
-    assert(result.id);
+  it('`next` should return a document', async () => {
+    result = await cursor.next()
+    assert(result)
+    assert(result.id)
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`each` should work', function* (done) {
-  try {
-    cursor = yield r.db(dbName).table(tableName).run({cursor: true});
-    assert(cursor);
-    var count = 0;
-    cursor.each(function(err, result) {
-      count++;
-      if (count === numDocs) {
-        done();
-      }
+  it('`each` should work', async () => {
+    cursor = await r.db(dbName).table(tableName).run({cursor: true})
+    assert(cursor)
+
+    await new Promise((resolve, reject) => {
+      let count = 0
+      cursor.each(function (err, result) {
+        if (err) reject(err)
+        count++
+        if (count === numDocs) resolve()
+      })
     })
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`eachAsync` should work', function* (done) {
-  try {
-    cursor = yield r.db(dbName).table(tableName).run({cursor: true});
-    assert(cursor);
-    var history = [];
-    var count = 0;
-    var promisesWait = 0;
-    cursor.eachAsync(function(result) {
-      history.push(count);
-      count++;
-      return new Promise(function(resolve, reject) {
-        setTimeout(function() {
-          history.push(promisesWait);
-          promisesWait--;
+  })
+
+  it('`each` should work - onFinish - reach end', async () => {
+    cursor = await r.db(dbName).table(tableName).run({cursor: true})
+    assert(cursor)
+
+    await new Promise((resolve, reject) => {
+      let count = 0
+      cursor.each(function (err, result) {
+        if (err) reject(err)
+        count++
+      }, () => {
+        if (count !== numDocs) {
+          reject(new Error('expected count to equal numDocs', count, numDocs))
+        }
+        assert.equal(count, numDocs)
+        resolve()
+      })
+    })
+  })
+
+  it('`each` should work - onFinish - return false', async () => {
+    cursor = await r.db(dbName).table(tableName).run({cursor: true})
+    assert(cursor)
+
+    await new Promise((resolve, reject) => {
+      let count = 0
+      cursor.each(function (err, result) {
+        if (err) reject(err)
+        count++
+        return false
+      }, function () {
+        count === 1 ? resolve() : reject(new Error('expected count to not equal 1'))
+      })
+    })
+  })
+
+  it('`eachAsync` should work', async () => {
+    cursor = await r.db(dbName).table(tableName).run({cursor: true})
+    assert(cursor)
+
+    const history = []
+    let count = 0
+    let promisesWait = 0
+
+    // TODO cleanup
+    await cursor.eachAsync(async (result) => {
+      history.push(count)
+      count++
+      await new Promise(function (resolve, reject) {
+        setTimeout(function () {
+          history.push(promisesWait)
+          promisesWait--
 
           if (count === numDocs) {
-            var expected = [];
-            for(var i=0; i<numDocs; i++) {
-              expected.push(i);
-              expected.push(-1*i);
+            var expected = []
+            for (var i = 0; i < numDocs; i++) {
+              expected.push(i)
+              expected.push(-1 * i)
             }
             assert.deepEqual(history, expected)
           }
-          resolve();
-        }, 1);
-      });
-    }).then(done);
-  }
-  catch(e) {
-    done(e);
-  }
-})
-
-It('`eachAsync` should work - callback style', function* (done) {
-  try {
-    cursor = yield r.db(dbName).table(tableName).run({cursor: true});
-    assert(cursor);
-    var count = 0;
-    var now = Date.now();
-    var timeout = 10;
-    cursor.eachAsync(function(result, onRowFinished) {
-      count++;
-      setTimeout(function() {
-        onRowFinished();
-      }, timeout)
-    }).then(function() {
-      var elapsed = Date.now()-now;
-      assert(elapsed >= timeout*count);
-      done();
-    });
-  }
-  catch(e) {
-    done(e);
-  }
-})
-
-It('`each` should work - onFinish - reach end', function* (done) {
-  try {
-    cursor = yield r.db(dbName).table(tableName).run({cursor: true});
-    assert(cursor);
-    var count = 0;
-    cursor.each(function(err, result) {
-    }, done)
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`each` should work - onFinish - return false', function* (done) {
-  try {
-    cursor = yield r.db(dbName).table(tableName).run({cursor: true});
-    assert(cursor);
-    var count = 0;
-    cursor.each(function(err, result) {
-      count++
-      return false
-    }, function() {
-      assert.equal(count, 1);
-      done();
+          if (count > numDocs) {
+            reject(new Error('eachAsync exceeded ' + numDocs + ' iterations'))
+          } else {
+            resolve()
+          }
+        }, 1)
+      })
     })
-  }
-  catch(e) {
-    done(e);
-  }
-})
+  })
 
+  it('`eachAsync` should work - callback style', async () => {
+    cursor = await r.db(dbName).table(tableName).run({cursor: true})
+    assert(cursor)
 
-It('`toArray` should work', function* (done) {
-  try {
-    cursor = yield r.db(dbName).table(tableName).run({cursor: true});
-    result = yield cursor.toArray();
-    assert.equal(result.length, numDocs);
+    let count = 0
+    const now = Date.now()
+    const timeout = 10
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`toArray` should work -- with a profile', function* (done) {
-  try {
-    result = yield r.db(dbName).table(tableName).run({cursor: true, profile: true});
-    result = yield result.result.toArray();
-    assert.equal(result.length, numDocs);
+    await cursor.eachAsync(function (result, onRowFinished) {
+      count++
+      setTimeout(onRowFinished, timeout)
+    })
+    assert.equal(count, 100)
+    const elapsed = Date.now() - now
+    assert(elapsed >= timeout * count)
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`toArray` should work with a datum', function* (done) {
-  try {
-    cursor = yield r.expr([1,2,3]).run({cursor: true});
-    result = yield cursor.toArray();
-    assert.deepEqual(result, [1,2,3]);
+  it('`toArray` should work', async () => {
+    cursor = await r.db(dbName).table(tableName).run({cursor: true})
+    result = await cursor.toArray()
+    assert.equal(result.length, numDocs)
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+  it('`toArray` should work - 2', async () => {
+    cursor = await r.db(dbName).table(tableName2).run({cursor: true})
+    result = await cursor.toArray()
+    assert.equal(result.length, smallNumDocs)
+  })
 
-It('`table` should return a cursor - 2', function* (done) {
-  try {
-    cursor = yield r.db(dbName).table(tableName2).run({cursor: true});
-    assert(cursor);
+  it('`toArray` should work -- with a profile', async () => {
+    cursor = await r.db(dbName).table(tableName).run({cursor: true, profile: true})
+    result = await cursor.result.toArray()
+    assert(Array.isArray(result))
+    assert.equal(result.length, numDocs)
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+  it('`toArray` should work with a datum', async () => {
+    cursor = await r.expr([1, 2, 3]).run({cursor: true})
+    result = await cursor.toArray()
+    assert(Array.isArray(result))
+    assert.deepEqual(result, [1, 2, 3])
+  })
 
-It('`next` should return a document - 2', function* (done) {
-  try {
-    result = yield cursor.next();
-    assert(result);
-    assert(result.id);
+  it('`table` should return a cursor - 2', async () => {
+    cursor = await r.db(dbName).table(tableName2).run({cursor: true})
+    assert(cursor)
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`next` should work -- testing common pattern', function* (done) {
-  try {
-    cursor = yield r.db(dbName).table(tableName2).run({cursor: true});
-    assert(cursor);
-    var i=0;
-    while(true) {
-      try{
-        result = yield cursor.next();
-        assert(result);
-        i++;
+  it('`next` should return a document - 2', async () => {
+    result = await cursor.next()
+    assert(result)
+    assert(result.id)
+  })
+
+  it('`next` should work -- testing common pattern', async () => {
+    cursor = await r.db(dbName).table(tableName2).run({cursor: true})
+    assert(cursor)
+
+    let i = 0
+    try {
+      while (true) {
+        result = await cursor.next()
+        assert(result)
+        i++
       }
-      catch(e) {
-        if (e.message === "No more rows in the cursor.") {
-          assert.equal(smallNumDocs, i);
-          done();
-          break;
-        }
-        else {
-          done(e);
-          break;
-        }
+    } catch (e) {
+      assert.equal(e.message, 'No more rows in the cursor.')
+      assert.equal(smallNumDocs, i)
+    }
+  })
+
+  it('`cursor.close` should return a promise', async () => {
+    var cursor = await r.db(dbName).table(tableName2).run({cursor: true})
+    await cursor.close()
+  })
+
+  it('`cursor.close` should still return a promise if the cursor was closed', async () => {
+    cursor = await r.db(dbName).table(tableName2).changes().run()
+    await cursor.close()
+    result = cursor.close()
+    try {
+      result.then(() => {}) // Promise's contract is to have a `then` method
+    } catch (e) {
+      assert.fail(e)
+    }
+  })
+
+  it('cursor should throw if the user try to serialize it in JSON', async () => {
+    cursor = await r.db(dbName).table(tableName).run({cursor: true})
+
+    try {
+      cursor.toJSON()
+    } catch (err) {
+      assert.equal(err.message, 'You cannot serialize a Cursor to JSON. Retrieve data from the cursor with `toArray` or `next`.')
+    }
+  })
+
+  it('Remove the field `val` in some docs - 1', async () => {
+    result = await r.db(dbName).table(tableName).update({val: 1}).run()
+    assert.equal(result.replaced, numDocs)
+
+    result = await r.db(dbName).table(tableName)
+      .orderBy({index: r.desc('id')})
+      .sample(5).replace(r.row.without('val'))
+      .run()
+    assert.equal(result.replaced, 5)
+  })
+
+  it('Remove the field `val` in some docs - 2', async () => {
+    result = await r.db(dbName).table(tableName).update({val: 1}).run()
+
+    result = await r.db(dbName).table(tableName)
+      .orderBy({index: r.desc('id')})
+      .limit(5).replace(r.row.without('val'))
+      .run()
+    assert.equal(result.replaced, 5)
+  })
+
+  it('`toArray` with multiple batches - testing empty SUCCESS_COMPLETE', async () => {
+    connection = await r.connect({host: config.host, port: config.port, authKey: config.authKey})
+    assert(connection.open)
+
+    cursor = await r.db(dbName).table(tableName).run(connection, {cursor: true, maxBatchRows: 1})
+    assert(cursor)
+
+    result = await cursor.toArray()
+    assert(Array.isArray(result))
+    assert.equal(result.length, 100)
+
+    await connection.close()
+    assert(!connection.open)
+  })
+
+  it('Automatic coercion from cursor to table with multiple batches', async () => {
+    connection = await r.connect({host: config.host, port: config.port, authKey: config.authKey})
+    assert(connection.open)
+
+    result = await r.db(dbName).table(tableName).run(connection, {maxBatchRows: 1})
+    assert(result.length > 0)
+
+    await connection.close()
+    assert(!connection.open)
+  })
+
+  it('`next` with multiple batches', async () => {
+    connection = await r.connect({host: config.host, port: config.port, authKey: config.authKey})
+    assert(connection.open)
+
+    cursor = await r.db(dbName).table(tableName).run(connection, {cursor: true, maxBatchRows: 1})
+    assert(cursor)
+
+    let i = 0
+    try {
+      while (true) {
+        result = await cursor.next()
+        i++
+      }
+    } catch (e) {
+      if ((i > 0) && (e.message === 'No more rows in the cursor.')) {
+        await connection.close()
+        assert(!connection.open)
+      } else {
+        assert.fail(e)
       }
     }
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`toArray` should work - 2', function* (done) {
-  try {
-    var cursor = yield r.db(dbName).table(tableName2).run({cursor: true});
-    result = yield cursor.toArray();
-    assert.equal(result.length, smallNumDocs);
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+  it('`next` should error when hitting an error -- not on the first batch', async () => {
+    connection = await r.connect({host: config.host, port: config.port, authKey: config.authKey})
+    assert(connection)
 
-It('`cursor.close` should return a promise', function* (done) {
-  try {
-    var cursor = yield r.db(dbName).table(tableName2).run({cursor: true});
-    yield cursor.close();
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`cursor.close` should still return a promise if the cursor was closed', function* (done) {
-  try {
-    var cursor = yield r.db(dbName).table(tableName2).changes().run();
-    yield cursor.close();
-    yield cursor.close();
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+    cursor = await r.db(dbName).table(tableName)
+      .orderBy({index: 'id'})
+      .map(r.row('val').add(1))
+      .run(connection, {cursor: true, maxBatchRows: 10})
+    assert(cursor)
 
-It('cursor shouldn\'t throw if the user try to serialize it in JSON', function* (done) {
-  try {
-    var cursor = yield r.db(dbName).table(tableName).run({cursor: true});
-    cursor.toJSON()
-    done(new Error('Was expecting an error'));
-  }
-  catch(e) {
-    assert.equal(e.message, "You cannot serialize a Cursor to JSON. Retrieve data from the cursor with `toArray` or `next`.");
-    done();
-  }
-})
+    let i = 0
 
-// This test is not working for now -- need more data? Server bug?
-It('Remove the field `val` in some docs', function* (done) {
-  var i=0;
-  try {
-    result = yield r.db(dbName).table(tableName).update({val: 1}).run();
-    //assert.equal(result.replaced, numDocs);
-
-    result = yield r.db(dbName).table(tableName)
-      .orderBy({index: r.desc("id")}).limit(5).replace(r.row.without("val"))
-      //.sample(1).replace(r.row.without("val"))
-      .run({cursor: true});
-    assert.equal(result.replaced, 5);
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`toArray` with multiple batches - testing empty SUCCESS_COMPLETE', function* (done) {
-  var i=0;
-  try {
-    var connection = yield r.connect({host: config.host, port: config.port, authKey: config.authKey});
-    assert(connection);
-
-    cursor = yield r.db(dbName).table(tableName).run(connection, {cursor: true, maxBatchRows: 1});
-
-    assert(cursor);
-    result = yield cursor.toArray();
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('Automatic coercion from cursor to table with multiple batches', function* (done) {
-  var i=0;
-  try {
-    var connection = yield r.connect({host: config.host, port: config.port, authKey: config.authKey});
-    assert(connection);
-
-    result = yield r.db(dbName).table(tableName).run(connection, {maxBatchRows: 1});
-    assert(result.length > 0);
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`next` with multiple batches', function* (done) {
-  var i=0;
-  try {
-    var connection = yield r.connect({host: config.host, port: config.port, authKey: config.authKey});
-    assert(connection);
-
-    cursor = yield r.db(dbName).table(tableName).run(connection, {cursor: true, maxBatchRows: 1});
-
-    assert(cursor);
-    while(true) {
-      try {
-        result = yield cursor.next();
-        i++;
+    try {
+      while (true) {
+        result = await cursor.next()
+        i++
       }
-      catch(e) {
-        if ((i > 0) && (e.message === "No more rows in the cursor.")) {
-          connection.close();
-          done()
-        }
-        else {
-          done(e);
-        }
-        break;
+    } catch (e) {
+      if ((i > 0) && (e.message.match(/^No attribute `val` in object/))) {
+        await connection.close()
+        assert(!connection.open)
+      } else {
+        assert.fail(e)
       }
     }
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`next` should error when hitting an error -- not on the first batch', function* (done) {
-  var i=0;
-  try {
-    var connection = yield r.connect({host: config.host, port: config.port, authKey: config.authKey});
-    assert(connection);
+  })
 
-    var cursor = yield r.db(dbName).table(tableName)
-      .orderBy({index: "id"})
-      .map(r.row("val").add(1))
-      .run(connection, {cursor: true, maxBatchRows: 10});
+  it('`changes` should return a feed', async () => {
+    feed = await r.db(dbName).table(tableName).changes().run()
+    assert(feed)
+    assert.equal(feed.toString(), '[object Feed]')
+    await feed.close()
+  })
 
-    assert(cursor);
-    while(true) {
-      try {
-        result = yield cursor.next();
-        i++;
-      }
-      catch(e) {
-        if ((i > 0) && (e.message.match(/^No attribute `val` in object/))) {
-          connection.close();
-          done()
-        }
-        else {
-          done(e);
-        }
-        break;
-      }
-    }
-  }
-  catch(e) {
-    done(e);
-  }
-})
+  it('`changes` should work with squash: true', async () => {
+    feed = await r.db(dbName).table(tableName).changes({squash: true}).run()
+    assert(feed)
+    assert.equal(feed.toString(), '[object Feed]')
+    await feed.close()
+  })
 
-It('`changes` should return a feed', function* (done) {
-  try {
-    feed = yield r.db(dbName).table(tableName).changes().run();
-    assert(feed);
-    assert.equal(feed.toString(), '[object Feed]');
-    yield feed.close();
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`changes` should work with squash: true', function* (done) {
-  try {
-    feed = yield r.db(dbName).table(tableName).changes({squash: true}).run();
-    assert(feed);
-    assert.equal(feed.toString(), '[object Feed]');
-    yield feed.close();
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+  it('`get.changes` should return a feed', async () => {
+    feed = await r.db(dbName).table(tableName).get(1).changes().run()
+    assert(feed)
+    assert.equal(feed.toString(), '[object AtomFeed]')
+    await feed.close()
+  })
 
-It('`get.changes` should return a feed', function* (done) {
-  try {
-    feed = yield r.db(dbName).table(tableName).get(1).changes().run();
-    assert(feed);
-    assert.equal(feed.toString(), '[object AtomFeed]');
-    yield feed.close();
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`orderBy.limit.changes` should return a feed', function* (done) {
-  try {
-    feed = yield r.db(dbName).table(tableName).orderBy({index: 'id'}).limit(2).changes().run();
-    assert(feed);
-    assert.equal(feed.toString(), '[object OrderByLimitFeed]');
-    yield feed.close();
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+  it('`orderBy.limit.changes` should return a feed', async () => {
+    feed = await r.db(dbName).table(tableName).orderBy({index: 'id'}).limit(2).changes().run()
+    assert(feed)
+    assert.equal(feed.toString(), '[object OrderByLimitFeed]')
+    await feed.close()
+  })
 
-It('`changes` with `includeOffsets` should work', function* (done) {
-  try {
-    feed = yield r.db(dbName).table(tableName).orderBy({index: 'id'}).limit(2).changes({
+  it('`changes` with `includeOffsets` should work', async () => {
+    feed = await r.db(dbName).table(tableName).orderBy({index: 'id'}).limit(2).changes({
       includeOffsets: true,
       includeInitial: true
-    }).run();
+    }).run()
 
-    var counter = 0;
-    feed.each(function(error, change) {
-      assert(typeof change.new_offset === 'number');
-      if (counter >= 2) {
-        assert(typeof change.old_offset === 'number');
-        feed.close().then(function() {
-          done();
-        }).error(done);
-      }
-      counter++;
-    });
+    let counter = 0
 
-    yield r.db(dbName).table(tableName).insert({id: 0});
+    const promise = new Promise((resolve, reject) => {
+      feed.each(function (error, change) {
+        if (error) reject(error)
+        assert(typeof change.new_offset === 'number')
+        if (counter >= 2) {
+          assert(typeof change.old_offset === 'number')
 
-    //done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+          feed.close().then(resolve).error(reject)
+        }
+        counter++
+      })
+    })
 
-It('`changes` with `includeTypes` should work', function* (done) {
-  try {
-    feed = yield r.db(dbName).table(tableName).orderBy({index: 'id'}).limit(2).changes({
+    await r.db(dbName).table(tableName).insert({id: 0})
+    await promise
+  })
+
+  it('`changes` with `includeTypes` should work', async () => {
+    feed = await r.db(dbName).table(tableName).orderBy({index: 'id'}).limit(2).changes({
       includeTypes: true,
       includeInitial: true
-    }).run();
+    }).run()
 
-    var counter = 0;
-    feed.each(function(error, change) {
-      assert(typeof change.type === 'string');
-      if (counter > 0) {
-        feed.close().then(function() {
-          done();
-        }).error(done);
+    let counter = 0
+
+    const promise = new Promise((resolve, reject) => {
+      feed.each(function (error, change) {
+        if (error) reject(error)
+        assert(typeof change.type === 'string')
+        if (counter > 0) {
+          feed.close().then(resolve).error(reject)
+        }
+        counter++
+      })
+    })
+
+    result = await r.db(dbName).table(tableName).insert({id: 0})
+    assert.equal(result.errors, 1) // Duplicate primary key (depends on previous test case)
+    await promise
+  })
+
+  it('`next` should work on a feed', async () => {
+    feed = await r.db(dbName).table(tableName2).changes().run()
+    assert(feed)
+
+    const promise = new Promise((resolve, reject) => {
+      let i = 0
+      while (true) {
+        feed.next().then(assert)
+        i++
+        if (i === smallNumDocs) {
+          return feed.close().then(resolve).catch(reject)
+        }
       }
-      counter++;
-    });
+    })
 
-    yield r.db(dbName).table(tableName).insert({id: 0});
+    await r.db(dbName).table(tableName2).update({foo: r.now()}).run()
+    await promise
+  })
 
-    //done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+  it('`next` should work on an atom feed', async () => {
+    let idValue = uuid()
+    feed = await r.db(dbName).table(tableName2).get(idValue).changes({includeInitial: true}).run()
+    assert(feed)
 
+    const promise = new Promise((resolve, reject) => {
+      feed.next()
+        .then((result) => assert.deepEqual(result, {new_val: null}))
+        .then(() => feed.next())
+        .then((result) => assert.deepEqual(result, {new_val: {id: idValue}, old_val: null}))
+        .then(resolve)
+        .catch(reject)
+    })
 
-It('`next` should work on a feed', function* (done) {
-  try {
-    yield util.sleep(1000);
-    feed = yield r.db(dbName).table(tableName2).changes().run();
-    setTimeout(function() {
-      r.db(dbName).table(tableName2).update({foo: r.now()}).run();
-    }, 100)
-    assert(feed);
-    var i=0;
-    while(true) {
-      result = yield feed.next();
-      assert(result);
-      i++;
-      if (i === smallNumDocs) {
-        yield feed.close();
-        done();
-        break;
-      }
+    await r.db(dbName).table(tableName2).insert({id: idValue}).run()
+    await promise
+    await feed.close()
+  })
+
+  it('`close` should work on feed', async () => {
+    feed = await r.db(dbName).table(tableName2).changes().run()
+    assert(feed)
+
+    await feed.close()
+  })
+
+  it('`close` should work on feed with events', async () => {
+    feed = await r.db(dbName).table(tableName2).changes().run()
+
+    const promise = new Promise((resolve, reject) => {
+      feed.on('error', reject)
+      feed.on('end', resolve)
+    })
+
+    await feed.close()
+    await promise
+  })
+
+  it('`on` should work on feed', async () => {
+    feed = await r.db(dbName).table(tableName2).changes().run()
+    assert(feed)
+
+    const promise = new Promise((resolve, reject) => {
+      let i = 0
+      feed.on('data', function () {
+        i++
+        if (i === smallNumDocs) {
+          feed.close().then(resolve).error(reject)
+        }
+      })
+      feed.on('error', reject)
+    })
+
+    await r.db(dbName).table(tableName2).update({foo: r.now()}).run()
+    await promise
+  })
+
+  it('`on` should work on cursor - a `end` event shoul be eventually emitted on a cursor', async () => {
+    cursor = await r.db(dbName).table(tableName2).run({cursor: true})
+    assert(cursor)
+
+    const promise = new Promise((resolve, reject) => {
+      cursor.on('end', resolve)
+      cursor.on('error', reject)
+    })
+
+    await r.db(dbName).table(tableName2).update({foo: r.now()}).run()
+    await promise
+  })
+
+  it('`next`, `each`, `toArray` should be deactivated if the EventEmitter interface is used', async () => {
+    feed = await r.db(dbName).table(tableName2).changes().run()
+
+    feed.on('data', () => {})
+    feed.on('error', assert.fail)
+
+    try {
+      feed.next()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message === 'You cannot call `next` once you have bound listeners on the Feed.')
+      await feed.close()
     }
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`next` should work on an atom feed', function* (done) {
-  try {
-    var idValue = uuid();
-    feed = yield r.db(dbName).table(tableName2).get(idValue).changes({includeInitial: true}).run();
-    setTimeout(function() {
-      r.db(dbName).table(tableName2).insert({id: idValue}).run();
-    }, 100)
-    assert(feed);
-    var i=0;
-    var change = yield feed.next();
-    assert.deepEqual(change, {new_val: null});
-    change = yield feed.next();
-    assert.deepEqual(change, {new_val: {id: idValue}, old_val: null});
-    yield feed.close();
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+  it('Import with cursor as default', async () => {
+    await util.sleep(2000)
+    const r1 = rethinkdbdash({cursor: true, host: config.host, port: config.port, authKey: config.authKey, buffer: config.buffer, max: config.max, silent: true})
 
-It('`close` should work on feed', function* (done) {
-  try {
-    feed = yield r.db(dbName).table(tableName2).changes().run();
-    setTimeout(function() {
-      feed.close().then(function() {
-        done();
-      });
-    }, 1000)
-    assert(feed);
-  }
-  catch(e) {
-    done(e);
-  }
-})
+    cursor = await r1.db(dbName).table(tableName).run()
+    assert.equal(cursor.toString(), '[object Cursor]')
+    await cursor.close().then().catch(assert.fail)
+  })
 
-It('`close` should work on feed with events', function* (done) {
-  try {
-    feed = yield r.db(dbName).table(tableName2).changes().run();
-    setTimeout(function() {
-      feed.close();
-    }, 1000)
-    assert(feed);
-    feed.on('error', function() {
-      // Ignore the error
-    });
-    feed.on('end', function() {
-      done();
-    });
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`on` should work on feed', function* (done) {
-  try {
-    feed = yield r.db(dbName).table(tableName2).changes().run();
-    setTimeout(function() {
-      r.db(dbName).table(tableName2).update({foo: r.now()}).run();
-    }, 100)
-    var i=0;
-    feed.on('data', function() {
-      i++;
-      if (i === smallNumDocs) {
-        feed.close().then(function() {
-          done();
-        }).error(function(error) {
-          done(error);
-        });
-      }
-    });
-    feed.on('error', function(e) {
-      done(e)
+  it('`each` should not return an error if the feed is closed - 1', async () => {
+    feed = await r.db(dbName).table(tableName2).changes().run()
+    assert(feed)
+
+    const promise = new Promise((resolve, reject) => {
+      let count = 0
+      feed.each(function (err, result) {
+        if (err) reject(err)
+        if (result.new_val.foo instanceof Date) {
+          count++
+        }
+        if (count === 1) {
+          setTimeout(function () {
+            feed.close().then(resolve).error(reject)
+          }, 100)
+        }
+      })
     })
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`on` should work on cursor - a `end` event shoul be eventually emitted on a cursor', function* (done) {
-  try {
-    cursor = yield r.db(dbName).table(tableName2).run({cursor: true});
-    setTimeout(function() {
-      r.db(dbName).table(tableName2).update({foo: r.now()}).run();
-    }, 100)
-    cursor.on('end', function() {
-      done()
-    });
-    cursor.on('error', function(e) {
-      done(e)
+
+    await r.db(dbName).table(tableName2).limit(2).update({foo: r.now()}).run()
+    await promise
+  })
+
+  it('`each` should not return an error if the feed is closed - 2', async () => {
+    feed = await r.db(dbName).table(tableName2).changes().run()
+    assert(feed)
+
+    const promise = new Promise((resolve, reject) => {
+      let count = 0
+      feed.each(function (err, result) {
+        if (err) reject(err)
+        if (result.new_val.foo instanceof Date) {
+          count++
+        }
+        if (count === 2) {
+          setTimeout(function () {
+            feed.close().then(resolve).error(reject)
+          }, 100)
+        }
+      })
     })
-  }
-  catch(e) {
-    done(e);
-  }
-})
+    await r.db(dbName).table(tableName2).limit(2).update({foo: r.now()}).run()
+    await promise
+  })
 
-It('`next`, `each`, `toArray` should be deactivated if the EventEmitter interface is used', function* (done) {
-  try {
-    feed = yield r.db(dbName).table(tableName2).changes().run();
-    setTimeout(function() {
-      r.db(dbName).table(tableName2).update({foo: r.now()}).run();
-    }, 100)
-    feed.on('data', function() { });
-    feed.on('error', function(error) {
-      done(error);
-    });
-    assert.throws(function() {
-      feed.next();
-    }, function(e) {
-      if (e.message === 'You cannot call `next` once you have bound listeners on the Feed.') {
-        feed.close().then(function() {
-          done();
-        }).error(function(error) {
-          done(error);
-        });
-      }
-      else {
-        done(e);
-      }
-      return true;
+  it('events should not return an error if the feed is closed - 1', async () => {
+    feed = await r.db(dbName).table(tableName2).get(1).changes().run()
+    assert(feed)
+
+    const promise = new Promise((resolve, reject) => {
+      feed.each(function (err, result) {
+        if (err) reject(err)
+        if ((result.new_val != null) && (result.new_val.id === 1)) {
+          feed.close().then(resolve).error(reject)
+        }
+      })
     })
-  }
-  catch(e) {
-    done(e);
-  }
-})
+    await r.db(dbName).table(tableName2).insert({id: 1}).run()
+    await promise
+  })
 
-It('Import with cursor as default', function* (done) {
-  yield util.sleep(1000);
-  var r1 = require('../lib')({cursor: true, host: config.host, port: config.port, authKey: config.authKey, buffer: config.buffer, max: config.max, silent: true});
-  var i=0;
-  try {
-    cursor = yield r1.db(dbName).table(tableName).run();
-    assert.equal(cursor.toString(), '[object Cursor]');
-    yield cursor.close();
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`each` should not return an error if the feed is closed - 1', function* (done) {
-  try {
-    feed = yield r.db(dbName).table(tableName2).changes().run();
-    setTimeout(function() {
-      r.db(dbName).table(tableName2).limit(2).update({foo: r.now()}).run();
-    }, 100)
-    var count = 0;
-    feed.each(function(err, result) {
-      if (result.new_val.foo instanceof Date) {
-        count++;
-      }
-      if (count === 1) {
-        setTimeout(function() {
-          feed.close().then(function() {
-            done();
-          }).error(done);
-        }, 100);
-      }
-    });
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`each` should not return an error if the feed is closed - 2', function* (done) {
-  try {
-    feed = yield r.db(dbName).table(tableName2).changes().run();
-    setTimeout(function() {
-      r.db(dbName).table(tableName2).limit(2).update({foo: r.now()}).run();
-    }, 100)
-    var count = 0;
-    feed.each(function(err, result) {
-      if (result.new_val.foo instanceof Date) {
-        count++;
-      }
-      if (count === 2) {
-        setTimeout(function() {
-          feed.close().then(function() {
-            done();
-          }).error(done);
-        }, 100);
-      }
-    });
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('events should not return an error if the feed is closed - 1', function* (done) {
-  try {
-    feed = yield r.db(dbName).table(tableName2).get(1).changes().run();
-    setTimeout(function() {
-      r.db(dbName).table(tableName2).insert({id: 1}).run();
-    }, 100)
-    feed.each(function(err, result) {
-      if (err) {
-        return done(err);
-      }
-      if ((result.new_val != null) && (result.new_val.id === 1)) {
-        feed.close().then(function() {
-          done();
-        }).error(done);
-      }
-    });
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('events should not return an error if the feed is closed - 2', function* (done) {
-  try {
-    feed = yield r.db(dbName).table(tableName2).changes().run();
-    setTimeout(function() {
-      r.db(dbName).table(tableName2).limit(2).update({foo: r.now()}).run();
-    },100)
-    var count = 0;
-    feed.on('data', function(result) {
-      if (result.new_val.foo instanceof Date) {
-        count++;
-      }
-      if (count === 1) {
-        setTimeout(function() {
-          feed.close().then(function() {
-            done();
-          }).error(done);
-        }, 100);
-      }
-    });
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`includeStates` should work', function* (done) {
-  try {
-    feed = yield r.db(dbName).table(tableName).orderBy({index: 'id'}).limit(10).changes({includeStates: true, includeInitial: true}).run();
-    var i = 0;
-    feed.each(function(err, change) {
-      i++;
-      if (i === 10) {
-        feed.close();
-        done();
-      }
-    });
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`each` should return an error if the connection dies', function* (done) {
-  var connection = yield r.connect({host: config.host, port: config.port, authKey: config.authKey});
-  assert(connection);
+  it('events should not return an error if the feed is closed - 2', async () => {
+    feed = await r.db(dbName).table(tableName2).changes().run()
+    assert(feed)
 
-  var feed = yield r.db(dbName).table(tableName).changes().run(connection);
-  feed.each(function(err, change) {
-    assert(err.message.match(/^The connection was closed before the query could be completed for/))
-    done();
-  });
-  // Kill the TCP connection
-  connection.connection.end()
-})
-It('`eachAync` should return an error if the connection dies', function* (done) {
-  var connection = yield r.connect({host: config.host, port: config.port, authKey: config.authKey});
-  assert(connection);
+    const promise = new Promise((resolve, reject) => {
+      let count = 0
+      feed.on('data', function (result) {
+        if (result.new_val.foo instanceof Date) {
+          count++
+        }
+        if (count === 1) {
+          setTimeout(function () {
+            feed.close().then(resolve).error(reject)
+          }, 100)
+        }
+      })
+    })
+    await r.db(dbName).table(tableName2).limit(2).update({foo: r.now()}).run()
+    await promise
+  })
 
-  var feed = yield r.db(dbName).table(tableName).changes().run(connection);
-  feed.eachAsync(function(change) {}).error(function(err) {
-    assert(err.message.match(/^The connection was closed before the query could be completed for/))
-    done();
-  });
-  // Kill the TCP connection
-  connection.connection.end()
-})
-It('`asyncIterator` should return an async iterator', function* (done) {
-  try {
-    var connection = yield r.connect({host: config.host, port: config.port, authKey: config.authKey});
-    assert(connection);
+  it('`includeStates` should work', async () => {
+    feed = await r.db(dbName).table(tableName).orderBy({index: 'id'}).limit(10).changes({includeStates: true, includeInitial: true}).run()
+    var i = 0
 
-    var feed = yield r.db(dbName).table(tableName).changes().run(connection);
-    var iterator = feed.asyncIterator();
-    assert(iterall.isAsyncIterable(iterator))
+    await new Promise((resolve, reject) => {
+      feed.each(function (err, change) {
+        if (err) reject(err)
+        i++
+        if (i === 10) {
+          feed.close().then(resolve).error(reject)
+        }
+      })
+    })
+  })
+
+  it('`each` should return an error if the connection dies', async () => {
+    connection = await r.connect({host: config.host, port: config.port, authKey: config.authKey})
+    assert(connection)
+
+    var feed = await r.db(dbName).table(tableName).changes().run(connection)
+
+    feed.each(function (err, change) {
+      assert(err.message.match(/^The connection was closed before the query could be completed for/))
+    })
+    // Kill the TCP connection
     connection.connection.end()
-    done();
-  } catch(err) {
-    done(err);
-  }
-})
-It('`asyncIterator` should have a working `next`method', function* (done) {
-  try {
-    feed = yield r.db(dbName).table(tableName2).changes().run();
-    var value = 1;
-    setTimeout(function() {
-      r.db(dbName).table(tableName2).update({foo: value}).run();
-    }, 100)
-    assert(feed);
-    var iterator = feed.asyncIterator();
-    assert(iterator);
-    var i=0;
-    var result = yield iterator.next();
-    assert(result.value.new_val.foo === value);
-    done();
-  } catch(err) {
-    done(err);
-  }
+  })
+
+  it('`eachAsync` should return an error if the connection dies', async () => {
+    connection = await r.connect({host: config.host, port: config.port, authKey: config.authKey})
+    assert(connection)
+
+    var feed = await r.db(dbName).table(tableName).changes().run(connection)
+    feed.eachAsync(function (change) {}).error(function (err) {
+      assert(err.message.match(/^The connection was closed before the query could be completed for/))
+    })
+    // Kill the TCP connection
+    connection.connection.end()
+  })
+
+  it('`asyncIterator` should return an async iterator', async () => {
+    connection = await r.connect({host: config.host, port: config.port, authKey: config.authKey})
+    assert(connection.open)
+
+    const feed = await r.db(dbName).table(tableName).changes().run(connection)
+    assert(feed)
+
+    const iterator = feed.asyncIterator()
+    assert(iterall.isAsyncIterable(iterator))
+    // Kill the TCP connection
+    connection.connection.end()
+  })
+
+  it('`asyncIterator` should have a working `next`method', async () => {
+    feed = await r.db(dbName).table(tableName2).changes().run()
+    assert(feed)
+
+    const value = 1
+    const iterator = feed.asyncIterator()
+    assert(iterator)
+
+    const promise = new Promise((resolve, reject) => {
+      iterator.next().then(resolve).catch(reject)
+    })
+
+    await r.db(dbName).table(tableName2).update({foo: value}).run()
+    result = await promise
+    assert(result.value.new_val.foo === value)
+  })
 })

--- a/test/dates-and-times.js
+++ b/test/dates-and-times.js
@@ -1,485 +1,293 @@
-var config = require(__dirname+'/config.js');
-var r = require(__dirname+'/../lib')(config);
-var util = require(__dirname+'/util/common.js');
-var assert = require('assert');
+const path = require('path')
+const config = require('./config.js')
+const rethinkdbdash = require(path.join(__dirname, '/../lib'))
+const assert = require('assert')
 
-var uuid = util.uuid;
-var It = util.It;
+const {before, after, describe, it} = require('mocha')
 
-var uuid = util.uuid;
-var dbName, tableName, result, result2;
+describe('dates and times', () => {
+  let r
 
+  before(async () => {
+    r = await rethinkdbdash(config)
+  })
 
-It('`r.now` should return a date', function* (done) {
-  try {
-    result = yield r.now().run();
-    assert(result instanceof Date);
+  after(async () => {
+    await r.getPoolMaster().drain()
+  })
 
-    result = yield r.expr({a: r.now()}).run();
-    assert(result.a instanceof Date);
+  it('`r.now` should return a date', async () => {
+    let result = await r.now().run()
+    assert(result instanceof Date)
 
-    result = yield r.expr([r.now()]).run();
-    assert(result[0] instanceof Date);
+    result = await r.expr({a: r.now()}).run()
+    assert(result.a instanceof Date)
 
-    result = yield r.expr([{}, {a: r.now()}]).run();
-    assert(result[1].a instanceof Date);
+    result = await r.expr([r.now()]).run()
+    assert(result[0] instanceof Date)
 
-    result = yield r.expr({b: [{}, {a: r.now()}]}).run();
-    assert(result.b[1].a instanceof Date);
+    result = await r.expr([{}, {a: r.now()}]).run()
+    assert(result[1].a instanceof Date)
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`now` is not defined after a term', function* (done) {
-  try {
-    result = yield r.expr(1).now("foo").run();
-  }
-  catch(e) {
-    if (e.message === "`now` is not defined after:\nr.expr(1)") {
-      done()
+    result = await r.expr({b: [{}, {a: r.now()}]}).run()
+    assert(result.b[1].a instanceof Date)
+  })
+
+  it('`now` is not defined after a term', async () => {
+    try {
+      await r.expr(1).now('foo').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`now` is not defined after:\nr.expr(1)')
     }
-    else {
-      done(e)
-    }
-  }
-})
+  })
 
-It('`r.time` should return a date -- with date and time', function* (done) {
-  try{
-    var now = new Date();
-    var result = yield r.time(1986, 11, 3, 12, 0, 0, 'Z').run();
+  it('`r.time` should return a date -- with date and time', async () => {
+    let result = await r.time(1986, 11, 3, 12, 0, 0, 'Z').run()
     assert.equal(result instanceof Date, true)
 
-    result = yield r.time(1986, 11, 3, 12, 20, 0, 'Z').minutes().run();
+    result = await r.time(1986, 11, 3, 12, 20, 0, 'Z').minutes().run()
     assert.equal(result, 20)
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-
-It('`r.time` should work with r.args', function* (done) {
-  try{
-    var now = new Date();
-    var result = yield r.time(r.args([1986, 11, 3, 12, 0, 0, 'Z'])).run();
+  it('`r.time` should work with r.args', async () => {
+    const result = await r.time(r.args([1986, 11, 3, 12, 0, 0, 'Z'])).run()
     assert.equal(result instanceof Date, true)
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-
-It('`r.time` should return a date -- just with a date', function* (done) {
-  try {
-    var result = yield r.time(1986, 11, 3, 'Z').run();
-    var result2 = yield r.time(1986, 11, 3, 0, 0, 0, 'Z').run();
+  it('`r.time` should return a date -- just with a date', async () => {
+    let result = await r.time(1986, 11, 3, 'Z').run()
     assert.equal(result instanceof Date, true)
+    result = await r.time(1986, 11, 3, 0, 0, 0, 'Z').run()
+    assert.equal(result instanceof Date, true)
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`r.time` should throw if no argument has been given', function* (done) {
-  try{
-    var result = yield r.time().run();
-  }
-  catch(e) {
-    if (e.message === "`r.time` called with 0 argument.\n`r.time` takes 4 or 7 arguments") {
-      done()
+  it('`r.time` should throw if no argument has been given', async () => {
+    try {
+      await r.time().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`r.time` called with 0 argument.\n`r.time` takes 4 or 7 arguments')
     }
-    else{
-      done(e);
-    }
-  }
-})
-It('`r.time` should throw if no 5 arguments', function* (done) {
-  try{
-    var result = yield r.time(1, 1, 1, 1, 1).run();
-  }
-  catch(e) {
-    if (e.message === "`r.time` called with 5 arguments.\n`r.time` takes 4 or 7 arguments") {
-      done()
-    }
-    else{
-      done(e);
-    }
-  }
-})
+  })
 
-It('`time` is not defined after a term', function* (done) {
-  try {
-    result = yield r.expr(1).time(1, 2, 3, 'Z').run();
-  }
-  catch(e) {
-    if (e.message === "`time` is not defined after:\nr.expr(1)") {
-      done()
+  it('`r.time` should throw if no 5 arguments', async () => {
+    try {
+      await r.time(1, 1, 1, 1, 1).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`r.time` called with 5 arguments.\n`r.time` takes 4 or 7 arguments')
     }
-    else {
-      done(e)
-    }
-  }
-})
+  })
 
-It('`epochTime` should work', function* (done) {
-  try {
-    var now = new Date();
-    result = yield r.epochTime(now.getTime()/1000).run();
-    assert.deepEqual(now, result);
+  it('`time` is not defined after a term', async () => {
+    try {
+      await r.expr(1).time(1, 2, 3, 'Z').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`time` is not defined after:\nr.expr(1)')
+    }
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`r.epochTime` should throw if no argument has been given', function* (done) {
-  try{
-    var result = yield r.epochTime().run();
-  }
-  catch(e) {
-    if (e.message === "`r.epochTime` takes 1 argument, 0 provided.") {
-      done()
-    }
-    else{
-      done(e);
-    }
-  }
-})
-It('`epochTime` is not defined after a term', function* (done) {
-  try {
-    result = yield r.expr(1).epochTime(Date.now()).run();
-  }
-  catch(e) {
-    if (e.message === "`epochTime` is not defined after:\nr.expr(1)") {
-      done()
-    }
-    else {
-      done(e)
-    }
-  }
-})
+  it('`epochTime` should work', async () => {
+    const now = new Date()
+    const result = await r.epochTime(now.getTime() / 1000).run()
+    assert.deepEqual(now, result)
+  })
 
-It('`ISO8601` should work', function* (done) {
-  try {
-    var result = yield r.ISO8601("1986-11-03T08:30:00-08:00").run();
-    assert(result, new Date(1986, 11, 3, 8, 30, 0, -8));
+  it('`r.epochTime` should throw if no argument has been given', async () => {
+    try {
+      await r.epochTime().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`r.epochTime` takes 1 argument, 0 provided.')
+    }
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`ISO8601` should work with a timezone', function* (done) {
-  try {
-    var result = yield r.ISO8601("1986-11-03T08:30:00", {defaultTimezone: "-08:00"}).run();
-    assert(result, new Date(1986, 11, 3, 8, 30, 0, -8));
+  it('`epochTime` is not defined after a term', async () => {
+    try {
+      await r.expr(1).epochTime(Date.now()).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`epochTime` is not defined after:\nr.expr(1)')
+    }
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`r.ISO8601` should throw if no argument has been given', function* (done) {
-  try{
-    var result = yield r.ISO8601().run();
-  }
-  catch(e) {
-    if (e.message === "`r.ISO8601` takes at least 1 argument, 0 provided.") {
-      done()
-    }
-    else{
-      done(e);
-    }
-  }
-})
-It('`r.ISO8601` should throw if too many arguments', function* (done) {
-  try{
-    var result = yield r.ISO8601(1, 1, 1).run();
-  }
-  catch(e) {
-    if (e.message === "`r.ISO8601` takes at most 2 arguments, 3 provided.") {
-      done()
-    }
-    else{
-      done(e);
-    }
-  }
-})
+  it('`ISO8601` should work', async () => {
+    const result = await r.ISO8601('1986-11-03T08:30:00-08:00').run()
+    assert(result, new Date(1986, 11, 3, 8, 30, 0, -8))
+  })
 
-It('`ISO8601` is not defined after a term', function* (done) {
-  try {
-    result = yield r.expr(1).ISO8601('validISOstring').run();
-  }
-  catch(e) {
-    if (e.message === "`ISO8601` is not defined after:\nr.expr(1)") {
-      done()
-    }
-    else {
-      done(e)
-    }
-  }
-})
+  it('`ISO8601` should work with a timezone', async () => {
+    const result = await r.ISO8601('1986-11-03T08:30:00', {defaultTimezone: '-08:00'}).run()
+    assert(result, new Date(1986, 11, 3, 8, 30, 0, -8))
+  })
 
-It('`inTimezone` should work', function* (done) {
-  try {
-    var result = yield r.now().inTimezone('-08:00').hours().do(function(h) {
+  it('`r.ISO8601` should throw if no argument has been given', async () => {
+    try {
+      await r.ISO8601().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`r.ISO8601` takes at least 1 argument, 0 provided.')
+    }
+  })
+
+  it('`r.ISO8601` should throw if too many arguments', async () => {
+    try {
+      await r.ISO8601(1, 1, 1).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`r.ISO8601` takes at most 2 arguments, 3 provided.')
+    }
+  })
+
+  it('`ISO8601` is not defined after a term', async () => {
+    try {
+      await r.expr(1).ISO8601('validISOstring').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`ISO8601` is not defined after:\nr.expr(1)')
+    }
+  })
+
+  it('`inTimezone` should work', async () => {
+    const result = await r.now().inTimezone('-08:00').hours().do(function (h) {
       return r.branch(
         h.eq(0),
         r.expr(23).eq(r.now().inTimezone('-09:00').hours()),
         h.eq(r.now().inTimezone('-09:00').hours().add(1))
       )
     }).run()
-    assert.equal(result, true);
+    assert.equal(result, true)
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`inTimezone` should throw if no argument has been given', function* (done) {
-  try{
-    var result = yield r.now().inTimezone().run();
-  }
-  catch(e) {
-    if (e.message === "`inTimezone` takes 1 argument, 0 provided after:\nr.now()") {
-      done()
+  it('`inTimezone` should throw if no argument has been given', async () => {
+    try {
+      await r.now().inTimezone().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`inTimezone` takes 1 argument, 0 provided after:\nr.now()')
     }
-    else{
-      done(e);
+  })
+
+  it('`timezone` should work', async () => {
+    const result = await r.ISO8601('1986-11-03T08:30:00-08:00').timezone().run()
+    assert.equal(result, '-08:00')
+  })
+
+  it('`during` should work', async () => {
+    let result = await r.now().during(r.time(2013, 12, 1, 'Z'), r.now().add(1000)).run()
+    assert.equal(result, true)
+
+    result = await r.now().during(r.time(2013, 12, 1, 'Z'), r.now(), {
+      leftBound: 'closed',
+      rightBound: 'closed'
+    }).run()
+    assert.equal(result, true)
+
+    result = await r.now().during(r.time(2013, 12, 1, 'Z'), r.now(), {
+      leftBound: 'closed',
+      rightBound: 'open'
+    }).run()
+    assert.equal(result, false)
+  })
+
+  it('`during` should throw if no argument has been given', async () => {
+    try {
+      await r.now().during().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`during` takes at least 2 arguments, 0 provided after:\nr.now()')
     }
-  }
-})
+  })
 
-It('`timezone` should work', function* (done) {
-  try {
-    var result = yield r.ISO8601("1986-11-03T08:30:00-08:00").timezone().run();
-    assert.equal(result, "-08:00");
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-
-It('`during` should work', function* (done) {
-  try {
-    var result = yield r.now().during(r.time(2013, 12, 1, "Z"), r.now().add(1000)).run();
-    assert.equal(result, true);
-
-    result = yield r.now().during(r.time(2013, 12, 1, "Z"), r.now(), {leftBound: "closed", rightBound: "closed"}).run();
-    assert.equal(result, true);
-
-    result = yield r.now().during(r.time(2013, 12, 1, "Z"), r.now(), {leftBound: "closed", rightBound: "open"}).run();
-    assert.equal(result, false);
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`during` should throw if no argument has been given', function* (done) {
-  try{
-    var result = yield r.now().during().run();
-  }
-  catch(e) {
-    if (e.message === "`during` takes at least 2 arguments, 0 provided after:\nr.now()") {
-      done()
+  it('`during` should throw if just one argument has been given', async () => {
+    try {
+      await r.now().during(1).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`during` takes at least 2 arguments, 1 provided after:\nr.now()')
     }
-    else{
-      done(e);
+  })
+
+  it('`during` should throw if too many arguments', async () => {
+    try {
+      await r.now().during(1, 1, 1, 1, 1).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`during` takes at most 3 arguments, 5 provided after:\nr.now()')
     }
-  }
-})
-It('`during` should throw if just one argument has been given', function* (done) {
-  try{
-    var result = yield r.now().during(1).run();
-  }
-  catch(e) {
-    if (e.message === "`during` takes at least 2 arguments, 1 provided after:\nr.now()") {
-      done()
-    }
-    else{
-      done(e);
-    }
-  }
-})
-It('`during` should throw if too many arguments', function* (done) {
-  try{
-    var result = yield r.now().during(1, 1, 1, 1, 1).run();
-  }
-  catch(e) {
-    if (e.message === "`during` takes at most 3 arguments, 5 provided after:\nr.now()") {
-      done()
-    }
-    else{
-      done(e);
-    }
-  }
-})
+  })
 
-It('`date` should work', function* (done) {
-  try {
-    var result = yield r.now().date().hours().run();
-    assert.equal(result, 0);
-    result = yield r.now().date().minutes().run();
-    assert.equal(result, 0);
-    result = yield r.now().date().seconds().run();
-    assert.equal(result, 0);
+  it('`date` should work', async () => {
+    let result = await r.now().date().hours().run()
+    assert.equal(result, 0)
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+    result = await r.now().date().minutes().run()
+    assert.equal(result, 0)
 
-It('`timeOfDay` should work', function* (done) {
-  try {
-    var result = yield r.now().timeOfDay().run();
-    assert(result>=0);
+    result = await r.now().date().seconds().run()
+    assert.equal(result, 0)
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+  it('`timeOfDay` should work', async () => {
+    const result = await r.now().timeOfDay().run()
+    assert(result >= 0)
+  })
 
-It('`year` should work', function* (done) {
-  try {
-    var result = yield r.now().inTimezone(new Date().toString().match(' GMT([^ ]*)')[1]).year().run();
-    assert.equal(result, new Date().getFullYear());
+  it('`year` should work', async () => {
+    const result = await r.now().inTimezone(new Date().toString().match(' GMT([^ ]*)')[1]).year().run()
+    assert.equal(result, new Date().getFullYear())
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+  it('`month` should work', async () => {
+    const result = await r.now().inTimezone(new Date().toString().match(' GMT([^ ]*)')[1]).month().run()
+    assert.equal(result, new Date().getMonth() + 1)
+  })
 
-It('`month` should work', function* (done) {
-  try {
-    var result = yield r.now().inTimezone(new Date().toString().match(' GMT([^ ]*)')[1]).month().run();
-    assert.equal(result, new Date().getMonth()+1);
+  it('`day` should work', async () => {
+    const result = await r.now().inTimezone(new Date().toString().match(' GMT([^ ]*)')[1]).day().run()
+    assert.equal(result, new Date().getDate())
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+  it('`dayOfYear` should work', async () => {
+    const result = await r.now().inTimezone(new Date().toString().match(' GMT([^ ]*)')[1]).dayOfYear().run()
+    assert(result > (new Date()).getMonth() * 28 + (new Date()).getDate() - 1)
+  })
 
-It('`day` should work', function* (done) {
-  try {
-    var result = yield r.now().inTimezone(new Date().toString().match(' GMT([^ ]*)')[1]).day().run();
-    assert.equal(result, new Date().getDate());
+  it('`dayOfWeek` should work', async () => {
+    let result = await r.now().inTimezone(new Date().toString().match(' GMT([^ ]*)')[1]).dayOfWeek().run()
+    if (result === 7) result = 0
+    assert.equal(result, new Date().getDay())
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+  it('`toISO8601` should work', async () => {
+    const result = await r.now().toISO8601().run()
+    assert.equal(typeof result, 'string')
+  })
 
-It('`dayOfYear` should work', function* (done) {
-  try {
-    var result = yield r.now().inTimezone(new Date().toString().match(' GMT([^ ]*)')[1]).dayOfYear().run();
-    assert(result > (new Date()).getMonth()*28+(new Date()).getDate()-1);
+  it('`toEpochTime` should work', async () => {
+    const result = await r.now().toEpochTime().run()
+    assert.equal(typeof result, 'number')
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-
-It('`dayOfWeek` should work', function* (done) {
-  try {
-    var result = yield r.now().inTimezone(new Date().toString().match(' GMT([^ ]*)')[1]).dayOfWeek().run();
-    if (result === 7) result = 0;
-    assert.equal(result, new Date().getDay());
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-
-It('`toISO8601` should work', function* (done) {
-  try {
-    var result = yield r.now().toISO8601().run();
-    assert.equal(typeof result, "string");
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-
-It('`toEpochTime` should work', function* (done) {
-  try {
-    var result = yield r.now().toEpochTime().run();
-    assert.equal(typeof result, "number");
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-
-It('Constant terms should work', function* (done) {
-  try {
-    var result = yield r.monday.run();
+  it('Constant terms should work', async () => {
+    let result = await r.monday.run()
     assert.equal(result, 1)
 
-    result = yield r.expr([r.monday, r.tuesday, r.wednesday, r.thursday, r.friday, r.saturday, r.sunday, r.january, r.february, r.march, r.april, r.may, r.june, r.july, r.august, r.september, r.october, r.november, r.december]).run();
-    assert.deepEqual(result, [1,2,3,4,5,6,7, 1,2,3,4,5,6,7,8,9,10,11,12]);
+    result = await r.expr([r.monday, r.tuesday, r.wednesday, r.thursday, r.friday, r.saturday, r.sunday, r.january, r.february, r.march, r.april, r.may, r.june, r.july, r.august, r.september, r.october, r.november, r.december]).run()
+    assert.deepEqual(result, [1, 2, 3, 4, 5, 6, 7, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+  it('`epochTime` should work', async () => {
+    const now = new Date()
+    const result = await r.epochTime(now.getTime() / 1000).run({timeFormat: 'raw'})
+    assert.equal(result.$reql_type$, 'TIME')
+  })
 
-It('`epochTime` should work', function* (done) {
-  try {
-    var now = new Date();
-    result = yield r.epochTime(now.getTime()/1000).run({timeFormat: "raw"});
-    assert.equal(result.$reql_type$, "TIME")
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-
-It('`ISO8601` run parameter should work', function* (done) {
-  try {
-    result = yield r.time(2018,5,2,13,0,0,"-03:00").run({timeFormat: "ISO8601"});
-    assert.equal(typeof result, "string");
-    assert.equal(result, "2018-05-02T13:00:00.000-03:00")
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
+  it('`ISO8601` run parameter should work', async () => {
+    const result = await r.time(2018, 5, 2, 13, 0, 0, '-03:00').run({timeFormat: 'ISO8601'})
+    assert.equal(typeof result, 'string')
+    assert.equal(result, '2018-05-02T13:00:00.000-03:00')
+  })
 })

--- a/test/datum.js
+++ b/test/datum.js
@@ -1,251 +1,172 @@
-var config = require(__dirname+'/config.js');
-var r = require(__dirname+'/../lib')(config);
-var util = require(__dirname+'/util/common.js');
-var assert = require('assert');
+const path = require('path')
+const config = require('./config.js')
+const rethinkdbdash = require(path.join(__dirname, '/../lib'))
+const assert = require('assert')
 
-var uuid = util.uuid;
-var It = util.It;
+const {before, after, afterEach, describe, it} = require('mocha')
 
-var uuid = util.uuid;
-var dbName, tableName, result;
+describe('datum', function () {
+  let r
 
+  before(async () => {
+    r = await rethinkdbdash(config)
+  })
 
-It("All raws datum shoul be defined", function* (done) {
-  try {
-    var result = yield r.expr(1).run();
-    assert.equal(result, 1);
+  after(async () => {
+    await r.getPoolMaster().drain()
+  })
 
-    result = yield r.expr(null).run();
-    assert.equal(result, null);
+  it('All raws datum should be defined', async function () {
+    let result = await r.expr(1).run()
+    assert.equal(result, 1)
 
-    result = yield r.expr(false).run();
-    assert.equal(result, false);
+    result = await r.expr(null).run()
+    assert.equal(result, null)
 
-    result = yield r.expr(true).run();
-    assert.equal(result, true);
+    result = await r.expr(false).run()
+    assert.equal(result, false)
 
-    result = yield r.expr("Hello").run();
-    assert.equal(result, "Hello");
+    result = await r.expr(true).run()
+    assert.equal(result, true)
 
-    result = yield r.expr([0, 1, 2]).run();
-    assert.deepEqual(result, [0, 1, 2]);
+    result = await r.expr('Hello').run()
+    assert.equal(result, 'Hello')
 
+    result = await r.expr([0, 1, 2]).run()
+    assert.deepEqual(result, [0, 1, 2])
 
-    result = yield r.expr({a: 0, b: 1}).run();
-    assert.deepEqual(result, {a: 0, b: 1});
+    result = await r.expr({a: 0, b: 1}).run()
+    assert.deepEqual(result, {a: 0, b: 1})
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It("`expr` is not defined after a term", function* (done) {
-  try {
-    result = yield r.expr(1).expr("foo").run();
-  }
-  catch(e) {
-    if (e.message === "`expr` is not defined after:\nr.expr(1)") {
-      done()
+  it('`expr` is not defined after a term', async function () {
+    try {
+      await r.expr(1).expr('foo').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`expr` is not defined after:\nr.expr(1)')
     }
-    else {
-      done(e)
-    }
-  }
-})
-It("`r.expr` should take a nestingLevel value and throw if the nesting level is reached", function* (done) {
-  try {
-    r.expr({a :{b: {c: {d: 1}}}}, 2)
-  }
-  catch(e) {
-    if (e.message === "Nesting depth limit exceeded.\nYou probably have a circular reference somewhere.") {
-      done()
-    }
-    else {
-      done(e);
-    }
-  }
-})
-It("`r.expr` should throw when setNestingLevel is too small", function* (done) {
-  try {
-    r.setNestingLevel(2);
-    var result = yield r.expr({a :{b: {c: {d: 1}}}}).run();
-  }
-  catch(e) {
-    if (e.message === "Nesting depth limit exceeded.\nYou probably have a circular reference somewhere.") {
-      done()
-    }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-It("`r.expr` should work when setNestingLevel set back the value to 100", function* (done) {
-  try {
-    r.setNestingLevel(100);
-    var result = yield r.expr({a :{b: {c: {d: 1}}}}).run();
-    assert.deepEqual(result, {a :{b: {c: {d: 1}}}})
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+  it('`r.expr` should take a nestingLevel value and throw if the nesting level is reached', async function () {
+    try {
+      r.expr({a: {b: {c: {d: 1}}}}, 2)
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, 'Nesting depth limit exceeded.\nYou probably have a circular reference somewhere.')
+    }
+  })
 
-It("`r.expr` should throw when ArrayLimit is too small", function* (done) {
-  try {
-    var result = yield r.expr([0,1,2,3,4,5,6,8,9]).run({arrayLimit: 2});
-    done(new Error("Was expecting an error"))
-  }
-  catch(e) {
-    if (e.message.match(/^Array over size limit `2` in/)) {
-      done()
-    }
-    else {
-      done(e);
-    }
-  }
-})
-It("`r.expr` should throw when ArrayLimit is too small - options in run take precedence", function* (done) {
-  try {
-    r.setArrayLimit(100);
-    var result = yield r.expr([0,1,2,3,4,5,6,8,9]).run({arrayLimit: 2});
-    done(new Error("Was expecting an error"))
-  }
-  catch(e) {
-    if (e.message.match(/^Array over size limit `2` in/)) {
-      done()
-    }
-    else {
-      done(e);
-    }
-  }
-})
+  describe('nesting level', function () {
+    afterEach(() => {
+      r.setNestingLevel(r._nestingLevel)
+    })
 
-It("`r.expr` should throw when setArrayLimit is too small", function* (done) {
-  try {
-    r.setArrayLimit(2);
-    var result = yield r.expr([0,1,2,3,4,5,6,8,9]).run();
-    done(new Error("Was expecting an error"))
-  }
-  catch(e) {
-    if (e.message.match(/^Array over size limit `2` in/)) {
-      done()
-    }
-    else {
-      done(e);
-    }
-  }
-})
+    it('`r.expr` should throw when setNestingLevel is too small', async function () {
+      r.setNestingLevel(2)
+      try {
+        await r.expr({a: {b: {c: {d: 1}}}}).run()
+        assert.fail('should throw')
+      } catch (e) {
+        assert.equal(e.message, 'Nesting depth limit exceeded.\nYou probably have a circular reference somewhere.')
+      }
+    })
 
-It("`r.expr` should work when setArrayLimit set back the value to 100000", function* (done) {
-  try {
-    r.setArrayLimit(100000);
-    var result = yield r.expr([0,1,2,3,4,5,6,8,9]).run();
-    assert.deepEqual(result, [0,1,2,3,4,5,6,8,9])
-    done();
-  }
-  catch(e) {
-    console.log(e);
-    done(e);
-  }
-})
+    it('`r.expr` should work when setNestingLevel set back the value to 100', async function () {
+      r.setNestingLevel(100)
+      const result = await r.expr({a: {b: {c: {d: 1}}}}).run()
+      assert.deepEqual(result, {a: {b: {c: {d: 1}}}})
+    })
+  })
 
-It("`r.expr` should fail with NaN", function* (done) {
-  try {
-    var result = yield r.expr(NaN).run();
-    done(new Error("NaN should throw an error"));
-  }
-  catch(e) {
-    if (e.message.match(/^Cannot convert `NaN` to JSON/)) {
-      done();
-    }
-    else {
-      console.log(e.message);
-      done(e);
-    }
-  }
-})
-It("`r.expr` should not NaN if not run", function* (done) {
-  try {
-    r.expr(NaN);
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+  describe('array limit', function () {
+    afterEach(() => {
+      r.setArrayLimit(r._arrayLimit)
+    })
 
-It("`r.expr` should fail with Infinity", function* (done) {
-  try {
-    var result = yield r.expr(Infinity).run();
-    done(new Error("Infinity should throw an error"));
-  }
-  catch(e) {
-    if (e.message.match(/^Cannot convert `Infinity` to JSON/)) {
-      done();
+    it('`r.expr` should throw when ArrayLimit is too small', async function () {
+      try {
+        await r.expr([0, 1, 2, 3, 4, 5, 6, 8, 9]).run({arrayLimit: 2})
+        assert.fail('should throw')
+      } catch (e) {
+        assert(e.message.match(/^Array over size limit `2` in/))
+      }
+    })
+
+    it('`r.expr` should throw when ArrayLimit is too small - options in run take precedence', async function () {
+      r.setArrayLimit(100)
+      try {
+        await r.expr([0, 1, 2, 3, 4, 5, 6, 8, 9]).run({arrayLimit: 2})
+        assert.fail('should throw')
+      } catch (e) {
+        assert(e.message.match(/^Array over size limit `2` in/))
+      }
+    })
+
+    it('`r.expr` should throw when setArrayLimit is too small', async function () {
+      r.setArrayLimit(2)
+      try {
+        await r.expr([0, 1, 2, 3, 4, 5, 6, 8, 9]).run()
+        assert.fail('shold throw')
+      } catch (e) {
+        assert(e.message.match(/^Array over size limit `2` in/))
+      }
+    })
+
+    it('`r.expr` should work when setArrayLimit set back the value to 100000', async function () {
+      r.setArrayLimit(100000)
+      const result = await r.expr([0, 1, 2, 3, 4, 5, 6, 8, 9]).run()
+      assert.deepEqual(result, [0, 1, 2, 3, 4, 5, 6, 8, 9])
+    })
+  })
+
+  it('`r.expr` should fail with NaN', async function () {
+    try {
+      await r.expr(NaN).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message.match(/^Cannot convert `NaN` to JSON/))
     }
-    else {
-      console.log(e.message);
-      done(e);
+  })
+
+  it('`r.expr` should not NaN if not run', async function () {
+    r.expr(NaN)
+  })
+
+  it('`r.expr` should fail with Infinity', async function () {
+    try {
+      await r.expr(Infinity).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message.match(/^Cannot convert `Infinity` to JSON/))
     }
-  }
-})
-It("`r.expr` should not Infinity if not run", function* (done) {
-  try {
-    r.expr(Infinity);
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It("`r.expr` should work with high unicode char", function* (done) {
-  try {
-    var result = yield r.expr('“').run();
+  })
+
+  it('`r.expr` should not Infinity if not run', async function () {
+    r.expr(Infinity)
+  })
+
+  it('`r.expr` should work with high unicode char', async function () {
+    const result = await r.expr('“').run()
     assert.equal(result, '“')
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It("`r.binary` should work - with a buffer", function* (done) {
-  try {
-    var result = yield r.binary(new Buffer([1,2,3,4,5,6])).run();
-    assert(result instanceof Buffer);
-    assert.deepEqual(result.toJSON().data, [1,2,3,4,5,6]);
-    done();
-  }
-  catch(e) {
-    console.log(e);
-    done(e);
-  }
-})
-It("`r.binary` should work - with a ReQL term", function* (done) {
-  try {
-    var result = yield r.binary(r.expr("foo")).run();
-    assert(result instanceof Buffer);
-    result = yield r.expr(result).coerceTo("STRING").run();
-    assert.equal(result, "foo");
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+  })
 
-It("`r.expr` should work with binaries", function* (done) {
-  try {
-    var result = yield r.expr(new Buffer([1,2,3,4,5,6])).run();
-    assert(result instanceof Buffer);
-    assert.deepEqual(result.toJSON().data, [1,2,3,4,5,6]);
-    done();
-  }
-  catch(e) {
-    console.log(e);
-    done(e);
-  }
-})
+  it('`r.binary` should work - with a buffer', async function () {
+    const result = await r.binary(Buffer.from([1, 2, 3, 4, 5, 6])).run()
+    assert(result instanceof Buffer)
+    assert.deepEqual(result.toJSON().data, [1, 2, 3, 4, 5, 6])
+  })
 
+  it('`r.binary` should work - with a ReQL term', async function () {
+    let result = await r.binary(r.expr('foo')).run()
+    assert(result instanceof Buffer)
+    result = await r.expr(result).coerceTo('STRING').run()
+    assert.equal(result, 'foo')
+  })
+
+  it('`r.expr` should work with binaries', async function () {
+    const result = await r.expr(Buffer.from([1, 2, 3, 4, 5, 6])).run()
+    assert(result instanceof Buffer)
+    assert.deepEqual(result.toJSON().data, [1, 2, 3, 4, 5, 6])
+  })
+})

--- a/test/dequeue.js
+++ b/test/dequeue.js
@@ -1,236 +1,230 @@
-var Dequeue = require(__dirname+'/../lib/dequeue.js')
-var assert = require('assert');
+const path = require('path')
+const Dequeue = require(path.join(__dirname, '/../lib/dequeue.js'))
+const assert = require('assert')
+const {describe, it} = require('mocha')
 
-var size = 20;
-var initSize = 3;
+describe('Dequeue', function () {
+  const size = 20
+  const initSize = 3
 
+  it('push and shift', function () {
+    const q = new Dequeue(initSize)
 
-it('Test dequeue - push and shift', function() {
-  var q = new Dequeue(initSize);
+    for (let i = 0; i < size; i++) {
+      q.push(i)
+    }
+    for (let i = 0; i < size; i++) {
+      assert.equal(i, q.shift())
+      assert.equal(q.getLength(), size - 1 - i)
+    }
+  })
 
-  for(var i=0; i<size; i++) {
-    q.push(i);
-  }
-  for(var i=0; i<size; i++) {
-    assert.equal(i, q.shift());
-    assert.equal(q.getLength(), size-1-i);
-  }
-})
+  it('push and pop', function () {
+    const q = new Dequeue(initSize)
+    for (let i = 0; i < size; i++) {
+      q.push(i)
+    }
+    for (let i = 0; i < size; i++) {
+      assert.equal(size - 1 - i, q.pop())
+      assert.equal(q.getLength(), size - 1 - i)
+    }
+  })
+  it('unshift and shift', function () {
+    const q = new Dequeue(initSize)
+    for (let i = 0; i < size; i++) {
+      q.unshift(i)
+    }
+    for (let i = 0; i < size; i++) {
+      assert.equal(size - 1 - i, q.shift())
+      assert.equal(q.getLength(), size - 1 - i)
+    }
+  })
 
-it('Test dequeue - push and pop', function() {
-  var q = new Dequeue(initSize);
-  for(var i=0; i<size; i++) {
-    q.push(i);
-  }
-  for(var i=0; i<size; i++) {
-    assert.equal(size-1-i, q.pop());
-    assert.equal(q.getLength(), size-1-i);
-  }
-})
-it('Test dequeue - unshift and shift', function() {
-  var q = new Dequeue(initSize);
-  for(var i=0; i<size; i++) {
-    q.unshift(i);
-  }
-  for(var i=0; i<size; i++) {
+  it('unshift and pop', function () {
+    const q = new Dequeue(initSize)
+    for (let i = 0; i < size; i++) {
+      q.unshift(i)
+    }
+    for (let i = 0; i < size; i++) {
+      assert.equal(i, q.pop())
+      assert.equal(q.getLength(), size - 1 - i)
+    }
+  })
 
-    assert.equal(size-1-i, q.shift());
-    assert.equal(q.getLength(), size-1-i);
-  }
-})
+  it('a little of everything', function () {
+    const q = new Dequeue(initSize)
+    for (let i = 0; i < size; i++) {
+      q.unshift(i)
+    }
+    for (let i = 0; i < size; i++) {
+      q.push(i + 100)
+    }
+    for (let i = 0; i < size - 10; i++) {
+      assert.equal(size - 1 + 100 - i, q.pop())
+    }
+    for (let i = 0; i < size - 10; i++) {
+      assert.equal(size - i - 1, q.shift())
+    }
 
-it('Test dequeue - unshift and pop', function() {
-  var q = new Dequeue(initSize);
-  for(var i=0; i<size; i++) {
-    q.unshift(i);
-  }
-  for(var i=0; i<size; i++) {
-    assert.equal(i, q.pop());
-    assert.equal(q.getLength(), size-1-i);
-  }
-})
+    assert(q.getLength(), size * 2 - 10 - 10)
+  })
 
-it('Test dequeue - a little of everything', function() {
-  var q = new Dequeue(initSize);
-  for(var i=0; i<size; i++) {
-    q.unshift(i);
-  }
-  for(var i=0; i<size; i++) {
-    q.push(i+100);
-  }
-  for(var i=0; i<size-10; i++) {
-    assert.equal(size-1+100-i, q.pop());
-  }
-  for(var i=0; i<size-10; i++) {
-    assert.equal(size-i-1, q.shift());
-  }
+  it('push/unshift', function () {
+    const q = new Dequeue(initSize)
+    for (let i = 0; i < size; i++) {
+      q.push(i)
+      q.unshift(i)
+    }
+    assert(q.getLength(), size * 2)
+    for (let i = 0; i < size * 10; i++) {
+      q.push(-1)
+    }
+    assert(q.getLength(), size * (2 + 10))
+  })
+  it('push and shift -- initSize = num push/shift', function () {
+    const q = new Dequeue(initSize)
 
-  assert(q.getLength(), size*2-10-10)
-})
+    for (let i = 0; i < initSize; i++) {
+      q.push(i)
+    }
+    for (let i = 0; i < initSize; i++) {
+      assert.equal(i, q.shift())
+      assert.equal(q.getLength(), initSize - 1 - i)
+    }
+  })
 
-it('Test dequeue - push/unshift', function() {
-  var q = new Dequeue(initSize);
-  for(var i=0; i<size; i++) {
-    q.push(i);
-    q.unshift(i);
-  }
-  assert(q.getLength(), size*2)
-  for(var i=0; i<size*10; i++) {
-    q.push(-1);
-  }
-  assert(q.getLength(), size*(2+10))
+  it('push and pop -- initSize = num push/shift', function () {
+    const q = new Dequeue(initSize)
+    for (let i = 0; i < initSize; i++) {
+      q.push(i)
+    }
+    for (let i = 0; i < initSize; i++) {
+      assert.equal(initSize - 1 - i, q.pop())
+      assert.equal(q.getLength(), initSize - 1 - i)
+    }
+  })
 
-})
-it('Test dequeue - push and shift -- initSize = num push/shift', function() {
-  var q = new Dequeue(initSize);
+  it('unshift and shift -- initSize = num push/shift', function () {
+    const q = new Dequeue(initSize)
+    for (let i = 0; i < initSize; i++) {
+      q.unshift(i)
+    }
+    for (let i = 0; i < initSize; i++) {
+      assert.equal(initSize - 1 - i, q.shift())
+      assert.equal(q.getLength(), initSize - 1 - i)
+    }
+  })
 
-  for(var i=0; i<initSize; i++) {
-    q.push(i);
-  }
-  for(var i=0; i<initSize; i++) {
-    assert.equal(i, q.shift());
-    assert.equal(q.getLength(), initSize-1-i);
-  }
-})
+  it('unshift and pop -- initSize = num push/shift', function () {
+    const q = new Dequeue(initSize)
+    for (let i = 0; i < initSize; i++) {
+      q.unshift(i)
+    }
+    for (let i = 0; i < initSize; i++) {
+      assert.equal(i, q.pop())
+      assert.equal(q.getLength(), initSize - 1 - i)
+    }
+  })
 
-it('Test dequeue - push and pop -- initSize = num push/shift', function() {
-  var q = new Dequeue(initSize);
-  for(var i=0; i<initSize; i++) {
-    q.push(i);
-  }
-  for(var i=0; i<initSize; i++) {
-    assert.equal(initSize-1-i, q.pop());
-    assert.equal(q.getLength(), initSize-1-i);
-  }
-})
+  it('push and shift -- initSize = num push/shift+1', function () {
+    const q = new Dequeue(initSize)
 
-it('Test dequeue - unshift and shift -- initSize = num push/shift', function() {
-  var q = new Dequeue(initSize);
-  for(var i=0; i<initSize; i++) {
-    q.unshift(i);
-  }
-  for(var i=0; i<initSize; i++) {
-    assert.equal(initSize-1-i, q.shift());
-    assert.equal(q.getLength(), initSize-1-i);
-  }
-})
+    for (let i = 0; i < initSize + 1; i++) {
+      q.push(i)
+    }
+    for (let i = 0; i < initSize + 1; i++) {
+      assert.equal(i, q.shift())
+      assert.equal(q.getLength(), initSize + 1 - 1 - i)
+    }
+  })
 
-it('Test dequeue - unshift and pop -- initSize = num push/shift', function() {
-  var q = new Dequeue(initSize);
-  for(var i=0; i<initSize; i++) {
-    q.unshift(i);
-  }
-  for(var i=0; i<initSize; i++) {
-    assert.equal(i, q.pop());
-    assert.equal(q.getLength(), initSize-1-i);
-  }
-})
+  it('push and pop -- initSize = num push/shift+1', function () {
+    const q = new Dequeue(initSize)
+    for (let i = 0; i < initSize + 1; i++) {
+      q.push(i)
+    }
+    for (let i = 0; i < initSize + 1; i++) {
+      assert.equal(initSize + 1 - 1 - i, q.pop())
+      assert.equal(q.getLength(), initSize + 1 - 1 - i)
+    }
+  })
 
-it('Test dequeue - push and shift -- initSize = num push/shift+1', function() {
-  var q = new Dequeue(initSize);
+  it('unshift and shift -- initSize = num push/shift+1', function () {
+    const q = new Dequeue(initSize)
+    for (let i = 0; i < initSize + 1; i++) {
+      q.unshift(i)
+    }
+    for (let i = 0; i < initSize + 1; i++) {
+      assert.equal(initSize + 1 - 1 - i, q.shift())
+      assert.equal(q.getLength(), initSize + 1 - 1 - i)
+    }
+  })
+  it('unshift and pop -- initSize = num push/shift+1', function () {
+    const q = new Dequeue(initSize)
+    for (let i = 0; i < initSize + 1; i++) {
+      q.unshift(i)
+    }
+    for (let i = 0; i < initSize + 1; i++) {
+      assert.equal(i, q.pop())
+      assert.equal(q.getLength(), initSize + 1 - 1 - i)
+    }
+  })
 
-  for(var i=0; i<initSize+1; i++) {
-    q.push(i);
-  }
-  for(var i=0; i<initSize+1; i++) {
-    assert.equal(i, q.shift());
-    assert.equal(q.getLength(), initSize+1-1-i);
-  }
-})
+  it('a little of everything', function () {
+    const q = new Dequeue(initSize)
+    for (let i = 0; i < size; i++) {
+      q.unshift(i)
+    }
+    for (let i = 0; i < size; i++) {
+      q.push(i + 100)
+    }
+    for (let i = 0; i < size - 10; i++) {
+      assert.equal(size - 1 + 100 - i, q.pop())
+    }
+    for (let i = 0; i < size - 10; i++) {
+      assert.equal(size - i - 1, q.shift())
+    }
 
-it('Test dequeue - push and pop -- initSize = num push/shift+1', function() {
-  var q = new Dequeue(initSize);
-  for(var i=0; i<initSize+1; i++) {
-    q.push(i);
-  }
-  for(var i=0; i<initSize+1; i++) {
-    assert.equal(initSize+1-1-i, q.pop());
-    assert.equal(q.getLength(), initSize+1-1-i);
-  }
-})
+    assert(q.getLength(), size * 2 - 10 - 10)
+  })
 
-it('Test dequeue - unshift and shift -- initSize = num push/shift+1', function() {
-  var q = new Dequeue(initSize);
-  for(var i=0; i<initSize+1; i++) {
-    q.unshift(i);
-  }
-  for(var i=0; i<initSize+1; i++) {
+  it('toArray', function () {
+    const q = new Dequeue(initSize)
+    for (let i = 0; i < 10; i++) {
+      q.unshift(i)
+    }
+    for (let i = 0; i < 10; i++) {
+      q.push(i + 100)
+    }
+    assert.deepEqual(q.toArray(), [9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109])
+  })
+  it('delete', function () {
+    const q = new Dequeue(initSize)
+    for (let i = 0; i < 10; i++) {
+      q.unshift(i)
+    }
+    for (let i = 0; i < 10; i++) {
+      q.push(i + 100)
+    }
+    q.delete(5)
+    assert.deepEqual(q.toArray(), [9, 8, 7, 6, 5, 3, 2, 1, 0, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109])
 
-    assert.equal(initSize+1-1-i, q.shift());
-    assert.equal(q.getLength(), initSize+1-1-i);
-  }
-})
-it('Test dequeue - unshift and pop -- initSize = num push/shift+1', function() {
-  var q = new Dequeue(initSize);
-  for(var i=0; i<initSize+1; i++) {
-    q.unshift(i);
-  }
-  for(var i=0; i<initSize+1; i++) {
-    assert.equal(i, q.pop());
-    assert.equal(q.getLength(), initSize+1-1-i);
-  }
-})
+    q.delete(0)
+    assert.deepEqual(q.toArray(), [8, 7, 6, 5, 3, 2, 1, 0, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109])
 
+    q.delete(0)
+    assert.deepEqual(q.toArray(), [7, 6, 5, 3, 2, 1, 0, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109])
+  })
 
+  it('shift returns undefined if no element', function () {
+    const q = new Dequeue(initSize)
+    assert.equal(q.shift(), undefined)
+    assert.equal(q.getLength(), 0)
+  })
 
-it('Test dequeue - a little of everything', function() {
-  var q = new Dequeue(initSize);
-  for(var i=0; i<size; i++) {
-    q.unshift(i);
-  }
-  for(var i=0; i<size; i++) {
-    q.push(i+100);
-  }
-  for(var i=0; i<size-10; i++) {
-    assert.equal(size-1+100-i, q.pop());
-  }
-  for(var i=0; i<size-10; i++) {
-    assert.equal(size-i-1, q.shift());
-  }
-
-  assert(q.getLength(), size*2-10-10)
-})
-
-it('Test dequeue - toArray', function() {
-  var q = new Dequeue(initSize);
-  for(var i=0; i<10; i++) {
-    q.unshift(i);
-  }
-  for(var i=0; i<10; i++) {
-    q.push(i+100);
-  }
-  assert.deepEqual(q.toArray(), [9,8,7,6,5,4,3,2,1,0,100,101,102,103,104,105,106,107,108,109]);
-
-})
-it('Test dequeue - delete', function() {
-  var q = new Dequeue(initSize);
-  for(var i=0; i<10; i++) {
-    q.unshift(i);
-  }
-  for(var i=0; i<10; i++) {
-    q.push(i+100);
-  }
-  q.delete(5)
-  assert.deepEqual(q.toArray(), [9,8,7,6,5,3,2,1,0,100,101,102,103,104,105,106,107,108,109]);
-
-  q.delete(0)
-  assert.deepEqual(q.toArray(), [8,7,6,5,3,2,1,0,100,101,102,103,104,105,106,107,108,109]);
-
-  q.delete(0)
-  assert.deepEqual(q.toArray(), [7,6,5,3,2,1,0,100,101,102,103,104,105,106,107,108,109]);
-
-
-})
-
-
-it('Test dequeue - shift returns undefined if no element', function() {
-  var q = new Dequeue(initSize);
-  assert.equal(q.shift(), undefined);
-  assert.equal(q.getLength(), 0)
-})
-
-it('Test dequeue - pop returns undefined if no element', function() {
-  var q = new Dequeue(initSize);
-  assert.equal(q.pop(), undefined);
-  assert.equal(q.getLength(), 0)
+  it('pop returns undefined if no element', function () {
+    const q = new Dequeue(initSize)
+    assert.equal(q.pop(), undefined)
+    assert.equal(q.getLength(), 0)
+  })
 })

--- a/test/document-manipulation.js
+++ b/test/document-manipulation.js
@@ -1,642 +1,386 @@
-var config = require(__dirname+'/config.js');
-var r = require(__dirname+'/../lib')(config);
-var util = require(__dirname+'/util/common.js');
-var assert = require('assert');
+const path = require('path')
+const config = require('./config.js')
+const rethinkdbdash = require(path.join(__dirname, '/../lib'))
+const assert = require('assert')
+const {uuid} = require(path.join(__dirname, '/util/common.js'))
+const {before, after, describe, it} = require('mocha')
 
-var uuid = util.uuid;
-var It = util.It;
+describe('dates and times', () => {
+  let r, dbName, tableName
 
-var uuid = util.uuid;
-var dbName, tableName, result;
+  before(async () => {
+    r = await rethinkdbdash(config)
+    dbName = uuid()
+    tableName = uuid()
 
-It('Init for `document-manipulation.js`', function* (done) {
-  try {
-    dbName = uuid();
-    tableName = uuid();
+    let result = await r.dbCreate(dbName).run()
+    assert.equal(result.dbs_created, 1)
 
-    result = yield r.dbCreate(dbName).run();
-    assert.equal(result.dbs_created, 1);
+    result = await r.db(dbName).tableCreate(tableName).run()
+    assert.equal(result.tables_created, 1)
+  })
 
-    result = yield r.db(dbName).tableCreate(tableName).run();
-    assert.equal(result.tables_created, 1);
+  after(async () => {
+    await r.getPoolMaster().drain()
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+  it('`r.row` should work - 1', async function () {
+    const result = await r.expr([1, 2, 3]).map(r.row).run()
+    assert.deepEqual(result, [1, 2, 3])
+  })
 
-It('`r.row` should work - 1', function* (done) {
-  try {
-    result = yield r.expr([1,2,3]).map(r.row).run();
-    assert.deepEqual(result, [1,2,3]);
-    done()
-  }
-  catch(e) {
-    done(e);
-  }
-})
+  it('`r.row` should work - 2', async function () {
+    let result = await r.db(dbName).table(tableName).insert({}).run()
+    assert.equal(result.inserted, 1)
 
-It('`r.row` should work - 2', function* (done) {
-  try {
-    var result = yield r.db(dbName).table(tableName).insert({}).run();
-    assert.equal(result.inserted, 1);
+    result = await r.db(dbName).table(tableName).update({idCopyUpdate: r.row('id')}).run()
+    assert.equal(result.replaced, 1)
+  })
 
-    result = yield r.db(dbName).table(tableName).update({idCopyUpdate: r.row("id")}).run();
-    assert.equal(result.replaced, 1);
+  it('`r.row` should work - 3', async function () {
+    const result = await r.db(dbName).table(tableName).replace(r.row).run()
+    assert.equal(result.replaced, 0)
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`r.row` should work - 3', function* (done) {
-  try {
-    var result = yield r.db(dbName).table(tableName).replace(r.row).run();
-    assert.equal(result.replaced, 0);
+  it('`r.row` should work - 4', async function () {
+    const result = await r.db(dbName).table(tableName).replace(function (doc) {
+      return doc.merge({idCopyReplace: doc('id')})
+    }).run()
+    assert.equal(result.replaced, 1)
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`r.row` should work - 4', function* (done) {
-  try {
-    var result = yield r.db(dbName).table(tableName).replace(function(doc) {
-      return doc.merge({idCopyReplace: doc("id")})
-    }).run();
-    assert.equal(result.replaced, 1);
- 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+  it('`r.row` should work - 5', async function () {
+    const result = await r.db(dbName).table(tableName).delete().run()
+    assert.equal(result.deleted, 1)
+  })
 
-It('`r.row` should work - 5', function* (done) {
-  try {
-    var result = yield r.db(dbName).table(tableName).delete().run();
-    assert.equal(result.deleted, 1);
+  it('`pluck` should work', async function () {
+    let result = await r.expr({a: 0, b: 1, c: 2}).pluck('a', 'b').run()
+    assert.deepEqual(result, {a: 0, b: 1})
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+    result = await r.expr([{a: 0, b: 1, c: 2}, {a: 0, b: 10, c: 20}]).pluck('a', 'b').run()
+    assert.deepEqual(result, [{a: 0, b: 1}, {a: 0, b: 10}])
+  })
 
-It('`pluck` should work', function* (done) {
-  try {
-    var result = yield r.expr({a: 0, b: 1, c: 2}).pluck("a", "b").run();
-    assert.deepEqual(result, {a: 0, b: 1});
-
-    result = yield r.expr([{a: 0, b: 1, c: 2}, {a: 0, b: 10, c: 20}]).pluck("a", "b").run();
-    assert.deepEqual(result, [{a: 0, b: 1}, {a: 0, b: 10}]);
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`pluck` should throw if no argument has been passed', function* (done) {
-  try {
-    var result = yield r.db(dbName).table(tableName).pluck().run();
-  }
-  catch(e) {
-    if (e.message === "`pluck` takes at least 1 argument, 0 provided after:\nr.db(\""+dbName+"\").table(\""+tableName+"\")") {
-      done();
+  it('`pluck` should throw if no argument has been passed', async function () {
+    try {
+      await r.db(dbName).table(tableName).pluck().run()
+      assert.fail('should trow')
+    } catch (e) {
+      assert.equal(e.message, '`pluck` takes at least 1 argument, 0 provided after:\nr.db("' + dbName + '").table("' + tableName + '")')
     }
-    else {
-      done(e);
+  })
+
+  it('`without` should work', async function () {
+    let result = await r.expr({a: 0, b: 1, c: 2}).without('c').run()
+    assert.deepEqual(result, {a: 0, b: 1})
+
+    result = await r.expr([{a: 0, b: 1, c: 2}, {a: 0, b: 10, c: 20}]).without('a', 'c').run()
+    assert.deepEqual(result, [{b: 1}, {b: 10}])
+  })
+
+  it('`without` should throw if no argument has been passed', async function () {
+    try {
+      await r.db(dbName).table(tableName).without().run()
+    } catch (e) {
+      assert.equal(e.message, '`without` takes at least 1 argument, 0 provided after:\nr.db("' + dbName + '").table("' + tableName + '")')
     }
-  }
-})
+  })
 
-It('`without` should work', function* (done) {
-  try {
-    var result = yield r.expr({a: 0, b: 1, c: 2}).without("c").run();
-    assert.deepEqual(result, {a: 0, b: 1});
+  it('`merge` should work', async function () {
+    let result = await r.expr({a: 0}).merge({b: 1}).run()
+    assert.deepEqual(result, {a: 0, b: 1})
 
-    result = yield r.expr([{a: 0, b: 1, c: 2}, {a: 0, b: 10, c: 20}]).without("a", "c").run();
-    assert.deepEqual(result, [{b: 1}, {b: 10}]);
+    result = await r.expr([{a: 0}, {a: 1}, {a: 2}]).merge({b: 1}).run()
+    assert.deepEqual(result, [{a: 0, b: 1}, {a: 1, b: 1}, {a: 2, b: 1}])
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`without` should throw if no argument has been passed', function* (done) {
-  try {
-    var result = yield r.db(dbName).table(tableName).without().run();
-  }
-  catch(e) {
-    if (e.message === "`without` takes at least 1 argument, 0 provided after:\nr.db(\""+dbName+"\").table(\""+tableName+"\")") {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
-})
-It('`merge` should work', function* (done) {
-  try {
-    var result = yield r.expr({a: 0}).merge({b: 1}).run();
-    assert.deepEqual(result, {a: 0, b: 1});
+    result = await r.expr({a: 0, c: {l: 'tt'}}).merge({b: {c: {d: {e: 'fff'}}, k: 'pp'}}).run()
+    assert.deepEqual(result, {a: 0, b: {c: {d: {e: 'fff'}}, k: 'pp'}, c: {l: 'tt'}})
 
-    result = yield r.expr([{a: 0}, {a: 1}, {a: 2}]).merge({b: 1}).run();
-    assert.deepEqual(result, [{a: 0, b: 1}, {a: 1, b: 1}, {a: 2, b: 1}]);
-
-    result = yield r.expr({a: 0, c: {l: "tt"}}).merge({b: {c: {d: {e: "fff"}}, k: "pp"}}).run();
-    assert.deepEqual(result, {a: 0, b: {c: {d: {e: "fff"}}, k: "pp"}, c: {l:"tt"}});
-
-    result = yield r.expr({a: 1}).merge({date: r.now()}).run();
+    result = await r.expr({a: 1}).merge({date: r.now()}).run()
     assert.equal(result.a, 1)
     assert(result.date instanceof Date)
 
-    result = yield r.expr({a: 1}).merge({nested: r.row}, {b: 2}).run();
+    result = await r.expr({a: 1}).merge({nested: r.row}, {b: 2}).run()
     assert.deepEqual(result, {a: 1, nested: {a: 1}, b: 2})
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`merge` should take an anonymous function', function* (done) {
-  try {
-    var result = yield r.expr({a: 0}).merge(function(doc) {
-      return {b: doc("a").add(1)}
-    }).run();
-    assert.deepEqual(result, {a: 0, b: 1});
+  it('`merge` should take an anonymous function', async function () {
+    let result = await r.expr({a: 0}).merge(function (doc) {
+      return {b: doc('a').add(1)}
+    }).run()
+    assert.deepEqual(result, {a: 0, b: 1})
 
-    result = yield r.expr({a: 0}).merge({
-      b: r.row("a").add(1)
-    }).run();
-    assert.deepEqual(result, {a: 0, b: 1});
+    result = await r.expr({a: 0}).merge({
+      b: r.row('a').add(1)
+    }).run()
+    assert.deepEqual(result, {a: 0, b: 1})
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+  it('`literal` should work', async function () {
+    const result = await r.expr({a: {b: 1}}).merge({a: r.literal({c: 2})}).run()
+    assert.deepEqual(result, {a: {c: 2}})
+  })
 
-It('`literal` should work', function* (done) {
-  try {
-    var data = r.expr({a: {b: 1}}).merge({a: r.literal({c: 2})})._self
-    var result = yield r.expr({a: {b: 1}}).merge({a: r.literal({c: 2})}).run();
-    assert.deepEqual(result, {a: {c: 2}});
+  it('`literal` is not defined after a term', async function () {
+    try {
+      await r.expr(1).literal('foo').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`literal` is not defined after:\nr.expr(1)')
+    }
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`literal` is not defined after a term', function* (done) {
-  try {
-    result = yield r.expr(1).literal("foo").run();
-  }
-  catch(e) {
-    if (e.message === "`literal` is not defined after:\nr.expr(1)") {
-      done()
+  it('`merge` should throw if no argument has been passed', async function () {
+    try {
+      await r.db(dbName).table(tableName).merge().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`merge` takes at least 1 argument, 0 provided after:\nr.db("' + dbName + '").table("' + tableName + '")')
     }
-    else {
-      done(e)
-    }
-  }
-})
-It('`merge` should throw if no argument has been passed', function* (done) {
-  try {
-    var result = yield r.db(dbName).table(tableName).merge().run();
-  }
-  catch(e) {
-    if (e.message === "`merge` takes at least 1 argument, 0 provided after:\nr.db(\""+dbName+"\").table(\""+tableName+"\")") {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
-})
-It('`literal` should work with no argument', function* (done) {
-  try {
-    var result = yield r.expr({foo: 'bar'}).merge({foo: r.literal()}).run();
-    assert.deepEqual(result, {});
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`append` should work', function* (done) {
-  try {
-    var result = yield r.expr([1,2,3]).append(4).run();
-    assert.deepEqual(result, [1,2,3,4]);
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`append` should throw if no argument has been passed', function* (done) {
-  try {
-    var result = yield r.db(dbName).table(tableName).append().run();
-  }
-  catch(e) {
-    if (e.message === "`append` takes 1 argument, 0 provided after:\nr.db(\""+dbName+"\").table(\""+tableName+"\")") {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
-})
-It('`prepend` should work', function* (done) {
-  try {
-    var result = yield r.expr([1,2,3]).prepend(4).run();
-    assert.deepEqual(result, [4,1,2,3]);
+  it('`literal` should work with no argument', async function () {
+    const result = await r.expr({foo: 'bar'}).merge({foo: r.literal()}).run()
+    assert.deepEqual(result, {})
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`prepend` should throw if no argument has been passed', function* (done) {
-  try {
-    var result = yield r.db(dbName).table(tableName).prepend().run();
-  }
-  catch(e) {
-    if (e.message === "`prepend` takes 1 argument, 0 provided after:\nr.db(\""+dbName+"\").table(\""+tableName+"\")") {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
-})
-It('`difference` should work', function* (done) {
-  try {
-    var result = yield r.expr([1,2,3]).prepend(4).run();
-    assert.deepEqual(result, [4,1,2,3]);
+  it('`append` should work', async function () {
+    const result = await r.expr([1, 2, 3]).append(4).run()
+    assert.deepEqual(result, [1, 2, 3, 4])
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`difference` should throw if no argument has been passed', function* (done) {
-  try {
-    var result = yield r.db(dbName).table(tableName).difference().run();
-  }
-  catch(e) {
-    if (e.message === "`difference` takes 1 argument, 0 provided after:\nr.db(\""+dbName+"\").table(\""+tableName+"\")") {
-      done();
+  it('`append` should throw if no argument has been passed', async function () {
+    try {
+      await r.db(dbName).table(tableName).append().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`append` takes 1 argument, 0 provided after:\nr.db("' + dbName + '").table("' + tableName + '")')
     }
-    else {
-      done(e);
-    }
-  }
-})
-It('`setInsert` should work', function* (done) {
-  try {
-    var result = yield r.expr([1,2,3]).setInsert(4).run();
-    assert.deepEqual(result, [1,2,3,4]);
+  })
 
-    result = yield r.expr([1,2,3]).setInsert(2).run();
-    assert.deepEqual(result, [1,2,3]);
+  it('`prepend` should work', async function () {
+    const result = await r.expr([1, 2, 3]).prepend(4).run()
+    assert.deepEqual(result, [4, 1, 2, 3])
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`setInsert` should throw if no argument has been passed', function* (done) {
-  try {
-    var result = yield r.db(dbName).table(tableName).setInsert().run();
-  }
-  catch(e) {
-    if (e.message === "`setInsert` takes 1 argument, 0 provided after:\nr.db(\""+dbName+"\").table(\""+tableName+"\")") {
-      done();
+  it('`prepend` should throw if no argument has been passed', async function () {
+    try {
+      await r.db(dbName).table(tableName).prepend().run()
+      assert.fail('sholud throw')
+    } catch (e) {
+      assert.equal(e.message, '`prepend` takes 1 argument, 0 provided after:\nr.db("' + dbName + '").table("' + tableName + '")')
     }
-    else {
-      done(e);
-    }
-  }
-})
-It('`setUnion` should work', function* (done) {
-  try {
-    var result = yield r.expr([1,2,3]).setUnion([2,4]).run();
-    assert.deepEqual(result, [1,2,3,4]);
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`setUnion` should throw if no argument has been passed', function* (done) {
-  try {
-    var result = yield r.db(dbName).table(tableName).setUnion().run();
-  }
-  catch(e) {
-    if (e.message === "`setUnion` takes 1 argument, 0 provided after:\nr.db(\""+dbName+"\").table(\""+tableName+"\")") {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
-})
+  it('`difference` should work', async function () {
+    const result = await r.expr([1, 2, 3]).prepend(4).run()
+    assert.deepEqual(result, [4, 1, 2, 3])
+  })
 
-It('`setIntersection` should work', function* (done) {
-  try {
-    var result = yield r.expr([1,2,3]).setIntersection([2,4]).run();
-    assert.deepEqual(result, [2]);
+  it('`difference` should throw if no argument has been passed', async function () {
+    try {
+      await r.db(dbName).table(tableName).difference().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`difference` takes 1 argument, 0 provided after:\nr.db("' + dbName + '").table("' + tableName + '")')
+    }
+  })
 
-    done()
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`setIntersection` should throw if no argument has been passed', function* (done) {
-  try {
-    var result = yield r.db(dbName).table(tableName).setIntersection().run();
-  }
-  catch(e) {
-    if (e.message === "`setIntersection` takes 1 argument, 0 provided after:\nr.db(\""+dbName+"\").table(\""+tableName+"\")") {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
-})
+  it('`setInsert` should work', async function () {
+    let result = await r.expr([1, 2, 3]).setInsert(4).run()
+    assert.deepEqual(result, [1, 2, 3, 4])
 
-It('`setDifference` should work', function* (done) {
-  try {
-    var result = yield r.expr([1,2,3]).setDifference([2,4]).run();
-    assert.deepEqual(result, [1,3]);
+    result = await r.expr([1, 2, 3]).setInsert(2).run()
+    assert.deepEqual(result, [1, 2, 3])
+  })
 
-    done()
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`setDifference` should throw if no argument has been passed', function* (done) {
-  try {
-    var result = yield r.db(dbName).table(tableName).setDifference().run();
-  }
-  catch(e) {
-    if (e.message === "`setDifference` takes 1 argument, 0 provided after:\nr.db(\""+dbName+"\").table(\""+tableName+"\")") {
-      done();
+  it('`setInsert` should throw if no argument has been passed', async function () {
+    try {
+      await r.db(dbName).table(tableName).setInsert().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`setInsert` takes 1 argument, 0 provided after:\nr.db("' + dbName + '").table("' + tableName + '")')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-It('`getField` should work', function* (done) {
-  try {
-    var result = yield r.expr({a:0, b:1})("a").run();
-    assert.equal(result, 0);
+  it('`setUnion` should work', async function () {
+    const result = await r.expr([1, 2, 3]).setUnion([2, 4]).run()
+    assert.deepEqual(result, [1, 2, 3, 4])
+  })
 
-    result = yield r.expr({a:0, b:1}).getField("a").run();
-    assert.equal(result, 0);
+  it('`setUnion` should throw if no argument has been passed', async function () {
+    try {
+      await r.db(dbName).table(tableName).setUnion().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`setUnion` takes 1 argument, 0 provided after:\nr.db("' + dbName + '").table("' + tableName + '")')
+    }
+  })
 
-    result = yield r.expr([{a:0, b:1}, {a:1}])("a").run();
-    assert.deepEqual(result, [0, 1]);
+  it('`setIntersection` should work', async function () {
+    const result = await r.expr([1, 2, 3]).setIntersection([2, 4]).run()
+    assert.deepEqual(result, [2])
+  })
 
-    done()
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`(...)` should throw if no argument has been passed', function* (done) {
-  try {
-    var result = yield r.db(dbName).table(tableName)().run();
-  }
-  catch(e) {
-    if (e.message === "`(...)` takes 1 argument, 0 provided.") {
-      done();
+  it('`setIntersection` should throw if no argument has been passed', async function () {
+    try {
+      await r.db(dbName).table(tableName).setIntersection().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`setIntersection` takes 1 argument, 0 provided after:\nr.db("' + dbName + '").table("' + tableName + '")')
     }
-    else {
-      done(e);
-    }
-  }
-})
-It('`getField` should throw if no argument has been passed', function* (done) {
-  try {
-    var result = yield r.db(dbName).table(tableName).getField().run();
-  }
-  catch(e) {
-    if (e.message === '`(...)` takes 1 argument, 0 provided after:\nr.db("'+dbName+'").table("'+tableName+'")') {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
-})
-It('`hasFields` should work', function* (done) {
-  try {
-    var result = yield r.expr([{a: 0, b: 1, c: 2}, {a: 0, b: 10, c: 20}, {b:1, c:3}]).hasFields("a", "c").run();
-    assert.deepEqual(result, [{a: 0, b: 1, c: 2}, {a: 0, b: 10, c: 20}]);
+  })
 
-    done()
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`hasFields` should throw if no argument has been passed', function* (done) {
-  try {
-    var result = yield r.db(dbName).table(tableName).hasFields().run();
-  }
-  catch(e) {
-    if (e.message === '`hasFields` takes at least 1 argument, 0 provided after:\nr.db("'+dbName+'").table("'+tableName+'")') {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
-})
+  it('`setDifference` should work', async function () {
+    const result = await r.expr([1, 2, 3]).setDifference([2, 4]).run()
+    assert.deepEqual(result, [1, 3])
+  })
 
-It('`insertAt` should work', function* (done) {
-  try {
-    var result = yield r.expr([1,2,3,4]).insertAt(0, 2).run();
-    assert.deepEqual(result, [2,1,2,3,4]);
+  it('`setDifference` should throw if no argument has been passed', async function () {
+    try {
+      await r.db(dbName).table(tableName).setDifference().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`setDifference` takes 1 argument, 0 provided after:\nr.db("' + dbName + '").table("' + tableName + '")')
+    }
+  })
 
-    result = yield r.expr([1,2,3,4]).insertAt(3, 2).run();
-    assert.deepEqual(result, [1,2,3,2,4]);
+  it('`getField` should work', async function () {
+    let result = await r.expr({a: 0, b: 1})('a').run()
+    assert.equal(result, 0)
 
-    done()
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`insertAt` should throw if no argument has been passed', function* (done) {
-  try {
-    var result = yield r.db(dbName).table(tableName).insertAt().run();
-  }
-  catch(e) {
-    if (e.message === '`insertAt` takes 2 arguments, 0 provided after:\nr.db("'+dbName+'").table("'+tableName+'")') {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
-})
-It('`spliceAt` should work', function* (done) {
-  try {
-    var result = yield r.expr([1,2,3,4]).spliceAt(1, [9, 9]).run();
-    assert.deepEqual(result, [1,9,9,2,3,4]);
+    result = await r.expr({a: 0, b: 1}).getField('a').run()
+    assert.equal(result, 0)
 
-    done()
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`spliceAt` should throw if no argument has been passed', function* (done) {
-  try {
-    var result = yield r.db(dbName).table(tableName).spliceAt().run();
-  }
-  catch(e) {
-    if (e.message === '`spliceAt` takes at least 1 argument, 0 provided after:\nr.db("'+dbName+'").table("'+tableName+'")') {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
-})
-It('`deleteAt` should work', function* (done) {
-  try {
-    var result = yield r.expr([1,2,3,4]).deleteAt(1).run();
-    assert.deepEqual(result, [1,3,4]);
+    result = await r.expr([{a: 0, b: 1}, {a: 1}])('a').run()
+    assert.deepEqual(result, [0, 1])
+  })
 
-    result = yield r.expr([1,2,3,4]).deleteAt(1, 3).run();
-    assert.deepEqual(result, [1,4]);
+  it('`(...)` should throw if no argument has been passed', async function () {
+    try {
+      await r.db(dbName).table(tableName)().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`(...)` takes 1 argument, 0 provided.')
+    }
+  })
 
-    done()
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`deleteAt` should throw if no argument has been passed', function* (done) {
-  try {
-    var result = yield r.db(dbName).table(tableName).deleteAt().run();
-  }
-  catch(e) {
-    if (e.message === '`deleteAt` takes at least 1 argument, 0 provided after:\nr.db("'+dbName+'").table("'+tableName+'")') {
-      done();
+  it('`getField` should throw if no argument has been passed', async function () {
+    try {
+      await r.db(dbName).table(tableName).getField().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`(...)` takes 1 argument, 0 provided after:\nr.db("' + dbName + '").table("' + tableName + '")')
     }
-    else {
-      done(e);
-    }
-  }
-})
-It('`deleteAt` should throw if too many arguments', function* (done) {
-  try {
-    var result = yield r.db(dbName).table(tableName).deleteAt(1, 1, 1, 1).run();
-  }
-  catch(e) {
-    if (e.message === '`deleteAt` takes at most 2 arguments, 4 provided after:\nr.db("'+dbName+'").table("'+tableName+'")') {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
-})
-It('`changeAt` should work', function* (done) {
-  try {
-    var result = yield r.expr([1,2,3,4]).changeAt(1, 3).run();
-    assert.deepEqual(result, [1,3,3,4]);
+  })
 
-    done()
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`changeAt` should throw if no argument has been passed', function* (done) {
-  try {
-    var result = yield r.db(dbName).table(tableName).changeAt().run();
-  }
-  catch(e) {
-    if (e.message === '`changeAt` takes at least 1 argument, 0 provided after:\nr.db("'+dbName+'").table("'+tableName+'")') {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
-})
-It('`keys` should work', function* (done) {
-  try {
-    var result = yield r.expr({a:0, b:1, c:2}).keys().orderBy(r.row).run();
-    assert.deepEqual(result, ["a", "b", "c"]);
+  it('`hasFields` should work', async function () {
+    const result = await r.expr([{a: 0, b: 1, c: 2}, {a: 0, b: 10, c: 20}, {b: 1, c: 3}]).hasFields('a', 'c').run()
+    assert.deepEqual(result, [{a: 0, b: 1, c: 2}, {a: 0, b: 10, c: 20}])
+  })
 
-    done()
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`keys` throw on a string', function* (done) {
-  try {
-    var result = yield r.expr("hello").keys().orderBy(r.row).run();
-  }
-  catch(e) {
-    if (e.message.match(/^Cannot call `keys` on objects of type `STRING` in/)) {
-      done();
+  it('`hasFields` should throw if no argument has been passed', async function () {
+    try {
+      await r.db(dbName).table(tableName).hasFields().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`hasFields` takes at least 1 argument, 0 provided after:\nr.db("' + dbName + '").table("' + tableName + '")')
     }
-    else {
-      console.log(e);
-      done(e);
+  })
+
+  it('`insertAt` should work', async function () {
+    let result = await r.expr([1, 2, 3, 4]).insertAt(0, 2).run()
+    assert.deepEqual(result, [2, 1, 2, 3, 4])
+
+    result = await r.expr([1, 2, 3, 4]).insertAt(3, 2).run()
+    assert.deepEqual(result, [1, 2, 3, 2, 4])
+  })
+
+  it('`insertAt` should throw if no argument has been passed', async function () {
+    try {
+      await r.db(dbName).table(tableName).insertAt().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`insertAt` takes 2 arguments, 0 provided after:\nr.db("' + dbName + '").table("' + tableName + '")')
     }
-  }
-})
-It('`values` should work', function* (done) {
-  try {
-    var result = yield r.expr({a:0, b:1, c:2}).values().orderBy(r.row).run();
-    assert.deepEqual(result, [0, 1, 2]);
+  })
 
-    done()
-  }
-  catch(e) {
-    done(e);
-  }
-})
+  it('`spliceAt` should work', async function () {
+    const result = await r.expr([1, 2, 3, 4]).spliceAt(1, [9, 9]).run()
+    assert.deepEqual(result, [1, 9, 9, 2, 3, 4])
+  })
 
-It('`object` should work', function* (done) {
-  try {
-    var result = yield r.object("a", 1, r.expr("2"), "foo").run();
-    assert.deepEqual(result, {"a": 1, "2": "foo"});
+  it('`spliceAt` should throw if no argument has been passed', async function () {
+    try {
+      await r.db(dbName).table(tableName).spliceAt().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`spliceAt` takes at least 1 argument, 0 provided after:\nr.db("' + dbName + '").table("' + tableName + '")')
+    }
+  })
 
-    done()
-  }
-  catch(e) {
-    done(e);
-  }
+  it('`deleteAt` should work', async function () {
+    let result = await r.expr([1, 2, 3, 4]).deleteAt(1).run()
+    assert.deepEqual(result, [1, 3, 4])
+
+    result = await r.expr([1, 2, 3, 4]).deleteAt(1, 3).run()
+    assert.deepEqual(result, [1, 4])
+  })
+
+  it('`deleteAt` should throw if no argument has been passed', async function () {
+    try {
+      await r.db(dbName).table(tableName).deleteAt().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`deleteAt` takes at least 1 argument, 0 provided after:\nr.db("' + dbName + '").table("' + tableName + '")')
+    }
+  })
+
+  it('`deleteAt` should throw if too many arguments', async function () {
+    try {
+      await r.db(dbName).table(tableName).deleteAt(1, 1, 1, 1).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`deleteAt` takes at most 2 arguments, 4 provided after:\nr.db("' + dbName + '").table("' + tableName + '")')
+    }
+  })
+
+  it('`changeAt` should work', async function () {
+    const result = await r.expr([1, 2, 3, 4]).changeAt(1, 3).run()
+    assert.deepEqual(result, [1, 3, 3, 4])
+  })
+
+  it('`changeAt` should throw if no argument has been passed', async function () {
+    try {
+      await r.db(dbName).table(tableName).changeAt().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`changeAt` takes at least 1 argument, 0 provided after:\nr.db("' + dbName + '").table("' + tableName + '")')
+    }
+  })
+
+  it('`keys` should work', async function () {
+    const result = await r.expr({a: 0, b: 1, c: 2}).keys().orderBy(r.row).run()
+    assert.deepEqual(result, ['a', 'b', 'c'])
+  })
+
+  it('`keys` throw on a string', async function () {
+    try {
+      await r.expr('hello').keys().orderBy(r.row).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message.match(/^Cannot call `keys` on objects of type `STRING` in/))
+    }
+  })
+
+  it('`values` should work', async function () {
+    const result = await r.expr({a: 0, b: 1, c: 2}).values().orderBy(r.row).run()
+    assert.deepEqual(result, [0, 1, 2])
+  })
+
+  it('`object` should work', async function () {
+    const result = await r.object('a', 1, r.expr('2'), 'foo').run()
+    assert.deepEqual(result, {'a': 1, '2': 'foo'})
+  })
 })

--- a/test/error.js
+++ b/test/error.js
@@ -1,52 +1,59 @@
-var config = require(__dirname+'/config.js');
-var r = require(__dirname+'/../lib')(config);
-var util = require(__dirname+'/util/common.js');
-var assert = require('assert');
+const path = require('path')
+const config = require('./config.js')
+const rethinkdbdash = require(path.join(__dirname, '/../lib'))
+const assert = require('assert')
 
-var uuid = util.uuid;
-var It = util.It;
+const {before, after, describe, it} = require('mocha')
 
-var uuid = util.uuid;
-var dbName, tableName, result;
+describe('errors', () => {
+  let r
 
-It("ReqlResourceError", function* (done) {
-  try {
-    result = yield r.expr([1,2,3,4]).run({arrayLimit: 2});
-  }
-  catch(e) {
-    assert.equal(e.name, 'ReqlResourceError');
-    done()
-  }
+  before(async () => {
+    r = await rethinkdbdash(config)
+  })
+
+  after(async () => {
+    await r.getPoolMaster().drain()
+  })
+
+  it('ReqlResourceError', async function () {
+    try {
+      await r.expr([1, 2, 3, 4]).run({arrayLimit: 2})
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.name, 'ReqlResourceError')
+    }
+  })
+
+  it('ReqlLogicError', async function () {
+    try {
+      await r.expr(1).add('foo').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.name, 'ReqlLogicError')
+    }
+  })
+
+  it('ReqlOpFailedError', async function () {
+    try {
+      await r.db('DatabaseThatDoesNotExist').tableList().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.name, 'ReqlOpFailedError')
+    }
+  })
+
+  it('ReqlUserError', async function () {
+    try {
+      await r.branch(r.error('a'), 1, 2).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.name, 'ReqlUserError')
+    }
+  })
+
+  describe('Missing tests', function () {
+    it('ReqlInternalError no easy way to trigger', function () {})
+    it('ReqlOpIndeterminateError no easy way to trigger', function () {})
+  })
 })
-It("ReqlLogicError", function* (done) {
-  try {
-    result = yield r.expr(1).add("foo").run();
-  }
-  catch(e) {
-    assert.equal(e.name, 'ReqlLogicError');
-    done()
-  }
-})
-
-It("ReqlOpFailedError", function* (done) {
-  try {
-    result = yield r.db('DatabaseThatDoesNotExist').tableList().run();
-  }
-  catch(e) {
-    assert.equal(e.name, 'ReqlOpFailedError');
-    done()
-  }
-})
-
-It("ReqlUserError", function* (done) {
-  try {
-    result = yield r.branch(r.error('a'), 1, 2).run()
-  }
-  catch(e) {
-    assert.equal(e.name, 'ReqlUserError');
-    done()
-  }
-})
-
-// Missing tests for ReqlInternalError and ReqlOpIndeterminateError
-// as there are no easy way to trigger those

--- a/test/error.js
+++ b/test/error.js
@@ -2,7 +2,7 @@ const path = require('path')
 const config = require('./config.js')
 const rethinkdbdash = require(path.join(__dirname, '/../lib'))
 const assert = require('assert')
-
+const {ReqlRuntimeError} = require(path.join(__dirname, '/../lib/error.js'))
 const {before, after, describe, it} = require('mocha')
 
 describe('errors', () => {
@@ -21,6 +21,7 @@ describe('errors', () => {
       await r.expr([1, 2, 3, 4]).run({arrayLimit: 2})
       assert.fail('should throw')
     } catch (e) {
+      assert(e instanceof ReqlRuntimeError)
       assert.equal(e.name, 'ReqlResourceError')
     }
   })
@@ -30,6 +31,7 @@ describe('errors', () => {
       await r.expr(1).add('foo').run()
       assert.fail('should throw')
     } catch (e) {
+      assert(e instanceof ReqlRuntimeError)
       assert.equal(e.name, 'ReqlLogicError')
     }
   })
@@ -39,6 +41,7 @@ describe('errors', () => {
       await r.db('DatabaseThatDoesNotExist').tableList().run()
       assert.fail('should throw')
     } catch (e) {
+      assert(e instanceof ReqlRuntimeError)
       assert.equal(e.name, 'ReqlOpFailedError')
     }
   })
@@ -48,11 +51,13 @@ describe('errors', () => {
       await r.branch(r.error('a'), 1, 2).run()
       assert.fail('should throw')
     } catch (e) {
+      assert(e instanceof ReqlRuntimeError)
       assert.equal(e.name, 'ReqlUserError')
     }
   })
 
   describe('Missing tests', function () {
+    it('ReqlServerError (maybe need to use fakeServer)', function () {})
     it('ReqlInternalError no easy way to trigger', function () {})
     it('ReqlOpIndeterminateError no easy way to trigger', function () {})
   })

--- a/test/extra.js
+++ b/test/extra.js
@@ -1,93 +1,65 @@
-var config = require(__dirname+'/config.js');
-var r = require(__dirname+'/../lib')(config);
-var util = require(__dirname+'/util/common.js');
-var assert = require('assert');
+const path = require('path')
+const config = require('./config.js')
+const rethinkdbdash = require(path.join(__dirname, '/../lib'))
+const assert = require('assert')
+const {uuid} = require(path.join(__dirname, '/util/common.js'))
+const {after, before, describe, it} = require('mocha')
 
-var uuid = util.uuid;
-var It = util.It;
+describe('extra', () => {
+  let r, dbName, tableName
 
-var uuid = util.uuid;
-var dbName, tableName, result;
+  before(async () => {
+    r = await rethinkdbdash(config)
+    dbName = uuid()
+    tableName = uuid() // Big table to test partial sequence
 
-It('Init for `extra.js`', function* (done) {
-  try {
-    dbName = uuid();
-    tableName = uuid(); // Big table to test partial sequence
+    let result = await r.dbCreate(dbName).run()
+    assert.equal(result.dbs_created, 1)
 
-    result = yield r.dbCreate(dbName).run()
-    assert.equal(result.dbs_created, 1);
-    //yield r.db(dbName).wait().run()
-    result = yield r.db(dbName).tableCreate(tableName)('tables_created').run();
-    assert.deepEqual(result, 1);
-    done();
-  }
-  catch(e) {
-    console.log(e);
-    done(e);
-  }
-})
-It('Change the default database on the fly in run', function* (done) {
-  try {
-    result = yield r.tableList().run({db: dbName})
-    assert.deepEqual(result, [tableName]);
-    done();
-  }
-  catch(e) {
-    console.log(e);
-    done(e);
-  }
-})
+    result = await r.db(dbName).tableCreate(tableName)('tables_created').run()
+    assert.deepEqual(result, 1)
+  })
 
-It('Anonymous function should throw if they return undefined', function* (done) {
-  try {
-    r.expr(1).do(function() {});
-  }
-  catch(e) {
-    if (e.message === "Anonymous function returned `undefined`. Did you forget a `return`? In:\nfunction () {}.") {
-      done()
+  after(async () => {
+    await r.getPoolMaster().drain()
+  })
+
+  it('Change the default database on the fly in run', async function () {
+    const result = await r.tableList().run({db: dbName})
+    assert.deepEqual(result, [tableName])
+  })
+
+  it('Anonymous function should throw if they return undefined', async function () {
+    try {
+      r.expr(1).do(function () {})
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, 'Anonymous function returned `undefined`. Did you forget a `return`? In:\nfunction () {}.')
     }
-    else {
-      done(e);
+  })
+
+  it('toString should work', function () {
+    let result = r.expr(1).add(2).toString()
+    assert.equal(result, 'r.expr(1).add(2)')
+
+    result = r.expr(1).toString()
+    assert.equal(result, 'r.expr(1)')
+  })
+
+  it('await a query should work - 1', async function () {
+    let result = await r.expr(1)
+    assert.equal(result, 1)
+
+    result = await r.expr(1).add(3)
+    assert.equal(result, 4)
+  })
+
+  it('await a query should work - 2', async function () {
+    try {
+      await r.expr(1).add('foo')
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message.match(/Expected type NUMBER but found STRING/))
     }
-  }
-})
-
-It('toString should work', function* (done) {
-  try {
-    assert.equal(r.expr(1).add(2).toString(), "r.expr(1).add(2)");
-    assert.equal(r.expr(1).toString(), "r.expr(1)");
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-
-It('yield a query should work - 1', function* (done) {
-  try {
-    var result = yield r.expr(1);
-    assert.equal(result, 1);
-
-    var result = yield r.expr(1).add(3);
-    assert.equal(result, 4);
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('yield a query should work - 2', function* (done) {
-  try {
-    var result = yield r.expr(1).add("foo");
-    done(new Error("Was expecting an error"));
-  }
-  catch(e) {
-    if (e.message.match(/Expected type NUMBER but found STRING/)) {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
+  })
 })

--- a/test/geo.js
+++ b/test/geo.js
@@ -1,527 +1,311 @@
-var config = require(__dirname+'/config.js');
-var r = require(__dirname+'/../lib')(config);
-var util = require(__dirname+'/util/common.js');
-var assert = require('assert');
+const path = require('path')
+const config = require('./config.js')
+const rethinkdbdash = require(path.join(__dirname, '/../lib'))
+const {uuid} = require(path.join(__dirname, '/util/common.js'))
+const assert = require('assert')
+const {before, after, describe, it} = require('mocha')
 
-var uuid = util.uuid;
-var It = util.It;
+describe('geo', () => {
+  let r, dbName, tableName
 
-var uuid = util.uuid;
-var dbName, tableName, result;
-var numDocs = 10;
+  const numDocs = 10
 
-It('Init for `geo.js`', function* (done) {
-  try {
-    dbName = uuid();
-    tableName = uuid();
+  before(async function () {
+    r = await rethinkdbdash(config)
+    dbName = uuid()
+    tableName = uuid()
 
-    result = yield r.dbCreate(dbName).run();
-    assert.equal(result.dbs_created, 1);
+    let result = await r.dbCreate(dbName).run()
+    assert.equal(result.dbs_created, 1)
 
-    result = yield r.db(dbName).tableCreate(tableName).run();
-    assert.equal(result.tables_created, 1);
+    result = await r.db(dbName).tableCreate(tableName).run()
+    assert.equal(result.tables_created, 1)
 
-    result = yield r.db(dbName).table(tableName).indexCreate("location", {geo: true}).run();
-    result = yield r.db(dbName).table(tableName).indexWait("location").run();
+    result = await r.db(dbName).table(tableName).indexCreate('location', {geo: true}).run()
+    assert.equal(result.created, 1)
+    await r.db(dbName).table(tableName).indexWait('location').run()
+    result = await r.db(dbName).table(tableName).insert(
+      Array(numDocs).fill({location: r.point(r.random(0, 1, {float: true}), r.random(0, 1, {float: true}))})
+    ).run()
+    assert.equal(result.inserted, numDocs)
+  })
 
-    var insert_docs = [];
-    for(var i=0; i<numDocs; i++) {
-      insert_docs.push({location: r.point(r.random(0, 1, {float: true}), r.random(0, 1, {float: true}))})
-    }
-    result = yield r.db(dbName).table(tableName).insert(insert_docs).run();
+  after(async function () {
+    await r.getPoolMaster().drain()
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+  it('`r.circle` should work - 1', async function () {
+    const result = await r.circle([0, 0], 2).run()
+    assert.equal(result.$reql_type$, 'GEOMETRY')
+    assert.equal(result.type, 'Polygon')
+    assert.equal(result.coordinates[0].length, 33)
+  })
 
-
-It('`r.circle` should work - 1', function* (done) {
-  try {
-    var result = yield r.circle([0, 0], 2).run();
-    assert.equal(result.$reql_type$, "GEOMETRY")
-    assert.equal(result.type, "Polygon")
+  it('`r.circle` should work - 2', async function () {
+    let result = await r.circle(r.point(0, 0), 2).run()
+    assert.equal(result.$reql_type$, 'GEOMETRY')
+    assert.equal(result.type, 'Polygon')
     assert.equal(result.coordinates[0].length, 33)
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`r.circle` should work - 2', function* (done) {
-  try {
-    var result = yield r.circle(r.point(0, 0), 2).run();
-    assert.equal(result.$reql_type$, "GEOMETRY")
-    assert.equal(result.type, "Polygon")
-    assert.equal(result.coordinates[0].length, 33)
-
-    var result = yield r.circle(r.point(0, 0), 2, {numVertices: 40}).run();
-    assert.equal(result.$reql_type$, "GEOMETRY")
-    assert.equal(result.type, "Polygon")
+    result = await r.circle(r.point(0, 0), 2, {numVertices: 40}).run()
+    assert.equal(result.$reql_type$, 'GEOMETRY')
+    assert.equal(result.type, 'Polygon')
     assert.equal(result.coordinates[0].length, 41)
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`r.circle` should work - 3', function* (done) {
-  try {
-    var result = yield r.circle(r.point(0, 0), 2, {numVertices: 40, fill: false}).run();
-    assert.equal(result.$reql_type$, "GEOMETRY")
-    assert.equal(result.type, "LineString")
+  it('`r.circle` should work - 3', async function () {
+    const result = await r.circle(r.point(0, 0), 2, {numVertices: 40, fill: false}).run()
+    assert.equal(result.$reql_type$, 'GEOMETRY')
+    assert.equal(result.type, 'LineString')
     assert.equal(result.coordinates.length, 41)
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`r.circle` should work - 4', function* (done) {
-  try {
-    var result = yield r.circle(r.point(0, 0), 1, {unit: "km"}).eq(r.circle(r.point(0, 0), 1000, {unit: "m"})).run();
-    assert(result);
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+  it('`r.circle` should work - 4', async function () {
+    const result = await r.circle(r.point(0, 0), 1, {unit: 'km'}).eq(r.circle(r.point(0, 0), 1000, {unit: 'm'})).run()
+    assert(result)
+  })
 
-It('`r.circle` should throw with non recognized arguments', function* (done) {
-  try {
-    var result = yield r.circle(r.point(0, 0), 1, {foo: "bar"}).run()
-    done(new Error("Was expecting an error"));
-  }
-  catch(e) {
-    if (e.message.match(/^Unrecognized option `foo` in `circle`/) !== null) {
-      done();
+  it('`r.circle` should throw with non recognized arguments', async function () {
+    try {
+      await r.circle(r.point(0, 0), 1, {foo: 'bar'}).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message.match(/^Unrecognized option `foo` in `circle`/))
     }
-    else {
-      done(e);
-    }
-  }
-})
-It('`r.circle` arity - 1', function* (done) {
-  try {
-    var result = yield r.circle(r.point(0, 0)).run()
-    done(new Error("Was expecting an error"));
-  }
-  catch(e) {
-    if (e.message.match(/^`r.circle` takes at least 2 arguments, 1 provided/) !== null) {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
-})
-It('`r.circle` arity - 2', function* (done) {
-  try {
-    var result = yield r.circle(0, 1, 2, 3, 4).run()
-    done(new Error("Was expecting an error"));
-  }
-  catch(e) {
-    if (e.message.match(/^`r.circle` takes at most 3 arguments, 5 provided/) !== null) {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
-})
-It('`distance` should work - 1', function* (done) {
-  try {
-    var result = yield r.point(0, 0).distance(r.point(1,1)).run();
-    assert.equal(Math.floor(result), 156899);
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`r.distance` should work - 1', function* (done) {
-  try {
-    var result = yield r.distance(r.point(0, 0), r.point(1,1)).run();
-    assert.equal(Math.floor(result), 156899);
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+  })
 
-It('`distance` should work - 2', function* (done) {
-  try {
-    var result = yield r.point(0, 0).distance(r.point(1,1), {unit: "km"}).run();
-    assert.equal(Math.floor(result), 156);
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+  it('`r.circle` arity - 1', async function () {
+    try {
+      await r.circle(r.point(0, 0)).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message.match(/^`r.circle` takes at least 2 arguments, 1 provided/))
+    }
+  })
 
-It('`distance` arity - 1', function* (done) {
-  try {
-    var result = yield r.point(0, 0).distance().run();
-    done(new Error("Was expecting an error"));
-    done();
-  }
-  catch(e) {
-    if (e.message.match(/^`distance` takes at least 1 argument, 0 provided/) !== null) {
-      done();
+  it('`r.circle` arity - 2', async function () {
+    try {
+      await r.circle(0, 1, 2, 3, 4).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message.match(/^`r.circle` takes at most 3 arguments, 5 provided/))
     }
-    else {
-      done(e);
-    }
-  }
-})
-It('`distance` arity - 2', function* (done) {
-  try {
-    var result = yield r.point(0, 0).distance(1, 2, 3).run();
-    done(new Error("Was expecting an error"));
-    done();
-  }
-  catch(e) {
-    if (e.message.match(/^`distance` takes at most 2 arguments, 3 provided/) !== null) {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-It('`fill` should work', function* (done) {
-  try {
-    var result = yield r.circle(r.point(0, 0), 2, {numVertices: 40, fill: false}).fill().run();
-    assert.equal(result.$reql_type$, "GEOMETRY")
-    assert.equal(result.type, "Polygon")
+  it('`distance` should work - 1', async function () {
+    const result = await r.point(0, 0).distance(r.point(1, 1)).run()
+    assert.equal(Math.floor(result), 156899)
+  })
+
+  it('`r.distance` should work - 1', async function () {
+    const result = await r.distance(r.point(0, 0), r.point(1, 1)).run()
+    assert.equal(Math.floor(result), 156899)
+  })
+
+  it('`distance` should work - 2', async function () {
+    const result = await r.point(0, 0).distance(r.point(1, 1), {unit: 'km'}).run()
+    assert.equal(Math.floor(result), 156)
+  })
+
+  it('`distance` arity - 1', async function () {
+    try {
+      await r.point(0, 0).distance().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message.match(/^`distance` takes at least 1 argument, 0 provided/))
+    }
+  })
+
+  it('`distance` arity - 2', async function () {
+    try {
+      await r.point(0, 0).distance(1, 2, 3).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message.match(/^`distance` takes at most 2 arguments, 3 provided/))
+    }
+  })
+
+  it('`fill` should work', async function () {
+    const result = await r.circle(r.point(0, 0), 2, {numVertices: 40, fill: false}).fill().run()
+    assert.equal(result.$reql_type$, 'GEOMETRY')
+    assert.equal(result.type, 'Polygon')
     assert.equal(result.coordinates[0].length, 41)
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`fill` arity error', function* (done) {
-  try {
-    var result = yield r.circle(r.point(0, 0), 2, {numVertices: 40, fill: false}).fill(1).run();
-    done(new Error("Was expecting an error"));
-    done();
-  }
-  catch(e) {
-    if (e.message.match(/^`fill` takes 0 argument, 1 provided/) !== null) {
-      done();
+  it('`fill` arity error', async function () {
+    try {
+      await r.circle(r.point(0, 0), 2, {numVertices: 40, fill: false}).fill(1).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message.match(/^`fill` takes 0 argument, 1 provided/))
     }
-    else {
-      done(e);
-    }
+  })
 
-  }
-})
-It('`geojson` should work', function* (done) {
-  try {
-    var result = yield r.geojson( {"coordinates":[0,0],"type":"Point"} ).run()
-    assert.equal(result.$reql_type$, "GEOMETRY")
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`geojson` arity error', function* (done) {
-  try {
-    var result = yield r.geojson(1,2,3).run()
-    done(new Error("Was expecting an error"));
-    done();
-  }
-  catch(e) {
-    if (e.message.match(/^`r.geojson` takes 1 argument, 3 provided/) !== null) {
-      done();
-    }
-    else {
-      done(e);
-    }
+  it('`geojson` should work', async function () {
+    const result = await r.geojson({'coordinates': [0, 0], 'type': 'Point'}).run()
+    assert.equal(result.$reql_type$, 'GEOMETRY')
+  })
 
-  }
-})
-It('`toGeojson` should work', function* (done) {
-  try {
-    var result = yield r.geojson( {"coordinates":[0,0],"type":"Point"}).toGeojson().run()
+  it('`geojson` arity error', async function () {
+    try {
+      await r.geojson(1, 2, 3).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message.match(/^`r.geojson` takes 1 argument, 3 provided/))
+    }
+  })
+
+  it('`toGeojson` should work', async function () {
+    const result = await r.geojson({'coordinates': [0, 0], 'type': 'Point'}).toGeojson().run()
     assert.equal(result.$reql_type$, undefined)
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`toGeojson` arity error', function* (done) {
-  try {
-    var result = yield r.point(0, 0).toGeojson(1, 2, 3).run()
-    done(new Error("Was expecting an error"));
-    done();
-  }
-  catch(e) {
-    if (e.message.match(/^`toGeojson` takes 0 argument, 3 provided/) !== null) {
-      done();
-    }
-    else {
-      done(e);
-    }
+  })
 
-  }
-})
+  it('`toGeojson` arity error', async function () {
+    try {
+      await r.point(0, 0).toGeojson(1, 2, 3).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message.match(/^`toGeojson` takes 0 argument, 3 provided/))
+    }
+  })
 
-It('`getIntersecting` should work', function* (done) {
-  try {
+  it('`getIntersecting` should work', async function () {
     // All points are in [0,1]x[0,1]
-    var result = yield r.db(dbName).table(tableName).getIntersecting(r.polygon([0, 0], [0,1], [1,1], [1,0]), {index: "location"}).count().run()
+    const result = await r.db(dbName).table(tableName).getIntersecting(r.polygon([0, 0], [0, 1], [1, 1], [1, 0]), {index: 'location'}).count().run()
     assert.equal(result, numDocs)
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`getIntersecting` arity', function* (done) {
-  try {
-    // All points are in [0,1]x[0,1]
-    var result = yield r.db(dbName).table(tableName).getIntersecting(r.polygon([0, 0], [0,1], [1,1], [1,0])).count().run()
-    done(new Error("Was expecting an error"));
-    done();
-  }
-  catch(e) {
-    if (e.message.match(/^`getIntersecting` takes 2 arguments, 1 provided/) !== null) {
-      done();
-    }
-    else {
-      done(e);
-    }
+  })
 
-  }
+  it('`getIntersecting` arity', async function () {
+    try {
+      // All points are in [0,1]x[0,1]
+      await r.db(dbName).table(tableName).getIntersecting(r.polygon([0, 0], [0, 1], [1, 1], [1, 0])).count().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message.match(/^`getIntersecting` takes 2 arguments, 1 provided/))
+    }
+  })
 
-})
-It('`getNearest` should work', function* (done) {
-  try {
+  it('`getNearest` should work', async function () {
     // All points are in [0,1]x[0,1]
-    var result = yield r.db(dbName).table(tableName).getNearest(r.point(0, 0), {index: "location", maxResults: 5}).run()
+    const result = await r.db(dbName).table(tableName).getNearest(r.point(0, 0), {
+      index: 'location',
+      maxResults: 5
+    }).run()
     assert(result.length <= 5)
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+  })
 
-It('`getNearest` arity', function* (done) {
-  try {
-    var result = yield r.db(dbName).table(tableName).getNearest(r.point(0, 0)).count().run()
-    done(new Error("Was expecting an error"));
-    done();
-  }
-  catch(e) {
-    if (e.message.match(/^`getNearest` takes 2 arguments, 1 provided/) !== null) {
-      done();
+  it('`getNearest` arity', async function () {
+    try {
+      await r.db(dbName).table(tableName).getNearest(r.point(0, 0)).count().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message.match(/^`getNearest` takes 2 arguments, 1 provided/))
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-It('`includes` should work', function* (done) {
-  try {
-    var point1 = r.point(-117.220406, 32.719464);
-    var point2 = r.point(-117.206201, 32.725186);
-    var result = yield r.circle(point1, 2000).includes(point2).run();
+  it('`includes` should work', async function () {
+    const point1 = r.point(-117.220406, 32.719464)
+    const point2 = r.point(-117.206201, 32.725186)
+    const result = await r.circle(point1, 2000).includes(point2).run()
     assert(result)
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`includes` arity', function* (done) {
-  try {
-    var result = yield r.circle([0,0], 2000).includes().run();
-    done(new Error("Was expecting an error"));
-    done();
-  }
-  catch(e) {
-    if (e.message.match(/^`includes` takes 1 argument, 0 provided/) !== null) {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-It('`intersects` should work', function* (done) {
-  try {
-    var point1 = r.point(-117.220406, 32.719464);
-    var point2 = r.point(-117.206201, 32.725186);
-    r.circle(point1, 2000).intersects(r.circle(point2, 2000)).run();
+  it('`includes` arity', async function () {
+    try {
+      await r.circle([0, 0], 2000).includes().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message.match(/^`includes` takes 1 argument, 0 provided/))
+    }
+  })
+
+  it('`intersects` should work', async function () {
+    const point1 = r.point(-117.220406, 32.719464)
+    const point2 = r.point(-117.206201, 32.725186)
+    const result = await r.circle(point1, 2000).intersects(r.circle(point2, 2000)).run()
     assert(result)
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`intersects` arity', function* (done) {
-  try {
-    // All points are in [0,1]x[0,1]
-    var point1 = r.point(-117.220406, 32.719464);
-    var point2 = r.point(-117.206201, 32.725186);
-    r.circle(point1, 2000).intersects(r.circle(point2, 2000), 2, 3).run();
+  })
 
-    done(new Error("Was expecting an error"));
-    done();
-  }
-  catch(e) {
-    if (e.message.match(/^`intersects` takes 1 argument, 3 provided/) !== null) {
-      done();
+  it('`intersects` arity', async function () {
+    try {
+      // All points are in [0,1]x[0,1]
+      const point1 = r.point(-117.220406, 32.719464)
+      const point2 = r.point(-117.206201, 32.725186)
+      await r.circle(point1, 2000).intersects(r.circle(point2, 2000), 2, 3).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message.match(/^`intersects` takes 1 argument, 3 provided/))
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-It('`r.line` should work - 1', function* (done) {
-  try {
-    var result = yield r.line([0, 0], [1, 2]).run();
-    assert.equal(result.$reql_type$, "GEOMETRY")
-    assert.equal(result.type, "LineString")
+  it('`r.line` should work - 1', async function () {
+    const result = await r.line([0, 0], [1, 2]).run()
+    assert.equal(result.$reql_type$, 'GEOMETRY')
+    assert.equal(result.type, 'LineString')
     assert.equal(result.coordinates[0].length, 2)
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`r.line` should work - 2', function* (done) {
-  try {
-    var result = yield r.line(r.point(0, 0), r.point(1, 2)).run();
-    assert.equal(result.$reql_type$, "GEOMETRY")
-    assert.equal(result.type, "LineString")
+  })
+
+  it('`r.line` should work - 2', async function () {
+    const result = await r.line(r.point(0, 0), r.point(1, 2)).run()
+    assert.equal(result.$reql_type$, 'GEOMETRY')
+    assert.equal(result.type, 'LineString')
     assert.equal(result.coordinates[0].length, 2)
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+  })
 
+  it('`r.line` arity', async function () {
+    try {
+      await r.line().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message.match(/^`r.line` takes at least 2 arguments, 0 provided/))
+    }
+  })
 
-It('`r.line` arity', function* (done) {
-  try {
-    var result = yield r.line().run();
-    done(new Error("Was expecting an error"));
-    done();
-  }
-  catch(e) {
-    if (e.message.match(/^`r.line` takes at least 2 arguments, 0 provided/) !== null) {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
-})
+  it('`r.point` should work', async function () {
+    const result = await r.point(0, 0).run()
+    assert.equal(result.$reql_type$, 'GEOMETRY')
+    assert.equal(result.type, 'Point')
+    assert.equal(result.coordinates.length, 2)
+  })
 
-It('`r.point` should work', function* (done) {
-  try {
-    var result = yield r.point(0, 0).run();
-    assert.equal(result.$reql_type$, "GEOMETRY");
-    assert.equal(result.type, "Point");
-    assert.equal(result.coordinates.length, 2);
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+  it('`r.point` arity', async function () {
+    try {
+      await r.point().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message.match(/^`r.point` takes 2 arguments, 0 provided/))
+    }
+  })
 
-It('`r.point` arity', function* (done) {
-  try {
-    var result = yield r.point().run();
-    done(new Error("Was expecting an error"));
-    done();
-  }
-  catch(e) {
-    if (e.message.match(/^`r.point` takes 2 arguments, 0 provided/) !== null) {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
-})
+  it('`r.polygon` should work', async function () {
+    const result = await r.polygon([0, 0], [0, 1], [1, 1]).run()
+    assert.equal(result.$reql_type$, 'GEOMETRY')
+    assert.equal(result.type, 'Polygon')
+    assert.equal(result.coordinates[0].length, 4) // The server will close the line
+  })
 
-It('`r.polygon` should work', function* (done) {
-  try {
-    var result = yield r.polygon([0, 0], [0, 1], [1, 1]).run();
-    assert.equal(result.$reql_type$, "GEOMETRY");
-    assert.equal(result.type, "Polygon");
-    assert.equal(result.coordinates[0].length, 4); // The server will close the line
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+  it('`r.polygon` arity', async function () {
+    try {
+      await r.polygon().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message.match(/^`r.polygon` takes at least 3 arguments, 0 provided/))
+    }
+  })
 
-It('`r.polygon` arity', function* (done) {
-  try {
-    var result = yield r.polygon().run();
-    done(new Error("Was expecting an error"));
-    done();
-  }
-  catch(e) {
-    if (e.message.match(/^`r.polygon` takes at least 3 arguments, 0 provided/) !== null) {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
-})
-It('`polygonSub` should work', function* (done) {
-  try {
-    var result = yield r.polygon([0, 0], [0, 1], [1, 1], [1, 0]).polygonSub(r.polygon([0.4, 0.4], [0.4, 0.5], [0.5, 0.5])).run();
-    assert.equal(result.$reql_type$, "GEOMETRY");
-    assert.equal(result.type, "Polygon");
-    assert.equal(result.coordinates.length, 2); // The server will close the line
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+  it('`polygonSub` should work', async function () {
+    const result = await r.polygon([0, 0], [0, 1], [1, 1], [1, 0]).polygonSub(r.polygon([0.4, 0.4], [0.4, 0.5], [0.5, 0.5])).run()
+    assert.equal(result.$reql_type$, 'GEOMETRY')
+    assert.equal(result.type, 'Polygon')
+    assert.equal(result.coordinates.length, 2) // The server will close the line
+  })
 
-It('`polygonSub` arity', function* (done) {
-  try {
-    var result = yield r.polygon([0, 0], [0, 1], [1, 1]).polygonSub().run();
-    done(new Error("Was expecting an error"));
-    done();
-  }
-  catch(e) {
-    if (e.message.match(/^`polygonSub` takes 1 argument, 0 provided/) !== null) {
-      done();
+  it('`polygonSub` arity', async function () {
+    try {
+      await r.polygon([0, 0], [0, 1], [1, 1]).polygonSub().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message.match(/^`polygonSub` takes 1 argument, 0 provided/))
     }
-    else {
-      done(e);
-    }
-  }
+  })
 })
-

--- a/test/joins.js
+++ b/test/joins.js
@@ -1,322 +1,210 @@
-var config = require(__dirname+'/config.js');
-var r = require(__dirname+'/../lib')(config);
-var util = require(__dirname+'/util/common.js');
-var assert = require('assert');
+const path = require('path')
+const config = require('./config.js')
+const rethinkdbdash = require(path.join(__dirname, '/../lib'))
+const assert = require('assert')
+const {uuid} = require(path.join(__dirname, '/util/common.js'))
+const {before, after, describe, it} = require('mocha')
 
-var uuid = util.uuid;
-var It = util.It;
+describe('joins', () => {
+  let r, dbName, tableName, pks
 
-var uuid = util.uuid;
-var dbName, tableName, result, pks;
+  before(async () => {
+    r = await rethinkdbdash(config)
+    dbName = uuid()
+    tableName = uuid()
 
-
-It('Init for `joins.js`', function* (done) {
-  try {
-    dbName = uuid();
-    tableName = uuid();
-
-    result = yield r.dbCreate(dbName).run();
-    assert.equal(result.dbs_created, 1);
-
-    result = yield r.db(dbName).tableCreate(tableName).run();
-    assert.equal(result.tables_created, 1);
-
-    result = yield r.db(dbName).table(tableName).insert([{val:1}, {val: 2}, {val: 3}]).run();
-    pks = result.generated_keys;
+    let result = await r.dbCreate(dbName).run()
+    assert.equal(result.dbs_created, 1)
+    result = await r.db(dbName).tableCreate(tableName).run()
+    assert.equal(result.tables_created, 1)
+    result = await r.db(dbName).table(tableName).insert([{val: 1}, {val: 2}, {val: 3}]).run()
+    pks = result.generated_keys
     assert.equal(result.inserted, 3)
 
-    result = yield r.db(dbName).table(tableName).indexCreate("val").run();
-    result = yield r.db(dbName).table(tableName).indexWait("val").run();
-    assert(result);
+    await r.db(dbName).table(tableName).indexCreate('val').run()
+    result = await r.db(dbName).table(tableName).indexWait('val').run()
+    assert(result)
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+  after(async () => {
+    await r.getPoolMaster().drain()
+  })
 
-It('`innerJoin` should return -- array-array', function* (done) {
-  try {
-    result = yield r.expr([1,2,3]).innerJoin(r.expr([1,2,3]), function(left, right) { return left.eq(right) }).run();
-    assert.deepEqual(result, [{left:1, right:1}, {left:2, right: 2}, {left:3, right: 3}]);
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`innerJoin` should return -- array-stream', function* (done) {
-  try {
-    result = yield r.expr([1,2,3]).innerJoin(r.db(dbName).table(tableName), function(left, right) { return left.eq(right("val")) }).run();
-    assert.equal(result.length, 3);
-    assert(result[0].left);
-    assert(result[0].right);
-    assert(result[1].left);
-    assert(result[1].right);
-    assert(result[2].left);
-    assert(result[2].right);
+  it('`innerJoin` should return -- array-array', async function () {
+    const result = await r.expr([1, 2, 3]).innerJoin(r.expr([1, 2, 3]), function (left, right) { return left.eq(right) }).run()
+    assert.deepEqual(result, [{left: 1, right: 1}, {left: 2, right: 2}, {left: 3, right: 3}])
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`innerJoin` should return -- stream-stream', function* (done) {
-  try {
-    result = yield r.db(dbName).table(tableName).innerJoin(r.db(dbName).table(tableName), function(left, right) { return left.eq(right) }).run();
-    assert.equal(result.length, 3);
-    assert(result[0].left);
-    assert(result[0].right);
-    assert(result[1].left);
-    assert(result[1].right);
-    assert(result[2].left);
-    assert(result[2].right);
+  it('`innerJoin` should return -- array-stream', async function () {
+    const result = await r.expr([1, 2, 3]).innerJoin(r.db(dbName).table(tableName), function (left, right) { return left.eq(right('val')) }).run()
+    assert.equal(result.length, 3)
+    assert(result[0].left)
+    assert(result[0].right)
+    assert(result[1].left)
+    assert(result[1].right)
+    assert(result[2].left)
+    assert(result[2].right)
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`innerJoin` should throw if no sequence', function* (done) {
-  try {
-    result = yield r.db(dbName).table(tableName).innerJoin().run();
-  }
-  catch(e) {
-    if (e.message === "`innerJoin` takes 2 arguments, 0 provided after:\nr.db(\""+dbName+"\").table(\""+tableName+"\")") {
-      done();
+  it('`innerJoin` should return -- stream-stream', async function () {
+    const result = await r.db(dbName).table(tableName).innerJoin(r.db(dbName).table(tableName), function (left, right) { return left.eq(right) }).run()
+    assert.equal(result.length, 3)
+    assert(result[0].left)
+    assert(result[0].right)
+    assert(result[1].left)
+    assert(result[1].right)
+    assert(result[2].left)
+    assert(result[2].right)
+  })
+
+  it('`innerJoin` should throw if no sequence', async function () {
+    try {
+      await r.db(dbName).table(tableName).innerJoin().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`innerJoin` takes 2 arguments, 0 provided after:\nr.db("' + dbName + '").table("' + tableName + '")')
     }
-    else {
-      done(e);
+  })
+
+  it('`innerJoin` should throw if no predicate', async function () {
+    try {
+      await r.db(dbName).table(tableName).innerJoin(r.expr([1, 2, 3])).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`innerJoin` takes 2 arguments, 1 provided after:\nr.db("' + dbName + '").table("' + tableName + '")')
     }
-  }
-})
-It('`innerJoin` should throw if no predicate', function* (done) {
-  try {
-    var result = yield r.db(dbName).table(tableName).innerJoin(r.expr([1,2,3])).run();
-  }
-  catch(e) {
-    if (e.message === "`innerJoin` takes 2 arguments, 1 provided after:\nr.db(\""+dbName+"\").table(\""+tableName+"\")") {
-      done();
+  })
+
+  it('`outerJoin` should return -- array-array', async function () {
+    const result = await r.expr([1, 2, 3]).outerJoin(r.expr([1, 2, 3]), function (left, right) { return left.eq(right) }).run()
+    assert.deepEqual(result, [{left: 1, right: 1}, {left: 2, right: 2}, {left: 3, right: 3}])
+  })
+
+  it('`outerJoin` should return -- array-stream - 1', async function () {
+    const result = await r.expr([1, 2, 3, 4]).outerJoin(r.db(dbName).table(tableName), function (left, right) { return left.eq(right('val')) }).run()
+    assert.equal(result.length, 4)
+    assert(result[0].left)
+    assert(result[0].right)
+    assert(result[1].left)
+    assert(result[1].right)
+    assert(result[2].left)
+    assert(result[2].right)
+  })
+
+  it('`outerJoin` should return -- array-stream - 2', async function () {
+    const result = await r.expr([1, 2, 3, 4]).outerJoin(r.db(dbName).table(tableName), function (left, right) { return left.eq(right('val')) }).run()
+    assert.equal(result.length, 4)
+    assert(result[0].left)
+    assert(result[0].right)
+    assert(result[1].left)
+    assert(result[1].right)
+    assert(result[2].left)
+    assert(result[2].right)
+    assert(result[3].left)
+    assert.equal(result[3].right, undefined)
+  })
+
+  it('`outerJoin` should return -- stream-stream', async function () {
+    const result = await r.db(dbName).table(tableName).outerJoin(r.db(dbName).table(tableName), function (left, right) { return left.eq(right) }).run()
+    assert.equal(result.length, 3)
+    assert(result[0].left)
+    assert(result[0].right)
+    assert(result[1].left)
+    assert(result[1].right)
+    assert(result[2].left)
+    assert(result[2].right)
+  })
+
+  it('`outerJoin` should throw if no sequence', async function () {
+    try {
+      await r.db(dbName).table(tableName).outerJoin().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`outerJoin` takes 2 arguments, 0 provided after:\nr.db("' + dbName + '").table("' + tableName + '")')
     }
-    else {
-      done(e);
+  })
+
+  it('`outerJoin` should throw if no predicate', async function () {
+    try {
+      await r.db(dbName).table(tableName).outerJoin(r.expr([1, 2, 3])).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`outerJoin` takes 2 arguments, 1 provided after:\nr.db("' + dbName + '").table("' + tableName + '")')
     }
-  }
-})
+  })
 
+  it('`eqJoin` should return -- pk -- array-stream - function', async function () {
+    const result = await r.expr(pks).eqJoin(function (doc) { return doc }, r.db(dbName).table(tableName)).run()
+    assert.equal(result.length, 3)
+    assert(result[0].left)
+    assert(result[0].right)
+    assert(result[1].left)
+    assert(result[1].right)
+    assert(result[2].left)
+    assert(result[2].right)
+  })
 
-It('`outerJoin` should return -- array-array', function* (done) {
-  try {
-    result = yield r.expr([1,2,3]).outerJoin(r.expr([1,2,3]), function(left, right) { return left.eq(right) }).run();
-    assert.deepEqual(result, [{left:1, right:1}, {left:2, right: 2}, {left:3, right: 3}]);
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`outerJoin` should return -- array-stream - 1', function* (done) {
-  try {
-    result = yield r.expr([1,2,3,4]).outerJoin(r.db(dbName).table(tableName), function(left, right) { return left.eq(right("val")) }).run();
-    assert.equal(result.length, 4);
-    assert(result[0].left);
-    assert(result[0].right);
-    assert(result[1].left);
-    assert(result[1].right);
-    assert(result[2].left);
-    assert(result[2].right);
+  it('`eqJoin` should return -- pk -- array-stream - r.row', async function () {
+    const result = await r.expr(pks).eqJoin(r.row, r.db(dbName).table(tableName)).run()
+    assert.equal(result.length, 3)
+    assert(result[0].left)
+    assert(result[0].right)
+    assert(result[1].left)
+    assert(result[1].right)
+    assert(result[2].left)
+    assert(result[2].right)
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+  it('`eqJoin` should return -- secondary index -- array-stream - r.row', async function () {
+    const result = await r.expr([1, 2, 3]).eqJoin(r.row, r.db(dbName).table(tableName), {index: 'val'}).run()
+    assert.equal(result.length, 3)
+    assert(result[0].left)
+    assert(result[0].right)
+    assert(result[1].left)
+    assert(result[1].right)
+    assert(result[2].left)
+    assert(result[2].right)
+  })
 
-It('`outerJoin` should return -- array-stream - 2', function* (done) {
-  try {
-    result = yield r.expr([1,2,3,4]).outerJoin(r.db(dbName).table(tableName), function(left, right) { return left.eq(right("val")) }).run();
-    assert.equal(result.length, 4);
-    assert(result[0].left);
-    assert(result[0].right);
-    assert(result[1].left);
-    assert(result[1].right);
-    assert(result[2].left);
-    assert(result[2].right);
-    assert(result[3].left);
-    assert.equal(result[3].right, undefined);
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`outerJoin` should return -- stream-stream', function* (done) {
-  try {
-    result = yield r.db(dbName).table(tableName).outerJoin(r.db(dbName).table(tableName), function(left, right) { return left.eq(right) }).run();
-    assert.equal(result.length, 3);
-    assert(result[0].left);
-    assert(result[0].right);
-    assert(result[1].left);
-    assert(result[1].right);
-    assert(result[2].left);
-    assert(result[2].right);
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`outerJoin` should throw if no sequence', function* (done) {
-  try {
-    var result = yield r.db(dbName).table(tableName).outerJoin().run();
-  }
-  catch(e) {
-    if (e.message === "`outerJoin` takes 2 arguments, 0 provided after:\nr.db(\""+dbName+"\").table(\""+tableName+"\")") {
-      done();
+  it('`eqJoin` should throw if no argument', async function () {
+    try {
+      await r.db(dbName).table(tableName).eqJoin().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`eqJoin` takes at least 2 arguments, 0 provided after:\nr.db("' + dbName + '").table("' + tableName + '")')
     }
-    else {
-      done(e);
-    }
-  }
-})
-It('`outerJoin` should throw if no predicate', function* (done) {
-  try {
-    var result = yield r.db(dbName).table(tableName).outerJoin(r.expr([1,2,3])).run();
-  }
-  catch(e) {
-    if (e.message === "`outerJoin` takes 2 arguments, 1 provided after:\nr.db(\""+dbName+"\").table(\""+tableName+"\")") {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-It('`eqJoin` should return -- pk -- array-stream - function', function* (done) {
-  try {
-    var result = yield r.expr(pks).eqJoin(function(doc) { return doc; }, r.db(dbName).table(tableName)).run();
-    assert.equal(result.length, 3);
-    assert(result[0].left);
-    assert(result[0].right);
-    assert(result[1].left);
-    assert(result[1].right);
-    assert(result[2].left);
-    assert(result[2].right);
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`eqJoin` should return -- pk -- array-stream - r.row', function* (done) {
-  try {
-    var result = yield r.expr(pks).eqJoin(r.row, r.db(dbName).table(tableName)).run();
-    assert.equal(result.length, 3);
-    assert(result[0].left);
-    assert(result[0].right);
-    assert(result[1].left);
-    assert(result[1].right);
-    assert(result[2].left);
-    assert(result[2].right);
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-
-It('`eqJoin` should return -- secondary index -- array-stream - r.row', function* (done) {
-  try {
-    var result = yield r.expr([1,2,3]).eqJoin(r.row, r.db(dbName).table(tableName), {index: "val"}).run();
-    assert.equal(result.length, 3);
-    assert(result[0].left);
-    assert(result[0].right);
-    assert(result[1].left);
-    assert(result[1].right);
-    assert(result[2].left);
-    assert(result[2].right);
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`eqJoin` should throw if no argument', function* (done) {
-  try {
-    var result = yield r.db(dbName).table(tableName).eqJoin().run();
-  }
-  catch(e) {
-    if (e.message === "`eqJoin` takes at least 2 arguments, 0 provided after:\nr.db(\""+dbName+"\").table(\""+tableName+"\")") {
-      done();
+  it('`eqJoin` should throw with a non valid key', async function () {
+    try {
+      await r.expr([1, 2, 3]).eqJoin(r.row, r.db(dbName).table(tableName), {nonValidKey: 'val'}).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, 'Unrecognized option `nonValidKey` in `eqJoin` after:\nr.expr([1, 2, 3])\nAvailable options are index <string>, ordered <boolean>')
     }
-    else {
-      done(e);
-    }
-  }
-})
-It('`eqJoin` should throw with a non valid key', function* (done) {
-  try {
-    var result = yield r.expr([1,2,3]).eqJoin(r.row, r.db(dbName).table(tableName), {nonValidKey: "val"}).run();
-  }
-  catch(e) {
-    if (e.message === "Unrecognized option `nonValidKey` in `eqJoin` after:\nr.expr([1, 2, 3])\nAvailable options are index <string>, ordered <boolean>") {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-It('`eqJoin` should throw if no sequence', function* (done) {
-  try {
-    var result = yield r.db(dbName).table(tableName).eqJoin("id").run();
-  }
-  catch(e) {
-    if (e.message === "`eqJoin` takes at least 2 arguments, 1 provided after:\nr.db(\""+dbName+"\").table(\""+tableName+"\")") {
-      done();
+  it('`eqJoin` should throw if no sequence', async function () {
+    try {
+      await r.db(dbName).table(tableName).eqJoin('id').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`eqJoin` takes at least 2 arguments, 1 provided after:\nr.db("' + dbName + '").table("' + tableName + '")')
     }
-    else {
-      done(e);
+  })
+
+  it('`eqJoin` should throw if too many arguments', async function () {
+    try {
+      await r.db(dbName).table(tableName).eqJoin(1, 1, 1, 1, 1).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`eqJoin` takes at most 3 arguments, 5 provided after:\nr.db("' + dbName + '").table("' + tableName + '")')
     }
-  }
-})
-It('`eqJoin` should throw if too many arguments', function* (done) {
-  try {
-    var result = yield r.db(dbName).table(tableName).eqJoin(1, 1, 1, 1, 1).run();
-  }
-  catch(e) {
-    if (e.message === "`eqJoin` takes at most 3 arguments, 5 provided after:\nr.db(\""+dbName+"\").table(\""+tableName+"\")") {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-
-
-It('`zip` should zip stuff', function* (done) {
-  try {
-    var result = yield r.expr(pks).eqJoin(function(doc) { return doc; }, r.db(dbName).table(tableName)).zip().run();
-    assert.equal(result.length, 3);
-    assert.equal(result[0].left, undefined);
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
+  it('`zip` should zip stuff', async function () {
+    const result = await r.expr(pks).eqJoin(function (doc) { return doc }, r.db(dbName).table(tableName)).zip().run()
+    assert.equal(result.length, 3)
+    assert.equal(result[0].left, undefined)
+  })
 })

--- a/test/linked_list.js
+++ b/test/linked_list.js
@@ -1,0 +1,205 @@
+const path = require('path')
+const LinkedList = require(path.join(__dirname, '/../lib/linked_list.js'))
+const assert = require('assert')
+const {describe, it} = require('mocha')
+
+describe('Linked list', function () {
+  const size = 20
+  const initSize = 3
+
+  it('push and shift', function () {
+    const q = new LinkedList()
+
+    for (let i = 0; i < size; i++) {
+      q.push(i)
+    }
+    for (let i = 0; i < size; i++) {
+      assert.equal(i, q.shift())
+      assert.equal(q.getLength(), size - 1 - i)
+    }
+  })
+
+  it('push and pop', function () {
+    const q = new LinkedList()
+    for (let i = 0; i < size; i++) {
+      q.push(i)
+    }
+    for (let i = 0; i < size; i++) {
+      assert.equal(size - 1 - i, q.pop())
+      assert.equal(q.getLength(), size - 1 - i)
+    }
+  })
+
+  it('unshift and shift', function () {
+    const q = new LinkedList()
+    for (let i = 0; i < size; i++) {
+      q.unshift(i)
+    }
+    for (let i = 0; i < size; i++) {
+      assert.equal(size - 1 - i, q.shift())
+      assert.equal(q.getLength(), size - 1 - i)
+    }
+  })
+
+  it('unshift and pop', function () {
+    const q = new LinkedList()
+    for (let i = 0; i < size; i++) {
+      q.unshift(i)
+    }
+    for (let i = 0; i < size; i++) {
+      assert.equal(i, q.pop())
+      assert.equal(q.getLength(), size - 1 - i)
+    }
+  })
+
+  it('a little of everything', function () {
+    const q = new LinkedList()
+    for (let i = 0; i < size; i++) {
+      q.unshift(i)
+    }
+    for (let i = 0; i < size; i++) {
+      q.push(i + 100)
+    }
+    for (let i = 0; i < size - 10; i++) {
+      assert.equal(size - 1 + 100 - i, q.pop())
+    }
+    for (let i = 0; i < size - 10; i++) {
+      assert.equal(size - i - 1, q.shift())
+    }
+
+    assert(q.getLength(), size * 2 - 10 - 10)
+  })
+
+  it('push/unshift', function () {
+    const q = new LinkedList()
+    for (let i = 0; i < size; i++) {
+      q.push(i)
+      q.unshift(i)
+    }
+    assert(q.getLength(), size * 2)
+    for (let i = 0; i < size * 10; i++) {
+      q.push(-1)
+    }
+    assert(q.getLength(), size * (2 + 10))
+  })
+
+  it('push and shift -- initSize = num push/shift', function () {
+    const q = new LinkedList()
+
+    for (let i = 0; i < initSize; i++) {
+      q.push(i)
+    }
+    for (let i = 0; i < initSize; i++) {
+      assert.equal(i, q.shift())
+      assert.equal(q.getLength(), initSize - 1 - i)
+    }
+  })
+
+  it('push and pop -- initSize = num push/shift', function () {
+    const q = new LinkedList()
+    for (let i = 0; i < initSize; i++) {
+      q.push(i)
+    }
+    for (let i = 0; i < initSize; i++) {
+      assert.equal(initSize - 1 - i, q.pop())
+      assert.equal(q.getLength(), initSize - 1 - i)
+    }
+  })
+
+  it('unshift and shift -- initSize = num push/shift', function () {
+    const q = new LinkedList()
+    for (let i = 0; i < initSize; i++) {
+      q.unshift(i)
+    }
+    for (let i = 0; i < initSize; i++) {
+      assert.equal(initSize - 1 - i, q.shift())
+      assert.equal(q.getLength(), initSize - 1 - i)
+    }
+  })
+
+  it('unshift and pop -- initSize = num push/shift', function () {
+    const q = new LinkedList()
+    for (let i = 0; i < initSize; i++) {
+      q.unshift(i)
+    }
+    for (let i = 0; i < initSize; i++) {
+      assert.equal(i, q.pop())
+      assert.equal(q.getLength(), initSize - 1 - i)
+    }
+  })
+
+  it('push and shift -- initSize = num push/shift+1', function () {
+    const q = new LinkedList()
+
+    for (let i = 0; i < initSize + 1; i++) {
+      q.push(i)
+    }
+    for (let i = 0; i < initSize + 1; i++) {
+      assert.equal(i, q.shift())
+      assert.equal(q.getLength(), initSize + 1 - 1 - i)
+    }
+  })
+
+  it('push and pop -- initSize = num push/shift+1', function () {
+    const q = new LinkedList()
+    for (let i = 0; i < initSize + 1; i++) {
+      q.push(i)
+    }
+    for (let i = 0; i < initSize + 1; i++) {
+      assert.equal(initSize + 1 - 1 - i, q.pop())
+      assert.equal(q.getLength(), initSize + 1 - 1 - i)
+    }
+  })
+
+  it('unshift and shift -- initSize = num push/shift+1', function () {
+    const q = new LinkedList()
+    for (let i = 0; i < initSize + 1; i++) {
+      q.unshift(i)
+    }
+    for (let i = 0; i < initSize + 1; i++) {
+      assert.equal(initSize + 1 - 1 - i, q.shift())
+      assert.equal(q.getLength(), initSize + 1 - 1 - i)
+    }
+  })
+
+  it('unshift and pop -- initSize = num push/shift+1', function () {
+    const q = new LinkedList()
+    for (let i = 0; i < initSize + 1; i++) {
+      q.unshift(i)
+    }
+    for (let i = 0; i < initSize + 1; i++) {
+      assert.equal(i, q.pop())
+      assert.equal(q.getLength(), initSize + 1 - 1 - i)
+    }
+  })
+
+  it('a little of everything', function () {
+    const q = new LinkedList()
+    for (let i = 0; i < size; i++) {
+      q.unshift(i)
+    }
+    for (let i = 0; i < size; i++) {
+      q.push(i + 100)
+    }
+    for (let i = 0; i < size - 10; i++) {
+      assert.equal(size - 1 + 100 - i, q.pop())
+    }
+    for (let i = 0; i < size - 10; i++) {
+      assert.equal(size - i - 1, q.shift())
+    }
+
+    assert(q.getLength(), size * 2 - 10 - 10)
+  })
+
+  it('shift returns undefined if no element', function () {
+    const q = new LinkedList()
+    assert.equal(q.shift(), undefined)
+    assert.equal(q.getLength(), 0)
+  })
+
+  it('pop returns undefined if no element', function () {
+    const q = new LinkedList()
+    assert.equal(q.pop(), undefined)
+    assert.equal(q.getLength(), 0)
+  })
+})

--- a/test/manipulating-tables.js
+++ b/test/manipulating-tables.js
@@ -1,394 +1,271 @@
-var config = require(__dirname+'/config.js');
-var r = require(__dirname+'/../lib')(config);
-var util = require(__dirname+'/util/common.js');
-var assert = require('assert');
+const path = require('path')
+const config = require('./config.js')
+const rethinkdbdash = require(path.join(__dirname, '/../lib'))
+const {uuid} = require(path.join(__dirname, '/util/common.js'))
+const assert = require('assert')
+const {before, after, describe, it} = require('mocha')
 
-var uuid = util.uuid;
-var It = util.It;
+describe('manipulating tables', () => {
+  let r, dbName
 
-var uuid = util.uuid;
-var dbName, tableName, result;
+  before(async function () {
+    r = await rethinkdbdash(config)
+    dbName = uuid() // export to the global scope
+    const result = await r.dbCreate(dbName).run()
+    assert.equal(result.dbs_created, 1)
+  })
 
+  after(async function () {
+    await r.getPoolMaster().drain()
+  })
 
-It('Init for `manipulating-tables.js`', function* (done) {
-  try {
-    dbName = uuid(); // export to the global scope
-    var result = yield r.dbCreate(dbName).run();
-    assert.equal(result.dbs_created, 1);
+  it('`tableList` should return a cursor', async function () {
+    const result = await r.db(dbName).tableList().run()
+    assert(Array.isArray(result))
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+  it('`tableList` should show the table we created', async function () {
+    const tableName = uuid() // export to the global scope
 
-It('`tableList` should return a cursor', function* (done) {
-  try {
-    result = yield r.db(dbName).tableList().run();
-    assert(Array.isArray(result));
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+    let result = await r.db(dbName).tableCreate(tableName).run()
+    assert.equal(result.tables_created, 1)
 
-It('`tableList` should show the table we created', function* (done) {
-  try {
-    tableName = uuid(); // export to the global scope
+    result = await r.db(dbName).tableList().run()
+    assert(Array.isArray(result))
+    assert.equal(tableName, result.find((name) => name === tableName))
+  })
 
-    result = yield r.db(dbName).tableCreate(tableName).run();
-    assert.equal(result.tables_created, 1);
+  it('`tableCreate` should create a table', async function () {
+    const tableName = uuid() // export to the global scope
 
-    result = yield r.db(dbName).tableList().run();
-    assert(Array.isArray(result));
+    const result = await r.db(dbName).tableCreate(tableName).run()
+    assert.equal(result.tables_created, 1)
+  })
 
-    var found = false;
-    for(var i=0; i<result.length; i++) {
-      if (result[i] === tableName) {
-        found = true; 
-        break;
+  it('`tableCreate` should create a table -- primaryKey', async function () {
+    const tableName = uuid()
+
+    let result = await r.db(dbName).tableCreate(tableName, {primaryKey: 'foo'}).run()
+    assert.equal(result.tables_created, 1)
+
+    result = await r.db(dbName).table(tableName).info().run()
+    assert(result.primary_key, 'foo')
+  })
+
+  it('`tableCreate` should create a table -- all args', async function () {
+    const tableName = uuid()
+
+    let result = await r.db(dbName).tableCreate(tableName, {durability: 'soft', primaryKey: 'foo'}).run()
+    assert.equal(result.tables_created, 1) // We can't really check other parameters...
+
+    result = await r.db(dbName).table(tableName).info().run()
+    assert(result.primary_key, 'foo')
+  })
+
+  it('`tableCreate` should throw -- non valid args', async function () {
+    try {
+      const tableName = uuid()
+
+      await r.db(dbName).tableCreate(tableName, {nonValidArg: true}).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message.match(/^Unrecognized option `nonValidArg` in `tableCreate`/))
+    }
+  })
+
+  it('`tableCreate` should throw if no argument is given', async function () {
+    try {
+      await r.db(dbName).tableCreate().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`tableCreate` takes at least 1 argument, 0 provided after:\nr.db("' + dbName + '")')
+    }
+  })
+
+  it('`tableCreate` should throw is the name contains special char', async function () {
+    try {
+      await r.db(dbName).tableCreate('-_-').run()
+    } catch (e) {
+      assert(e.message.match(/Table name `-_-` invalid \(Use A-Za-z0-9_ only\)/))
+    }
+  })
+
+  it('`tableDrop` should drop a table', async function () {
+    const tableName = uuid()
+
+    let result = await r.db(dbName).tableCreate(tableName).run()
+    assert.equal(result.tables_created, 1)
+
+    result = await r.db(dbName).tableList().run()
+    assert(Array.isArray(result))
+    assert.equal(result.find((name) => name === tableName), tableName)
+
+    result = await r.db(dbName).tableDrop(tableName).run()
+    assert.equal(result.tables_dropped, 1)
+
+    result = await r.db(dbName).tableList().run()
+    assert(result.find((name) => name === tableName) === undefined)
+  })
+
+  it('`tableDrop` should throw if no argument is given', async function () {
+    try {
+      await r.db(dbName).tableDrop().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`tableDrop` takes 1 argument, 0 provided after:\nr.db("' + dbName + '")')
+    }
+  })
+
+  describe('indices', function () {
+    const dbName = uuid()
+    const tableName = uuid()
+
+    before(async () => {
+      let result = await r.dbCreate(dbName).run()
+      assert.equal(result.dbs_created, 1)
+
+      result = await r.db(dbName).tableCreate(tableName).run()
+      assert.equal(result.tables_created, 1)
+    })
+
+    it('index operations', async function () {
+      let result = await r.db(dbName).table(tableName).indexCreate('newField').run()
+      assert.deepEqual(result, {created: 1})
+
+      result = await r.db(dbName).table(tableName).indexList().run()
+      assert.deepEqual(result, ['newField'])
+
+      result = await r.db(dbName).table(tableName).indexWait().pluck('index', 'ready').run()
+      assert.deepEqual(result, [{index: 'newField', ready: true}])
+      result = await r.db(dbName).table(tableName).indexStatus().pluck('index', 'ready').run()
+      assert.deepEqual(result, [{index: 'newField', ready: true}])
+
+      result = await r.db(dbName).table(tableName).indexDrop('newField').run()
+      assert.deepEqual(result, {dropped: 1})
+
+      result = await r.db(dbName).table(tableName).indexCreate('field1', function (doc) { return doc('field1') }).run()
+      assert.deepEqual(result, {created: 1})
+
+      result = await r.db(dbName).table(tableName).indexWait('field1').pluck('index', 'ready').run()
+      assert.deepEqual(result, [{index: 'field1', ready: true}])
+      result = await r.db(dbName).table(tableName).indexStatus('field1').pluck('index', 'ready').run()
+      assert.deepEqual(result, [{index: 'field1', ready: true}])
+
+      result = await r.db(dbName).table(tableName).indexDrop('field1').run()
+      assert.deepEqual(result, {dropped: 1})
+    })
+
+    it('`indexCreate` should work with options', async function () {
+      let result = await r.db(dbName).table(tableName).indexCreate('foo', {multi: true}).run()
+      assert.deepEqual(result, {created: 1})
+
+      result = await r.db(dbName).table(tableName).indexCreate('foo1', r.row('foo'), {multi: true}).run()
+      assert.deepEqual(result, {created: 1})
+
+      result = await r.db(dbName).table(tableName).indexCreate('foo2', function (doc) { return doc('foo') }, {multi: true}).run()
+      assert.deepEqual(result, {created: 1})
+
+      await r.db(dbName).table(tableName).indexWait().run()
+
+      result = await r.db(dbName).table(tableName).insert({foo: ['bar1', 'bar2'], buzz: 1}).run()
+      assert.equal(result.inserted, 1)
+
+      result = await r.db(dbName).table(tableName).insert({foo: ['bar1', 'bar3'], buzz: 2}).run()
+      assert.equal(result.inserted, 1)
+
+      result = await r.db(dbName).table(tableName).getAll('bar1', {index: 'foo'}).count().run()
+      assert.equal(result, 2)
+
+      result = await r.db(dbName).table(tableName).getAll('bar1', {index: 'foo1'}).count().run()
+      assert.equal(result, 2)
+      result = await r.db(dbName).table(tableName).getAll('bar1', {index: 'foo2'}).count().run()
+      assert.equal(result, 2)
+
+      result = await r.db(dbName).table(tableName).getAll('bar2', {index: 'foo'}).count().run()
+      assert.equal(result, 1)
+      result = await r.db(dbName).table(tableName).getAll('bar2', {index: 'foo1'}).count().run()
+      assert.equal(result, 1)
+      result = await r.db(dbName).table(tableName).getAll('bar2', {index: 'foo2'}).count().run()
+      assert.equal(result, 1)
+
+      result = await r.db(dbName).table(tableName).getAll('bar3', {index: 'foo'}).count().run()
+      assert.equal(result, 1)
+      result = await r.db(dbName).table(tableName).getAll('bar3', {index: 'foo1'}).count().run()
+      assert.equal(result, 1)
+      result = await r.db(dbName).table(tableName).getAll('bar3', {index: 'foo2'}).count().run()
+      assert.equal(result, 1)
+
+      // Test when the function is wrapped in an array
+      result = await r.db(dbName).table(tableName).indexCreate('buzz', [r.row('buzz')]).run()
+      assert.deepEqual(result, {created: 1})
+
+      await r.db(dbName).table(tableName).indexWait().run()
+
+      result = await r.db(dbName).table(tableName).getAll([1], {index: 'buzz'}).count().run()
+      assert.equal(result, 1)
+    })
+
+    it('`indexCreate` should throw if no argument is passed', async function () {
+      try {
+        await r.db(dbName).table(tableName).indexCreate().run()
+        assert.fail('should throw')
+      } catch (e) {
+        assert.equal(e.message, '`indexCreate` takes at least 1 argument, 0 provided after:\nr.db("' + dbName + '").table("' + tableName + '")')
       }
-    };
+    })
 
-    if (found === false) {
-      done(new Error("Previously created table not found."))
-    }
-    else {
-      done();
-    }
-  }
-  catch(e) {
-    done(e);
-  }
-})
-
-
-It('`tableCreate` should create a table', function* (done) {
-  try {
-    tableName = uuid(); // export to the global scope
-
-    result = yield r.db(dbName).tableCreate(tableName).run();
-    assert.equal(result.tables_created, 1);
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`tableCreate` should create a table -- primaryKey', function* (done) {
-  try {
-    tableName = uuid();
-
-    result = yield r.db(dbName).tableCreate(tableName, {primaryKey: "foo"}).run();
-    assert.equal(result.tables_created, 1);
-
-    result = yield r.db(dbName).table(tableName).info().run();
-    assert(result.primary_key, "foo");
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`tableCreate` should create a table -- all args', function* (done) {
-  try {
-    tableName = uuid();
-
-    result = yield r.db(dbName).tableCreate(tableName, {durability: "soft", primaryKey: "foo"}).run();
-    assert.equal(result.tables_created, 1); // We can't really check other parameters...
-
-    result = yield r.db(dbName).table(tableName).info().run();
-    assert(result.primary_key, "foo");
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`tableCreate` should throw -- non valid args', function* (done) {
-  try {
-    tableName = uuid();
-
-    result = yield r.db(dbName).tableCreate(tableName, {nonValidArg: true}).run();
-  }
-  catch(e) {
-    if (e.message.match(/^Unrecognized option `nonValidArg` in `tableCreate`/)) {
-      done()
-    }
-    else {
-      done(e)
-    }
-  }
-})
-It('`tableCreate` should throw if no argument is given', function* (done) {
-  try {
-    result = yield r.db(dbName).tableCreate().run();
-  }
-  catch(e) {
-    if (e.message === '`tableCreate` takes at least 1 argument, 0 provided after:\nr.db("'+dbName+'")') {
-      done()
-    }
-    else {
-      done(e)
-    }
-  }
-})
-It('`tableCreate` should throw is the name contains special char', function* (done) {
-  try {
-    result = yield r.db(dbName).tableCreate("-_-").run();
-  }
-  catch(e) {
-    if (e.message.match(/Table name `-_-` invalid \(Use A-Za-z0-9_ only\)/)) { done(); }
-    else { done(e); }
-  }
-})
-
-
-
-It('`tableDrop` should drop a table', function* (done) {
-  try {
-    tableName = uuid();
-
-    result = yield r.db(dbName).tableCreate(tableName).run();
-    assert.equal(result.tables_created, 1);
-
-    result = yield r.db(dbName).tableList().run();
-
-    result = yield r.db(dbName).tableDrop(tableName).run();
-    assert.equal(result.tables_dropped, 1);
-
-    result = yield r.db(dbName).tableList().run();
-    assert(Array.isArray(result));
-
-    var found = false;
-    for(var i=0; i<result.length; i++) {
-      if (result[i] === tableName) {
-        found = true; 
-        break;
+    it('`indexDrop` should throw if no argument is passed', async function () {
+      try {
+        await r.db(dbName).table(tableName).indexDrop().run()
+        assert.fail('should throw')
+      } catch (e) {
+        assert.equal(e.message, '`indexDrop` takes 1 argument, 0 provided after:\nr.db("' + dbName + '").table("' + tableName + '")')
       }
-    };
+    })
 
-    if (found === true) done(new Error("Previously dropped table found."));
-    else done();
-  }
-  catch(e) {
-    done(e);
-  }
+    it('`indexRename` should work', async function () {
+      const toRename = uuid()
+      const renamed = uuid()
+      const existing = uuid()
+
+      let result = await r.db(dbName).table(tableName).indexCreate(toRename).run()
+      assert.deepEqual(result, {created: 1})
+
+      result = await r.db(dbName).table(tableName).indexRename(toRename, renamed).run()
+      assert.deepEqual(result, {renamed: 1})
+
+      result = await r.db(dbName).table(tableName).indexCreate(existing).run()
+      assert.deepEqual(result, {created: 1})
+
+      result = await r.db(dbName).table(tableName).indexRename(renamed, existing, {overwrite: true}).run()
+      assert.deepEqual(result, {renamed: 1})
+    })
+
+    it('`indexRename` should not overwrite an index if not specified', async function () {
+      try {
+        const name = uuid()
+        const otherName = uuid()
+
+        let result = await r.db(dbName).table(tableName).indexCreate(name).run()
+        assert.deepEqual(result, {created: 1})
+
+        result = await r.db(dbName).table(tableName).indexCreate(otherName).run()
+        assert.deepEqual(result, {created: 1})
+
+        await r.db(dbName).table(tableName).indexRename(otherName, name).run()
+        assert.fail('should throw')
+      } catch (e) {
+        assert(e.message.match(/^Index `.*` already exists on table/))
+      }
+    })
+
+    it('`indexRename` should throw -- non valid args', async function () {
+      try {
+        await r.db(dbName).table(tableName).indexRename('foo', 'bar', {nonValidArg: true}).run()
+        assert.fail('should throw')
+      } catch (e) {
+        assert(e.message.match(/^Unrecognized option `nonValidArg` in `indexRename`/))
+      }
+    })
+  })
 })
-
-It('`tableDrop` should throw if no argument is given', function* (done) {
-  try {
-    result = yield r.db(dbName).tableDrop().run();
-  }
-  catch(e) {
-    if (e.message === '`tableDrop` takes 1 argument, 0 provided after:\nr.db("'+dbName+'")') {
-      done()
-    }
-    else {
-      done(e)
-    }
-  }
-})
-
-
-It('index operations', function* (done) {
-  try {
-    dbName = uuid();
-    tableName = uuid();
-
-    result = yield r.dbCreate(dbName).run();
-    assert.equal(result.dbs_created, 1);
-
-    result = yield r.db(dbName).tableCreate(tableName).run();
-    assert.equal(result.tables_created, 1);
-
-    result = yield r.db(dbName).table(tableName).indexCreate("newField").run();
-    assert.deepEqual(result, {created: 1});
-
-    result = yield r.db(dbName).table(tableName).indexList().run();
-    assert.deepEqual(result, ["newField"]);
-
-    result = yield r.db(dbName).table(tableName).indexWait().pluck('index', 'ready').run();
-    assert.deepEqual(result, [ { index: 'newField', ready: true } ]);
-
-    result = yield r.db(dbName).table(tableName).indexStatus().pluck('index', 'ready').run();
-    assert.deepEqual(result, [ { index: 'newField', ready: true } ]);
-
-    result = yield r.db(dbName).table(tableName).indexDrop("newField").run();
-    assert.deepEqual(result, {dropped: 1});
-
-    result = yield r.db(dbName).table(tableName).indexCreate("field1", function(doc) { return doc("field1") }).run();
-    assert.deepEqual(result, {created: 1});
-
-    result = yield r.db(dbName).table(tableName).indexWait('field1').pluck('index', 'ready').run();
-    assert.deepEqual(result, [ { index: 'field1', ready: true } ]);
-
-    result = yield r.db(dbName).table(tableName).indexStatus('field1').pluck('index', 'ready').run();
-    assert.deepEqual(result, [ { index: 'field1', ready: true } ]);
-
-    result = yield r.db(dbName).table(tableName).indexDrop("field1").run();
-    assert.deepEqual(result, {dropped: 1});
-
-    done();
-  }
-  catch(e) {
-    done(e)
-  }
-})
-
-
-It('`indexCreate` should work with options', function* (done) {
-  try {
-    var result = yield r.db(dbName).table(tableName).indexCreate("foo", {multi: true}).run();
-    assert.deepEqual(result, {created: 1});
-
-    result = yield r.db(dbName).table(tableName).indexCreate("foo1", r.row("foo"), {multi: true}).run();
-    assert.deepEqual(result, {created: 1});
-
-    result = yield r.db(dbName).table(tableName).indexCreate("foo2", function(doc) { return doc("foo")}, {multi: true}).run();
-    assert.deepEqual(result, {created: 1});
-
-    yield r.db(dbName).table(tableName).indexWait().run();
-
-    result = yield r.db(dbName).table(tableName).insert({foo: ["bar1", "bar2"], buzz: 1}).run()
-    assert.equal(result.inserted, 1); 
-
-    result = yield r.db(dbName).table(tableName).insert({foo: ["bar1", "bar3"], buzz: 2}).run()
-    assert.equal(result.inserted, 1); 
-
-    result = yield r.db(dbName).table(tableName).getAll("bar1", {index: "foo"}).count().run()
-    assert.equal(result, 2)
-
-    result = yield r.db(dbName).table(tableName).getAll("bar1", {index: "foo1"}).count().run()
-    assert.equal(result, 2)
-    result = yield r.db(dbName).table(tableName).getAll("bar1", {index: "foo2"}).count().run()
-    assert.equal(result, 2)
-
-    result = yield r.db(dbName).table(tableName).getAll("bar2", {index: "foo"}).count().run()
-    assert.equal(result, 1)
-    result = yield r.db(dbName).table(tableName).getAll("bar2", {index: "foo1"}).count().run()
-    assert.equal(result, 1)
-    result = yield r.db(dbName).table(tableName).getAll("bar2", {index: "foo2"}).count().run()
-    assert.equal(result, 1)
-
-    result = yield r.db(dbName).table(tableName).getAll("bar3", {index: "foo"}).count().run()
-    assert.equal(result, 1)
-    result = yield r.db(dbName).table(tableName).getAll("bar3", {index: "foo1"}).count().run()
-    assert.equal(result, 1)
-    result = yield r.db(dbName).table(tableName).getAll("bar3", {index: "foo2"}).count().run()
-    assert.equal(result, 1)
-
-
-    // Test when the function is wrapped in an array
-    result = yield r.db(dbName).table(tableName).indexCreate("buzz", [r.row("buzz")]).run();
-    assert.deepEqual(result, {created: 1});
-
-    yield r.db(dbName).table(tableName).indexWait().run();
-
-    result = yield r.db(dbName).table(tableName).getAll([1], {index: "buzz"}).count().run()
-    assert.equal(result, 1)
-
-    done()
-
-  }
-  catch(e) {
-    done(e)
-  }
-
-})
-
-It('`indexCreate` should throw if no argument is passed', function* (done) {
-  try {
-    var result = yield r.db(dbName).table(tableName).indexCreate().run();
-  }
-  catch(e) {
-    if (e.message === '`indexCreate` takes at least 1 argument, 0 provided after:\nr.db("'+dbName+'").table("'+tableName+'")') {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
-})
-It('`indexDrop` should throw if no argument is passed', function* (done) {
-  try {
-    var result = yield r.db(dbName).table(tableName).indexDrop().run();
-  }
-  catch(e) {
-    if (e.message === '`indexDrop` takes 1 argument, 0 provided after:\nr.db("'+dbName+'").table("'+tableName+'")') {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
-})
-It('`indexRename` should work', function* (done) {
-  var toRename = uuid();
-  var renamed = uuid();
-  var existing = uuid();
-  try {
-    var result = yield r.db(dbName).table(tableName).indexCreate(toRename).run();
-    assert.deepEqual(result, {created: 1});
-
-    var result = yield r.db(dbName).table(tableName).indexRename(toRename, renamed).run();
-    assert.deepEqual(result, {renamed: 1});
-
-    var result = yield r.db(dbName).table(tableName).indexCreate(existing).run();
-    assert.deepEqual(result, {created: 1});
-
-    var result = yield r.db(dbName).table(tableName).indexRename(renamed, existing, {overwrite: true}).run();
-    assert.deepEqual(result, {renamed: 1});
-
-
-    done()
-
-  }
-  catch(e) {
-    console.log(e);
-    done(e)
-  }
-
-})
-It('`indexRename` should not overwrite an index if not specified', function* (done) {
-  try {
-    var name = uuid();
-    var otherName = uuid();
-
-    var result = yield r.db(dbName).table(tableName).indexCreate(name).run();
-    assert.deepEqual(result, {created: 1});
-    var result = yield r.db(dbName).table(tableName).indexCreate(otherName).run();
-    assert.deepEqual(result, {created: 1});
-
-    var result = yield r.db(dbName).table(tableName).indexRename(otherName, name).run();
-  }
-  catch(e) {
-    if (e.message.match(/^Index `.*` already exists on table/)) {
-      done()
-    }
-    else {
-      done(e)
-    }
-  }
-})
-It('`indexRename` should throw -- non valid args', function* (done) {
-  try {
-    tableName = uuid();
-
-    result = yield r.db(dbName).table(tableName).indexRename("foo", "bar", {nonValidArg: true}).run();
-  }
-  catch(e) {
-    if (e.message.match(/^Unrecognized option `nonValidArg` in `indexRename`/)) {
-      done()
-    }
-    else {
-      done(e)
-    }
-  }
-})
-

--- a/test/math-and-logic.js
+++ b/test/math-and-logic.js
@@ -1,798 +1,552 @@
-var config = require(__dirname+'/config.js');
-var r = require(__dirname+'/../lib')(config);
-var util = require(__dirname+'/util/common.js');
-var assert = require('assert');
+const path = require('path')
+const config = require('./config.js')
+const rethinkdbdash = require(path.join(__dirname, '/../lib'))
+const assert = require('assert')
+const {before, after, describe, it} = require('mocha')
 
-var uuid = util.uuid;
-var It = util.It;
+describe('math and logic', () => {
+  let r
 
-var uuid = util.uuid;
-var dbName, tableName, result;
+  before(async () => {
+    r = await rethinkdbdash(config)
+  })
 
-It('`add` should work', function* (done) {
-  try {
-    result = yield r.expr(1).add(1).run();
-    assert.equal(result, 2);
+  after(async () => {
+    await r.getPoolMaster().drain()
+  })
 
-    result = yield r.expr(1).add(1).add(1).run();
-    assert.equal(result, 3);
+  it('`add` should work', async function () {
+    let result = await r.expr(1).add(1).run()
+    assert.equal(result, 2)
 
-    result = yield r.expr(1).add(1, 1).run();
-    assert.equal(result, 3);
+    result = await r.expr(1).add(1).add(1).run()
+    assert.equal(result, 3)
 
-    result = yield r.add(1, 1, 1).run();
-    assert.equal(result, 3);
+    result = await r.expr(1).add(1, 1).run()
+    assert.equal(result, 3)
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
+    result = await r.add(1, 1, 1).run()
+    assert.equal(result, 3)
+  })
+
+  it('`add` should throw if no argument has been passed', async function () {
+    try {
+      await r.expr(1).add().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`add` takes at least 1 argument, 0 provided after:\nr.expr(1)')
+    }
+  })
+
+  it('`add` should throw if no argument has been passed -- r.add', async function () {
+    try {
+      await r.add().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`r.add` takes at least 2 arguments, 0 provided.')
+    }
+  })
+
+  it('`add` should throw if just one argument has been passed -- r.add', async function () {
+    try {
+      await r.add(1).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`r.add` takes at least 2 arguments, 1 provided.')
+    }
+  })
+
+  it('`sub` should work', async function () {
+    var result = await r.expr(1).sub(1).run()
+    assert.equal(result, 0)
+
+    result = await r.sub(5, 3, 1).run()
+    assert.equal(result, 1)
+  })
+
+  it('`sub` should throw if no argument has been passed', async function () {
+    try {
+      await r.expr(1).sub().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`sub` takes at least 1 argument, 0 provided after:\nr.expr(1)')
+    }
+  })
+
+  it('`sub` should throw if no argument has been passed -- r.sub', async function () {
+    try {
+      await r.sub().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`r.sub` takes at least 2 arguments, 0 provided.')
+    }
+  })
+
+  it('`sub` should throw if just one argument has been passed -- r.sub', async function () {
+    try {
+      await r.sub(1).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`r.sub` takes at least 2 arguments, 1 provided.')
+    }
+  })
+
+  it('`mul` should work', async function () {
+    let result = await r.expr(2).mul(3).run()
+    assert.equal(result, 6)
+
+    result = await r.mul(2, 3, 4).run()
+    assert.equal(result, 24)
+  })
+
+  it('`mul` should throw if no argument has been passed', async function () {
+    try {
+      await r.expr(1).mul().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`mul` takes at least 1 argument, 0 provided after:\nr.expr(1)')
+    }
+  })
+
+  it('`mul` should throw if no argument has been passed -- r.mul', async function () {
+    try {
+      await r.mul().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`r.mul` takes at least 2 arguments, 0 provided.')
+    }
+  })
+
+  it('`mul` should throw if just one argument has been passed -- r.mul', async function () {
+    try {
+      await r.mul(1).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`r.mul` takes at least 2 arguments, 1 provided.')
+    }
+  })
+
+  it('`div` should work', async function () {
+    let result = await r.expr(24).div(2).run()
+    assert.equal(result, 12)
+
+    result = await r.div(20, 2, 5, 1).run()
+    assert.equal(result, 2)
+  })
+
+  it('`div` should throw if no argument has been passed', async function () {
+    try {
+      await r.expr(1).div().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`div` takes at least 1 argument, 0 provided after:\nr.expr(1)')
+    }
+  })
+
+  it('`div` should throw if no argument has been passed -- r.div', async function () {
+    try {
+      await r.div().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`r.div` takes at least 2 arguments, 0 provided.')
+    }
+  })
+
+  it('`div` should throw if just one argument has been passed -- r.div', async function () {
+    try {
+      await r.div(1).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`r.div` takes at least 2 arguments, 1 provided.')
+    }
+  })
+
+  it('`mod` should work', async function () {
+    var result = await r.expr(24).mod(7).run()
+    assert.equal(result, 3)
+
+    result = await r.mod(24, 7).run()
+    assert.equal(result, 3)
+  })
+
+  it('`mod` should throw if no argument has been passed', async function () {
+    try {
+      await r.expr(1).mod().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`mod` takes 1 argument, 0 provided after:\nr.expr(1)')
+    }
+  })
+
+  it('`mod` should throw if more than two arguments -- r.mod', async function () {
+    try {
+      await r.mod(24, 7, 2).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`r.mod` takes 2 arguments, 3 provided.')
+    }
+  })
+
+  it('`and` should work', async function () {
+    let result = await r.expr(true).and(false).run()
+    assert.equal(result, false)
+
+    result = await r.expr(true).and(true).run()
+    assert.equal(result, true)
+
+    result = await r.and(true, true, true).run()
+    assert.equal(result, true)
+
+    result = await r.and(true, true, true, false).run()
+    assert.equal(result, false)
+
+    result = await r.and(r.args([true, true, true])).run()
+    assert.equal(result, true)
+  })
+
+  it('`and` should work if no argument has been passed -- r.and', async function () {
+    const result = await r.and().run()
+    assert.equal(result, true)
+  })
+
+  it('`or` should work', async function () {
+    let result = await r.expr(true).or(false).run()
+    assert.equal(result, true)
+
+    result = await r.expr(false).or(false).run()
+    assert.equal(result, false)
+
+    result = await r.or(true, true, true).run()
+    assert.equal(result, true)
+
+    result = await r.or(r.args([false, false, true])).run()
+    assert.equal(result, true)
+
+    result = await r.or(false, false, false, false).run()
+    assert.equal(result, false)
+  })
+
+  it('`or` should work if no argument has been passed -- r.or', async function () {
+    const result = await r.or().run()
+    assert.equal(result, false)
+  })
+
+  it('`eq` should work', async function () {
+    let result = await r.expr(1).eq(1).run()
+    assert.equal(result, true)
+
+    result = await r.expr(1).eq(2).run()
+    assert.equal(result, false)
+
+    result = await r.eq(1, 1, 1, 1).run()
+    assert.equal(result, true)
+
+    result = await r.eq(1, 1, 2, 1).run()
+    assert.equal(result, false)
+  })
+
+  it('`eq` should throw if no argument has been passed', async function () {
+    try {
+      await r.expr(1).eq().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`eq` takes at least 1 argument, 0 provided after:\nr.expr(1)')
+    }
+  })
+
+  it('`eq` should throw if no argument has been passed -- r.eq', async function () {
+    try {
+      await r.eq().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`r.eq` takes at least 2 arguments, 0 provided.')
+    }
+  })
+
+  it('`eq` should throw if just one argument has been passed -- r.eq', async function () {
+    try {
+      await r.eq(1).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`r.eq` takes at least 2 arguments, 1 provided.')
+    }
+  })
+
+  it('`ne` should work', async function () {
+    let result = await r.expr(1).ne(1).run()
+    assert.equal(result, false)
+
+    result = await r.expr(1).ne(2).run()
+    assert.equal(result, true)
+
+    result = await r.ne(1, 1, 1, 1).run()
+    assert.equal(result, false)
+
+    result = await r.ne(1, 1, 2, 1).run()
+    assert.equal(result, true)
+  })
+
+  it('`ne` should throw if no argument has been passed', async function () {
+    try {
+      await r.expr(1).ne().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`ne` takes at least 1 argument, 0 provided after:\nr.expr(1)')
+    }
+  })
+
+  it('`ne` should throw if no argument has been passed -- r.ne', async function () {
+    try {
+      await r.ne().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`r.ne` takes at least 2 arguments, 0 provided.')
+    }
+  })
+
+  it('`ne` should throw if just one argument has been passed -- r.ne', async function () {
+    try {
+      await r.ne(1).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`r.ne` takes at least 2 arguments, 1 provided.')
+    }
+  })
+
+  it('`gt` should work', async function () {
+    let result = await r.expr(1).gt(2).run()
+    assert.equal(result, false)
+    result = await r.expr(2).gt(2).run()
+    assert.equal(result, false)
+    result = await r.expr(3).gt(2).run()
+    assert.equal(result, true)
+
+    result = await r.gt(10, 9, 7, 2).run()
+    assert.equal(result, true)
+
+    result = await r.gt(10, 9, 9, 1).run()
+    assert.equal(result, false)
+  })
+
+  it('`gt` should throw if no argument has been passed', async function () {
+    try {
+      await r.expr(1).gt().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`gt` takes at least 1 argument, 0 provided after:\nr.expr(1)')
+    }
+  })
+
+  it('`gt` should throw if no argument has been passed -- r.gt', async function () {
+    try {
+      await r.gt().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`r.gt` takes at least 2 arguments, 0 provided.')
+    }
+  })
+  it('`gt` should throw if just one argument has been passed -- r.gt', async function () {
+    try {
+      await r.gt(1).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`r.gt` takes at least 2 arguments, 1 provided.')
+    }
+  })
+
+  it('`ge` should work', async function () {
+    let result = await r.expr(1).ge(2).run()
+    assert.equal(result, false)
+    result = await r.expr(2).ge(2).run()
+    assert.equal(result, true)
+    result = await r.expr(3).ge(2).run()
+    assert.equal(result, true)
+
+    result = await r.ge(10, 9, 7, 2).run()
+    assert.equal(result, true)
+
+    result = await r.ge(10, 9, 9, 1).run()
+    assert.equal(result, true)
+
+    result = await r.ge(10, 9, 10, 1).run()
+    assert.equal(result, false)
+  })
+
+  it('`ge` should throw if no argument has been passed', async function () {
+    try {
+      await r.expr(1).ge().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`ge` takes at least 1 argument, 0 provided after:\nr.expr(1)')
+    }
+  })
+
+  it('`ge` should throw if no argument has been passed -- r.ge', async function () {
+    try {
+      await r.ge().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`r.ge` takes at least 2 arguments, 0 provided.')
+    }
+  })
+
+  it('`ge` should throw if just one argument has been passed -- r.ge', async function () {
+    try {
+      await r.ge(1).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`r.ge` takes at least 2 arguments, 1 provided.')
+    }
+  })
+
+  it('`lt` should work', async function () {
+    let result = await r.expr(1).lt(2).run()
+    assert.equal(result, true)
+    result = await r.expr(2).lt(2).run()
+    assert.equal(result, false)
+    result = await r.expr(3).lt(2).run()
+    assert.equal(result, false)
+
+    result = await r.lt(0, 2, 4, 20).run()
+    assert.equal(result, true)
+
+    result = await r.lt(0, 2, 2, 4).run()
+    assert.equal(result, false)
+
+    result = await r.lt(0, 2, 1, 20).run()
+    assert.equal(result, false)
+  })
+
+  it('`lt` should throw if no argument has been passed', async function () {
+    try {
+      await r.expr(1).lt().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`lt` takes at least 1 argument, 0 provided after:\nr.expr(1)')
+    }
+  })
+
+  it('`lt` should throw if no argument has been passed -- r.lt', async function () {
+    try {
+      await r.lt().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`r.lt` takes at least 2 arguments, 0 provided.')
+    }
+  })
+
+  it('`lt` should throw if just one argument has been passed -- r.lt', async function () {
+    try {
+      await r.lt(1).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`r.lt` takes at least 2 arguments, 1 provided.')
+    }
+  })
+
+  it('`le` should work', async function () {
+    let result = await r.expr(1).le(2).run()
+    assert.equal(result, true)
+    result = await r.expr(2).le(2).run()
+    assert.equal(result, true)
+    result = await r.expr(3).le(2).run()
+    assert.equal(result, false)
+
+    result = await r.le(0, 2, 4, 20).run()
+    assert.equal(result, true)
+
+    result = await r.le(0, 2, 2, 4).run()
+    assert.equal(result, true)
+
+    result = await r.le(0, 2, 1, 20).run()
+    assert.equal(result, false)
+  })
+
+  it('`le` should throw if no argument has been passed', async function () {
+    try {
+      await r.expr(1).le().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`le` takes at least 1 argument, 0 provided after:\nr.expr(1)')
+    }
+  })
+
+  it('`le` should throw if no argument has been passed -- r.le', async function () {
+    try {
+      await r.le().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`r.le` takes at least 2 arguments, 0 provided.')
+    }
+  })
+
+  it('`le` should throw if just one argument has been passed -- r.le', async function () {
+    try {
+      await r.le(1).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`r.le` takes at least 2 arguments, 1 provided.')
+    }
+  })
+
+  it('`not` should work', async function () {
+    let result = await r.expr(true).not().run()
+    assert.equal(result, false)
+    result = await r.expr(false).not().run()
+    assert.equal(result, true)
+  })
+
+  it('`random` should work', async function () {
+    let result = await r.random().run()
+    assert((result > 0) && (result < 1))
+
+    result = await r.random(10).run()
+    assert((result >= 0) && (result < 10))
+    assert.equal(Math.floor(result), result)
+
+    result = await r.random(5, 10).run()
+    assert((result >= 5) && (result < 10))
+    assert.equal(Math.floor(result), result)
+
+    result = await r.random(5, 10, {float: true}).run()
+    assert((result >= 5) && (result < 10))
+    assert.notEqual(Math.floor(result), result) // that's "almost" safe
+
+    result = await r.random(5, {float: true}).run()
+    assert((result < 5) && (result > 0))
+    assert.notEqual(Math.floor(result), result) // that's "almost" safe
+  })
+
+  it('`r.floor` should work', async function () {
+    let result = await r.floor(1.2).run()
+    assert.equal(result, 1)
+    result = await r.expr(1.2).floor().run()
+    assert.equal(result, 1)
+    result = await r.floor(1.8).run()
+    assert.equal(result, 1)
+    result = await r.expr(1.8).floor().run()
+    assert.equal(result, 1)
+  })
+
+  it('`r.ceil` should work', async function () {
+    let result = await r.ceil(1.2).run()
+    assert.equal(result, 2)
+    result = await r.expr(1.2).ceil().run()
+    assert.equal(result, 2)
+    result = await r.ceil(1.8).run()
+    assert.equal(result, 2)
+    result = await r.expr(1.8).ceil().run()
+    assert.equal(result, 2)
+  })
+
+  it('`r.round` should work', async function () {
+    let result = await r.round(1.8).run()
+    assert.equal(result, 2)
+    result = await r.expr(1.8).round().run()
+    assert.equal(result, 2)
+    result = await r.round(1.2).run()
+    assert.equal(result, 1)
+    result = await r.expr(1.2).round().run()
+    assert.equal(result, 1)
+  })
 })
-It('`add` should throw if no argument has been passed', function* (done) {
-  try {
-    var result = yield r.expr(1).add().run();
-  }
-  catch(e) {
-    if (e.message === "`add` takes at least 1 argument, 0 provided after:\nr.expr(1)") {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
-})
-
-It('`add` should throw if no argument has been passed -- r.add', function* (done) {
-  try {
-    var result = yield r.add().run();
-  }
-  catch(e) {
-    if (e.message === "`r.add` takes at least 2 arguments, 0 provided.") {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
-})
-It('`add` should throw if just one argument has been passed -- r.add', function* (done) {
-  try {
-    var result = yield r.add(1).run();
-  }
-  catch(e) {
-    if (e.message === "`r.add` takes at least 2 arguments, 1 provided.") {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
-})
-
-It('`sub` should work', function* (done) {
-  try {
-    var result = yield r.expr(1).sub(1).run();
-    assert.equal(result, 0);
-
-    result = yield r.sub(5, 3, 1).run();
-    assert.equal(result, 1);
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`sub` should throw if no argument has been passed', function* (done) {
-  try {
-    var result = yield r.expr(1).sub().run();
-  }
-  catch(e) {
-    if (e.message === "`sub` takes at least 1 argument, 0 provided after:\nr.expr(1)") {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
-})
-It('`sub` should throw if no argument has been passed -- r.sub', function* (done) {
-  try {
-    var result = yield r.sub().run();
-  }
-  catch(e) {
-    if (e.message === "`r.sub` takes at least 2 arguments, 0 provided.") {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
-})
-It('`sub` should throw if just one argument has been passed -- r.sub', function* (done) {
-  try {
-    var result = yield r.sub(1).run();
-  }
-  catch(e) {
-    if (e.message === "`r.sub` takes at least 2 arguments, 1 provided.") {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
-})
-It('`mul` should work', function* (done) {
-  try {
-    var result = yield r.expr(2).mul(3).run();
-    assert.equal(result, 6);
-
-    result = yield r.mul(2, 3, 4).run();
-    assert.equal(result, 24);
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`mul` should throw if no argument has been passed', function* (done) {
-  try {
-    var result = yield r.expr(1).mul().run();
-  }
-  catch(e) {
-    if (e.message === "`mul` takes at least 1 argument, 0 provided after:\nr.expr(1)") {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
-})
-It('`mul` should throw if no argument has been passed -- r.mul', function* (done) {
-  try {
-    var result = yield r.mul().run();
-  }
-  catch(e) {
-    if (e.message === "`r.mul` takes at least 2 arguments, 0 provided.") {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
-})
-It('`mul` should throw if just one argument has been passed -- r.mul', function* (done) {
-  try {
-    var result = yield r.mul(1).run();
-  }
-  catch(e) {
-    if (e.message === "`r.mul` takes at least 2 arguments, 1 provided.") {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
-})
-It('`div` should work', function* (done) {
-  try {
-    var result = yield r.expr(24).div(2).run();
-    assert.equal(result, 12);
-
-    result = yield r.div(20, 2, 5, 1).run();
-    assert.equal(result, 2);
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`div` should throw if no argument has been passed', function* (done) {
-  try {
-    var result = yield r.expr(1).div().run();
-  }
-  catch(e) {
-    if (e.message === "`div` takes at least 1 argument, 0 provided after:\nr.expr(1)") {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
-})
-It('`div` should throw if no argument has been passed -- r.div', function* (done) {
-  try {
-    var result = yield r.div().run();
-  }
-  catch(e) {
-    if (e.message === "`r.div` takes at least 2 arguments, 0 provided.") {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
-})
-It('`div` should throw if just one argument has been passed -- r.div', function* (done) {
-  try {
-    var result = yield r.div(1).run();
-  }
-  catch(e) {
-    if (e.message === "`r.div` takes at least 2 arguments, 1 provided.") {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
-})
-It('`mod` should work', function* (done) {
-  try {
-    var result = yield r.expr(24).mod(7).run();
-    assert.equal(result, 3);
-
-    result = yield r.mod(24, 7).run();
-    assert.equal(result, 3);
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`mod` should throw if no argument has been passed', function* (done) {
-  try {
-    var result = yield r.expr(1).mod().run();
-  }
-  catch(e) {
-    if (e.message === "`mod` takes 1 argument, 0 provided after:\nr.expr(1)") {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
-})
-It('`mod` should throw if more than two arguments -- r.mod', function* (done) {
-  try {
-    var result = yield r.mod(24, 7, 2).run();
-  }
-  catch(e) {
-    if (e.message === "`r.mod` takes 2 arguments, 3 provided.") {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
-})
-It('`and` should work', function* (done) {
-  try {
-    var result = yield r.expr(true).and(false).run();
-    assert.equal(result, false);
-
-    result = yield r.expr(true).and(true).run();
-    assert.equal(result, true);
-
-    result = yield r.and(true, true, true).run();
-    assert.equal(result, true);
-
-    result = yield r.and(true, true, true, false).run();
-    assert.equal(result, false);
-
-    result = yield r.and(r.args([true, true, true])).run();
-    assert.equal(result, true);
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`and` should work if no argument has been passed -- r.and', function* (done) {
-  try {
-    var result = yield r.and().run();
-    assert.equal(result, true);
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`or` should work', function* (done) {
-  try {
-    var result = yield r.expr(true).or(false).run();
-    assert.equal(result, true);
-
-    result = yield r.expr(false).or(false).run();
-    assert.equal(result, false);
-
-    result = yield r.or(true, true, true).run();
-    assert.equal(result, true);
-
-    result = yield r.or(r.args([false, false, true])).run();
-    assert.equal(result, true);
-
-
-    result = yield r.or(false, false, false, false).run();
-    assert.equal(result, false);
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`or` should work if no argument has been passed -- r.or', function* (done) {
-  try {
-    var result = yield r.or().run();
-    assert.equal(result, false);
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-
-It('`eq` should work', function* (done) {
-  try {
-    var result = yield r.expr(1).eq(1).run();
-    assert.equal(result, true);
-
-    result = yield r.expr(1).eq(2).run();
-    assert.equal(result, false);
-
-    result = yield r.eq(1, 1, 1, 1).run();
-    assert.equal(result, true);
-
-    result = yield r.eq(1, 1, 2, 1).run();
-    assert.equal(result, false);
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`eq` should throw if no argument has been passed', function* (done) {
-  try {
-    var result = yield r.expr(1).eq().run();
-  }
-  catch(e) {
-    if (e.message === "`eq` takes at least 1 argument, 0 provided after:\nr.expr(1)") {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
-})
-It('`eq` should throw if no argument has been passed -- r.eq', function* (done) {
-  try {
-    var result = yield r.eq().run();
-  }
-  catch(e) {
-    if (e.message === "`r.eq` takes at least 2 arguments, 0 provided.") {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
-})
-It('`eq` should throw if just one argument has been passed -- r.eq', function* (done) {
-  try {
-    var result = yield r.eq(1).run();
-  }
-  catch(e) {
-    if (e.message === "`r.eq` takes at least 2 arguments, 1 provided.") {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
-})
-It('`ne` should work', function* (done) {
-  try {
-    var result = yield r.expr(1).ne(1).run();
-    assert.equal(result, false);
-
-    result = yield r.expr(1).ne(2).run();
-    assert.equal(result, true);
-
-    result = yield r.ne(1, 1, 1, 1).run();
-    assert.equal(result, false);
-
-    result = yield r.ne(1, 1, 2, 1).run();
-    assert.equal(result, true);
-
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`ne` should throw if no argument has been passed', function* (done) {
-  try {
-    var result = yield r.expr(1).ne().run();
-  }
-  catch(e) {
-    if (e.message === "`ne` takes at least 1 argument, 0 provided after:\nr.expr(1)") {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
-})
-It('`ne` should throw if no argument has been passed -- r.ne', function* (done) {
-  try {
-    var result = yield r.ne().run();
-  }
-  catch(e) {
-    if (e.message === "`r.ne` takes at least 2 arguments, 0 provided.") {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
-})
-It('`ne` should throw if just one argument has been passed -- r.ne', function* (done) {
-  try {
-    var result = yield r.ne(1).run();
-  }
-  catch(e) {
-    if (e.message === "`r.ne` takes at least 2 arguments, 1 provided.") {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
-})
-It('`gt` should work', function* (done) {
-  try {
-    var result = yield r.expr(1).gt(2).run();
-    assert.equal(result, false);
-    result = yield r.expr(2).gt(2).run();
-    assert.equal(result, false);
-    result = yield r.expr(3).gt(2).run();
-    assert.equal(result, true);
-
-    result = yield r.gt(10, 9, 7, 2).run();
-    assert.equal(result, true);
-
-    result = yield r.gt(10, 9, 9, 1).run();
-    assert.equal(result, false);
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`gt` should throw if no argument has been passed', function* (done) {
-  try {
-    var result = yield r.expr(1).gt().run();
-  }
-  catch(e) {
-    if (e.message === "`gt` takes at least 1 argument, 0 provided after:\nr.expr(1)") {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
-})
-It('`gt` should throw if no argument has been passed -- r.gt', function* (done) {
-  try {
-    var result = yield r.gt().run();
-  }
-  catch(e) {
-    if (e.message === "`r.gt` takes at least 2 arguments, 0 provided.") {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
-})
-It('`gt` should throw if just one argument has been passed -- r.gt', function* (done) {
-  try {
-    var result = yield r.gt(1).run();
-  }
-  catch(e) {
-    if (e.message === "`r.gt` takes at least 2 arguments, 1 provided.") {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
-})
-It('`ge` should work', function* (done) {
-  try {
-    var result = yield r.expr(1).ge(2).run();
-    assert.equal(result, false);
-    result = yield r.expr(2).ge(2).run();
-    assert.equal(result, true);
-    result = yield r.expr(3).ge(2).run();
-    assert.equal(result, true);
-
-    result = yield r.ge(10, 9, 7, 2).run();
-    assert.equal(result, true);
-
-    result = yield r.ge(10, 9, 9, 1).run();
-    assert.equal(result, true);
-
-    result = yield r.ge(10, 9, 10, 1).run();
-    assert.equal(result, false);
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`ge` should throw if no argument has been passed', function* (done) {
-  try {
-    var result = yield r.expr(1).ge().run();
-  }
-  catch(e) {
-    if (e.message === "`ge` takes at least 1 argument, 0 provided after:\nr.expr(1)") {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
-})
-It('`ge` should throw if no argument has been passed -- r.ge', function* (done) {
-  try {
-    var result = yield r.ge().run();
-  }
-  catch(e) {
-    if (e.message === "`r.ge` takes at least 2 arguments, 0 provided.") {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
-})
-It('`ge` should throw if just one argument has been passed -- r.ge', function* (done) {
-  try {
-    var result = yield r.ge(1).run();
-  }
-  catch(e) {
-    if (e.message === "`r.ge` takes at least 2 arguments, 1 provided.") {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
-})
-It('`lt` should work', function* (done) {
-  try {
-    var result = yield r.expr(1).lt(2).run();
-    assert.equal(result, true);
-    result = yield r.expr(2).lt(2).run();
-    assert.equal(result, false);
-    result = yield r.expr(3).lt(2).run();
-    assert.equal(result, false);
-
-    result = yield r.lt(0, 2, 4, 20).run();
-    assert.equal(result, true);
-
-    result = yield r.lt(0, 2, 2, 4).run();
-    assert.equal(result, false);
-
-    result = yield r.lt(0, 2, 1, 20).run();
-    assert.equal(result, false);
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`lt` should throw if no argument has been passed', function* (done) {
-  try {
-    var result = yield r.expr(1).lt().run();
-  }
-  catch(e) {
-    if (e.message === "`lt` takes at least 1 argument, 0 provided after:\nr.expr(1)") {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
-})
-It('`lt` should throw if no argument has been passed -- r.lt', function* (done) {
-  try {
-    var result = yield r.lt().run();
-  }
-  catch(e) {
-    if (e.message === "`r.lt` takes at least 2 arguments, 0 provided.") {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
-})
-It('`lt` should throw if just one argument has been passed -- r.lt', function* (done) {
-  try {
-    var result = yield r.lt(1).run();
-  }
-  catch(e) {
-    if (e.message === "`r.lt` takes at least 2 arguments, 1 provided.") {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
-})
-It('`le` should work', function* (done) {
-  try {
-    var result = yield r.expr(1).le(2).run();
-    assert.equal(result, true);
-    result = yield r.expr(2).le(2).run();
-    assert.equal(result, true);
-    result = yield r.expr(3).le(2).run();
-    assert.equal(result, false);
-
-    result = yield r.le(0, 2, 4, 20).run();
-    assert.equal(result, true);
-
-    result = yield r.le(0, 2, 2, 4).run();
-    assert.equal(result, true);
-
-    result = yield r.le(0, 2, 1, 20).run();
-    assert.equal(result, false);
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`le` should throw if no argument has been passed', function* (done) {
-  try {
-    var result = yield r.expr(1).le().run();
-  }
-  catch(e) {
-    if (e.message === "`le` takes at least 1 argument, 0 provided after:\nr.expr(1)") {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
-})
-It('`le` should throw if no argument has been passed -- r.le', function* (done) {
-  try {
-    var result = yield r.le().run();
-  }
-  catch(e) {
-    if (e.message === "`r.le` takes at least 2 arguments, 0 provided.") {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
-})
-It('`le` should throw if just one argument has been passed -- r.le', function* (done) {
-  try {
-    var result = yield r.le(1).run();
-  }
-  catch(e) {
-    if (e.message === "`r.le` takes at least 2 arguments, 1 provided.") {
-      done();
-    }
-    else {
-      done(e);
-    }
-  }
-})
-It('`not` should work', function* (done) {
-  try {
-    var result = yield r.expr(true).not().run();
-    assert.equal(result, false);
-    result = yield r.expr(false).not().run();
-    assert.equal(result, true);
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`random` should work', function* (done) {
-  try {
-    var result = yield r.random().run();
-    assert((result > 0) && (result < 1));
-
-    result = yield r.random(10).run();
-    assert((result >= 0) && (result < 10));
-    assert.equal(Math.floor(result), result);
-
-    result = yield r.random(5, 10).run();
-    assert((result >= 5) && (result < 10));
-    assert.equal(Math.floor(result), result);
-
-    result = yield r.random(5, 10, {float: true}).run();
-    assert((result >= 5) && (result < 10));
-    assert.notEqual(Math.floor(result), result); // that's "almost" safe
-
-    result = yield r.random(5, {float: true}).run();
-    assert((result < 5) && (result > 0));
-    assert.notEqual(Math.floor(result), result); // that's "almost" safe
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`r.floor` should work', function* (done) {
-  try {
-    var result = yield r.floor(1.2).run();
-    assert.equal(result, 1);
-    result = yield r.expr(1.2).floor().run();
-    assert.equal(result, 1);
-    result = yield r.floor(1.8).run();
-    assert.equal(result, 1);
-    result = yield r.expr(1.8).floor().run();
-    assert.equal(result, 1);
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`r.ceil` should work', function* (done) {
-  try {
-    var result = yield r.ceil(1.2).run();
-    assert.equal(result, 2);
-    result = yield r.expr(1.2).ceil().run();
-    assert.equal(result, 2);
-    result = yield r.ceil(1.8).run();
-    assert.equal(result, 2);
-    result = yield r.expr(1.8).ceil().run();
-    assert.equal(result, 2);
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`r.round` should work', function* (done) {
-  try {
-    var result = yield r.round(1.8).run();
-    assert.equal(result, 2);
-    result = yield r.expr(1.8).round().run();
-    assert.equal(result, 2);
-    result = yield r.round(1.2).run();
-    assert.equal(result, 1);
-    result = yield r.expr(1.2).round().run();
-    assert.equal(result, 1);
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-

--- a/test/multiple-require.js
+++ b/test/multiple-require.js
@@ -1,47 +1,39 @@
-var config = require(__dirname+'/config.js');
-var r = require(__dirname+'/../lib')(config);
-var r_ = require(__dirname+'/../lib')(config);
-var util = require(__dirname+'/util/common.js');
-var assert = require('assert');
+const path = require('path')
+const config = require(path.join(__dirname, '/config.js'))
+const rethinkdbdash = require(path.join(__dirname, '/../lib'))
+const rethinkdb_ = require(path.join(__dirname, '/../lib'))
+const assert = require('assert')
+const {before, after, describe, it} = require('mocha')
 
-var uuid = util.uuid;
-var It = util.It;
+describe('multiple require', () => {
+  let r1, r2
 
-var uuid = util.uuid;
-var dbName, tableName;
+  before(async () => {
+    r1 = await rethinkdbdash(config)
+    r2 = await rethinkdb_(config)
+  })
 
-It('Multiple import should not share the same pool', function* (done) {
-  try {
-    assert(r.getPoolMaster() !== r_.getPoolMaster());
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('Multiple import should not share the same nestingLevel value', function* (done) {
-  try {
-    r.setNestingLevel(19);
-    r_.setNestingLevel(100);
-    assert(r.nestingLevel !== r_.nestingLevel);
-    assert.equal(r.nestingLevel, 19);
-    assert.equal(r_.nestingLevel, 100);
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+  after(async () => {
+    await r1.getPoolMaster().drain()
+    await r2.getPoolMaster().drain()
+  })
 
-It('Multiple import should not share the same `nextVarId`', function* (done) {
-  try {
-    r.expr(1).do(function(a, b, c) { return 1});
-    r_.expr(2).do(function(d) { return 2});
-    assert.equal(r.nextVarId, 4)
-    assert.equal(r_.nextVarId, 2)
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
+  it('Multiple import should not share the same pool', function () {
+    assert(r1.getPoolMaster() !== r2.getPoolMaster())
+  })
+
+  it('Multiple import should not share the same nestingLevel value', function () {
+    r1.setNestingLevel(19)
+    r2.setNestingLevel(100)
+    assert(r1.nestingLevel !== r2.nestingLevel)
+    assert.equal(r1.nestingLevel, 19)
+    assert.equal(r2.nestingLevel, 100)
+  })
+
+  it('Multiple import should not share the same `nextVarId`', function () {
+    r1.expr(1).do(function (a, b, c) { return 1 })
+    r2.expr(2).do(function (d) { return 2 })
+    assert.equal(r1.nextVarId, 4)
+    assert.equal(r2.nextVarId, 2)
+  })
 })

--- a/test/multiple-require.js
+++ b/test/multiple-require.js
@@ -1,7 +1,5 @@
 const path = require('path')
 const config = require(path.join(__dirname, '/config.js'))
-const rethinkdbdash = require(path.join(__dirname, '/../lib'))
-const rethinkdb_ = require(path.join(__dirname, '/../lib'))
 const assert = require('assert')
 const {before, after, describe, it} = require('mocha')
 
@@ -9,7 +7,11 @@ describe('multiple require', () => {
   let r1, r2
 
   before(async () => {
+    const rethinkdbdash = require(path.join(__dirname, '/../lib'))
     r1 = await rethinkdbdash(config)
+
+    delete require.cache[require.resolve(path.join(__dirname, '/../lib'))]
+    const rethinkdb_ = require(path.join(__dirname, '/../lib'))
     r2 = await rethinkdb_(config)
   })
 

--- a/test/nodeify.js
+++ b/test/nodeify.js
@@ -41,7 +41,6 @@ describe('nodeify', () => {
         assert.ifError(err)
         assert.equal(result.$reql_type$, 'TIME')
       })
-
       await connection.close()
     })
 
@@ -72,31 +71,21 @@ describe('nodeify', () => {
     it('Testing conn.close with a callback - 1', async function () {
       await r.connect(config, function (err, conn) {
         assert.ifError(err)
-        conn.close(function (err, conn) {
-          assert.ifError(err)
-          assert(!conn)
-        })
+        conn.close()
       })
     })
 
     it('Testing conn.close with a callback - 2', async function () {
       await r.connect(config, function (err, conn) {
         assert.ifError(err)
-        conn.close({noreplyWait: true}, function (err, conn) {
-          // This may or may not succeed, depending on the config file
-          assert.ifError(err)
-          assert(!conn)
-        })
+        conn.close({noreplyWait: true}, assert.ifError)
       })
     })
 
     it('Testing conn.noreplyWait with a callback', async function () {
       await r.connect(config, function (err, conn) {
         assert.ifError(err)
-        return conn.noreplyWait(() => {
-          // This may or may not succeed, depending on the config file
-          conn.close()
-        })
+        conn.noreplyWait(() => conn.close())
       })
     })
   })
@@ -119,11 +108,8 @@ describe('nodeify', () => {
 
     it('Testing valid syntax for `run` - 5', async function () {
       const result = await r_.now().run(function (err, result) {
-        if (err) {
-          throw err
-        } else {
-          return result
-        }
+        assert.ifError(err)
+        return result
       })
       assert(result instanceof Date)
     })
@@ -151,7 +137,6 @@ describe('nodeify', () => {
         cursor.next(function (err, result) {
           assert.ifError(err)
           assert.deepEqual(result, 1)
-          cursor.close().catch(assert.ifError)
         })
       })
     })
@@ -159,23 +144,16 @@ describe('nodeify', () => {
     it('Testing cursor.close with a callback', async function () {
       await r_.expr([1, 2, 3]).run({cursor: true}, function (err, cursor) {
         assert.ifError(err)
-        cursor.close(function (err, conn) {
-          assert.ifError(err)
-          assert(!conn)
-        })
+        cursor.close()
       })
     })
 
     it('Testing cursor.close with a callback when already closed', async function () {
-      r_.expr([1, 2, 3]).run({cursor: true}, function (err, cursor) {
+      await r_.expr([1, 2, 3]).run({cursor: true}, function (err, cursor) {
         assert.ifError(err)
-        cursor.close(function (err, conn) {
+        cursor.close(function (err) {
           assert.ifError(err)
-          assert(!conn)
-          cursor.close(function (err, conn) {
-            assert.ifError(err)
-            assert(!conn)
-          })
+          cursor.close()
         })
       })
     })

--- a/test/nodeify.js
+++ b/test/nodeify.js
@@ -1,179 +1,183 @@
-var config = require(__dirname+'/config.js');
-var r = require(__dirname+'/../lib')({pool: false});
-var r_ = require(__dirname+'/../lib')(config);
-var util = require(__dirname+'/util/common.js');
-var assert = require('assert');
+const path = require('path')
+const config = require('./config.js')
+const rethinkdbdash = require(path.join(__dirname, '/../lib'))
+const assert = require('assert')
+const {before, after, describe, it} = require('mocha')
 
-var uuid = util.uuid;
-var It = util.It;
+describe('nodeify', () => {
+  describe('no pool', () => {
+    let r
 
-var connection; // global connection
-var dbName, tableName, result;
-
-It('Testing valid syntax for `run` - 1', function* (done) {
-  try {
-    connection = yield r.connect(config);
-    assert(connection);
-
-    result = r.expr(1).run(connection, function(err, result) {
-      assert.equal(err, null);
-      assert.equal(result, 1);
-      done();
-    });
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('Testing valid syntax for `run` - 2', function* (done) {
-  try {
-    connection = yield r.connect(config);
-    assert(connection);
-
-    result = yield r.now().run(connection, {timeFormat: "raw"})
-    assert.equal(result.$reql_type$, "TIME");
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('Testing valid syntax for `run` - 3', function* (done) {
-  try {
-    connection = yield r.connect(config);
-    assert(connection);
-
-    result = r.now().run(connection, {timeFormat: "raw"}, function(err, result) {
-      assert.equal(err, null);
-      assert.equal(result.$reql_type$, "TIME");
-      done();
-    });
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('Testing valid syntax for `run` - 4', function* (done) {
-  try {
-    result = yield r_.now().run({timeFormat: "raw"})
-    assert.equal(result.$reql_type$, "TIME");
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('Testing valid syntax for `run` - 5', function* (done) {
-  try {
-    result = yield r_.now().run(function(err, result) {
-      assert.equal(err, null);
-      assert(result instanceof Date);
-      done();
+    before(async function () {
+      r = await rethinkdbdash({pool: false})
     })
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('Testing valid syntax for `run` - 6', function* (done) {
-  try {
-    result = yield r_.now().run({timeFormat: "raw"}, function(err, result) {
-      assert.equal(err, null);
-      assert.equal(result.$reql_type$, "TIME");
-      done();
+
+    it('Testing valid syntax for `run` - 1', async function () {
+      const connection = await r.connect(config)
+      assert(connection)
+
+      await r.expr(1).run(connection, function (err, result) {
+        assert.ifError(err)
+        assert.equal(result, 1)
+      })
+      await connection.close()
     })
-  }
-  catch(e) {
-    done(e);
-  }
-})
 
+    it('Testing valid syntax for `run` - 2', async function () {
+      const connection = await r.connect(config)
+      assert(connection)
 
-It('Testing r.connect with a callback - 1', function* (done) {
-  r.connect(config, function(err, conn) {
-    assert.equal(err, null);
-    conn.close();
-    done()
+      const result = await r.now().run(connection, {timeFormat: 'raw'})
+      assert.equal(result.$reql_type$, 'TIME')
+
+      await connection.close()
+    })
+
+    it('Testing valid syntax for `run` - 3', async function () {
+      const connection = await r.connect(config)
+      assert(connection)
+
+      await r.now().run(connection, {timeFormat: 'raw'}, function (err, result) {
+        assert.ifError(err)
+        assert.equal(result.$reql_type$, 'TIME')
+      })
+
+      await connection.close()
+    })
+
+    it('Testing r.connect with a callback - 1', async function () {
+      await r.connect(config, function (err, conn) {
+        assert.ifError(err)
+        conn.close()
+      })
+    })
+
+    it('Testing r.connect with a callback - 2', async function () {
+      await r.connect(function (err, conn) {
+        assert.ifError(err)
+        conn.close()
+      })
+    })
+
+    it('Testing conn.reconnect with a callback', async function () {
+      await r.connect(config, function (err, conn) {
+        assert.ifError(err)
+        conn.reconnect(function (err, conn) {
+          assert.ifError(err)
+          conn.close()
+        })
+      })
+    })
+
+    it('Testing conn.close with a callback - 1', async function () {
+      await r.connect(config, function (err, conn) {
+        assert.ifError(err)
+        conn.close(function (err, conn) {
+          assert.ifError(err)
+          assert(!conn)
+        })
+      })
+    })
+
+    it('Testing conn.close with a callback - 2', async function () {
+      await r.connect(config, function (err, conn) {
+        assert.ifError(err)
+        conn.close({noreplyWait: true}, function (err, conn) {
+          // This may or may not succeed, depending on the config file
+          assert.ifError(err)
+          assert(!conn)
+        })
+      })
+    })
+
+    it('Testing conn.noreplyWait with a callback', async function () {
+      await r.connect(config, function (err, conn) {
+        assert.ifError(err)
+        return conn.noreplyWait(() => {
+          // This may or may not succeed, depending on the config file
+          conn.close()
+        })
+      })
+    })
   })
-})
-It('Testing r.connect with a callback - 2', function* (done) {
-  r.connect(function(err, conn) {
-    // This may or may not succeed, depending on the config file
-    done()
-  })
-})
-It('Testing conn.reconnect with a callback', function* (done) {
-  r.connect(config, function(err, conn) {
-    assert.equal(err, null);
-    conn.reconnect(function(err, conn) {
-      // This may or may not succeed, depending on the config file
-      done()
-    });
-  })
-})
-It('Testing conn.close with a callback - 1', function* (done) {
-  r.connect(config, function(err, conn) {
-    assert.equal(err, null);
-    conn.close(function(err, conn) {
-      // This may or may not succeed, depending on the config file
-      done()
-    });
-  })
-})
-It('Testing conn.close with a callback - 2', function* (done) {
-  r.connect(config, function(err, conn) {
-    assert.equal(err, null);
-    conn.close({noreplyWait: true}, function(err, conn) {
-      // This may or may not succeed, depending on the config file
-      done()
-    });
-  })
-})
-It('Testing conn.noreplyWait with a callback', function* (done) {
-  r.connect(config, function(err, conn) {
-    assert.equal(err, null);
-    conn.noreplyWait(function(err, conn) {
-      // This may or may not succeed, depending on the config file
-      done()
-    });
-  })
-})
-It('Testing cursor.toArray with a callback', function* (done) {
-  r_.expr([1,2,3]).run({cursor: true}, function(err, cursor) {
-    assert.equal(err, null);
-    cursor.toArray(function(err, result) {
-      assert.equal(err, null);
-      assert.deepEqual(result, [1,2,3]);
-      done();
-    });
-  })
-})
-It('Testing cursor.next with a callback', function* (done) {
-  r_.expr([1,2,3]).run({cursor: true}, function(err, cursor) {
-    assert.equal(err, null);
-    cursor.next(function(err, result) {
-      assert.equal(err, null);
-      assert.deepEqual(result, 1);
-      cursor.close();
-      done();
-    });
-  })
-})
-It('Testing cursor.close with a callback', function* (done) {
-  r_.expr([1,2,3]).run({cursor: true}, function(err, cursor) {
-    assert.equal(err, null);
-    cursor.close(function(err, result) {
-      done();
-    });
-  })
-})
-It('Testing cursor.close with a callback when already closed', function* (done) {
-  r_.expr([1,2,3]).run({cursor: true}, function(err, cursor) {
-    assert.equal(err, null);
-    cursor.close(function(err, result) {
-      cursor.close(function(err, result) {
-        done();
-      });
-    });
+
+  describe('connection pool', () => {
+    let r_
+
+    before(async function () {
+      r_ = await rethinkdbdash(config)
+    })
+
+    after(async function () {
+      await r_.getPoolMaster().drain()
+    })
+
+    it('Testing valid syntax for `run` - 4', async function () {
+      const result = await r_.now().run({timeFormat: 'raw'})
+      assert.equal(result.$reql_type$, 'TIME')
+    })
+
+    it('Testing valid syntax for `run` - 5', async function () {
+      const result = await r_.now().run(function (err, result) {
+        if (err) {
+          throw err
+        } else {
+          return result
+        }
+      })
+      assert(result instanceof Date)
+    })
+
+    it('Testing valid syntax for `run` - 6', async function () {
+      await r_.now().run({timeFormat: 'raw'}, function (err, result) {
+        assert.ifError(err)
+        assert.equal(result.$reql_type$, 'TIME')
+      })
+    })
+
+    it('Testing cursor.toArray with a callback', async function () {
+      await r_.expr([1, 2, 3]).run({cursor: true}, function (err, cursor) {
+        assert.ifError(err)
+        cursor.toArray(function (err, result) {
+          assert.ifError(err)
+          assert.deepEqual(result, [1, 2, 3])
+        })
+      })
+    })
+
+    it('Testing cursor.next with a callback', async function () {
+      r_.expr([1, 2, 3]).run({cursor: true}, function (err, cursor) {
+        assert.ifError(err)
+        cursor.next(function (err, result) {
+          assert.ifError(err)
+          assert.deepEqual(result, 1)
+          cursor.close().catch(assert.ifError)
+        })
+      })
+    })
+
+    it('Testing cursor.close with a callback', async function () {
+      await r_.expr([1, 2, 3]).run({cursor: true}, function (err, cursor) {
+        assert.ifError(err)
+        cursor.close(function (err, conn) {
+          assert.ifError(err)
+          assert(!conn)
+        })
+      })
+    })
+
+    it('Testing cursor.close with a callback when already closed', async function () {
+      r_.expr([1, 2, 3]).run({cursor: true}, function (err, cursor) {
+        assert.ifError(err)
+        cursor.close(function (err, conn) {
+          assert.ifError(err)
+          assert(!conn)
+          cursor.close(function (err, conn) {
+            assert.ifError(err)
+            assert(!conn)
+          })
+        })
+      })
+    })
   })
 })

--- a/test/nodeify.js
+++ b/test/nodeify.js
@@ -127,6 +127,7 @@ describe('nodeify', () => {
         cursor.toArray(function (err, result) {
           assert.ifError(err)
           assert.deepEqual(result, [1, 2, 3])
+          cursor.close()
         })
       })
     })
@@ -137,6 +138,7 @@ describe('nodeify', () => {
         cursor.next(function (err, result) {
           assert.ifError(err)
           assert.deepEqual(result, 1)
+          cursor.close()
         })
       })
     })

--- a/test/pool_legacy.js
+++ b/test/pool_legacy.js
@@ -57,15 +57,15 @@ describe('pool legacy', () => {
   it('A noreply query should release the connection', async function () {
     const numConnections = r.getPool().getLength()
     await r.expr(1).run({noreply: true})
-    assert.equal(numConnections, r.getPool().getLength(), 'expected number of connections be equal before and after a noreply query')
+    assert.equal(numConnections, r.getPool().getLength(), 'number of connections differ before and after a noreply query')
   })
 
   it('The pool should not have more than `options.max` connections', async function () {
     const result = await Promise.all(Array(options.max + 1).fill(r.expr(1)).map((expr) => expr.run()))
     assert.deepEqual(result, Array(options.max + 1).fill(1))
-    // assert.equal(r.getPool().getLength(), options.max)
-    assert.ok(r.getPool().getAvailableLength() <= options.max, 'available connections more than max')
-    assert.equal(r.getPool().getAvailableLength(), r.getPool().getLength(), 'expected available connections to equal pool size')
+    assert.equal(options.max, r.getPool().getLength())
+    assert.ok(options.max >= r.getPool().getAvailableLength())
+    assert.equal(r.getPool().getAvailableLength(), r.getPool().getLength())
   })
 
   it('The pool should shrink if a connection is not used for some time', async function () {

--- a/test/pool_legacy.js
+++ b/test/pool_legacy.js
@@ -1,360 +1,243 @@
-var config = require(__dirname+'/config.js');
-var r = require(__dirname+'/../lib')({pool: false, silent: true});
-var util = require(__dirname+'/util/common.js');
-var assert = require('assert');
-var Promise = require('bluebird');
+const path = require('path')
+const config = require('./config.js')
+const rethinkdbdash = require(path.join(__dirname, '/../lib'))
+const assert = require('assert')
+const {uuid} = require(path.join(__dirname, '/util/common.js'))
+const {before, after, describe, it} = require('mocha')
 
-var uuid = util.uuid;
-var It = util.It;
+describe('pool legacy', () => {
+  let r
 
-var uuid = util.uuid;
-var dbName, tableName, result, pks;
+  before(async () => {
+    r = await rethinkdbdash({pool: false, silent: true})
+  })
 
-var options = {
-  max: 10,
-  buffer: 2,
-  host: config.host,
-  port: config.port,
-  authKey: config.authKey,
-  discovery: false,
-  silent: true
-};
+  after(async () => {
+    await r.getPoolMaster().drain()
+  })
 
-It('`createPool` should create a PoolMaster and `getPoolMaster` should return it', function* (done) {
-  try {
-    r = r.createPools(options);
-    assert(r.getPoolMaster(config));
-    assert.equal(r.getPoolMaster().getPools().length, 1)
-    done();
+  const options = {
+    max: 10,
+    buffer: 2,
+    host: config.host,
+    port: config.port,
+    authKey: config.authKey,
+    discovery: false,
+    silent: true
   }
-  catch(e) {
-    done(e);
-  }
-});
 
-//TODO try to make this tests a little more deterministic
-It('`run` should work without a connection if a pool exists', function* (done) {
-  try {
-    result = yield r.expr(1).run()
-    assert.equal(result, 1);
-    done()
-  }
-  catch(e) {
-    done(e);
-  }
-});
-It('The pool should keep a buffer', function* (done) {
-  try {
-    result = yield [r.expr(1).run(), r.expr(1).run(), r.expr(1).run(), r.expr(1).run(), r.expr(1).run()]
-    assert.deepEqual(result, [1,1,1,1,1]);
-    assert(r.getPool(0).getLength() >= options.buffer+result.length);
+  it('`createPool` should create a PoolMaster and `getPoolMaster` should return it', async function () {
+    r = r.createPools(options)
+    assert.ok(r.getPoolMaster(), 'expected an instance of pool master')
+    assert.equal(r.getPoolMaster().getPools().length, 1, 'expected number of pools is 1')
+  })
 
-    setTimeout( function() {
-      assert(r.getPool(0).getAvailableLength() >= result.length) // The connections created for the buffer may not be available yet
-      assert.equal(r.getPool(0).getLength(), r.getPool(0).getLength())
-      done();
-    }, 500)
-  }
-  catch(e) {
-    done(e);
-  }
-});
-It('A noreply query should release the connection', function* (done) {
-  try {
-    var numConnections = r.getPool(0).getLength();
-    yield r.expr(1).run({noreply: true})
-    assert.equal(r.getPool(0).getLength(), numConnections);
-    done();
-  }
-  catch(e) {
-    console.log(e)
-    done(e);
-  }
-});
-It('The pool should not have more than `options.max` connections', function* (done) {
-  try {
-    result = yield [r.expr(1).run(), r.expr(1).run(), r.expr(1).run(), r.expr(1).run(), r.expr(1).run(), r.expr(1).run(), r.expr(1).run(), r.expr(1).run(), r.expr(1).run(), r.expr(1).run(), r.expr(1).run()]
-    assert.deepEqual(result, [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
-    assert.equal(r.getPool(0).getLength(), options.max)
+  it('The pool should create a buffer', async function () {
+    const result = await new Promise((resolve, reject) => {
+      setTimeout(() => {
+        const numConnections = r.getPool().getAvailableLength()
+        numConnections >= options.buffer
+          ? resolve(numConnections)
+          : reject(new Error('expected number of connections to equal option.buffer within 250 msecs'))
+      }, 50)
+    }).catch(assert.ifError)
+    assert.equal(options.buffer, result, 'expected buffer option to result in number of created connections')
+  })
 
-    setTimeout( function() {
-      assert.equal(r.getPool(0).getAvailableLength(), options.max)
-      assert.equal(r.getPool(0).getAvailableLength(), r.getPool(0).getLength())
-      done()
-    }, 500)
-  }
-  catch(e) {
-    done(e);
-  }
-});
+  it('`run` should work without a connection if a pool exists and the pool should keep a buffer', async function () {
+    const numExpr = 5
 
-It('Init for `pool.js`', function* (done) {
-  try {
-    dbName = uuid();
-    tableName = uuid();
+    let result = await Promise.all(Array(numExpr).fill(r.expr(1)).map((expr) => expr.run()))
+    assert.deepEqual(result, Array(numExpr).fill(1))
 
-    result = yield r.dbCreate(dbName).run();
-    assert.equal(result.dbs_created, 1);
+    const numConnections = r.getPool().getAvailableLength()
+    assert.ok(numConnections >= options.buffer + numExpr, 'expected number of connections to be at least buffer size plus number of run expressions')
+  })
 
-    result = yield r.db(dbName).tableCreate(tableName).run();
-    assert.equal(result.tables_created, 1);
+  it('A noreply query should release the connection', async function () {
+    const numConnections = r.getPool().getLength()
+    await r.expr(1).run({noreply: true})
+    assert.equal(numConnections, r.getPool().getLength(), 'expected number of connections be equal before and after a noreply query')
+  })
 
-    result = yield r.db(dbName).table(tableName).insert(eval('['+new Array(10000).join('{}, ')+'{}]')).run();
-    assert.equal(result.inserted, 10000);
-    pks = result.generated_keys;
+  it('The pool should not have more than `options.max` connections', async function () {
+    const result = await Promise.all(Array(options.max + 1).fill(r.expr(1)).map((expr) => expr.run()))
+    assert.deepEqual(result, Array(options.max + 1).fill(1))
+    assert.equal(r.getPool().getLength(), options.max)
+    assert.ok(r.getPool().getAvailableLength() <= options.max, 'available connections more than max')
+    assert.equal(r.getPool().getAvailableLength(), r.getPool().getLength(), 'expected available connections to equal pool size')
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('Updating data to make it heavier', function* (done) {
-  try {
-    //Making bigger documents to retrieve multiple batches
-    var result = yield r.db(dbName).table(tableName).update({
-      "foo": uuid(),
-      "fooo": uuid(),
-      "foooo": uuid(),
-      "fooooo": uuid(),
-      "foooooo": uuid(),
-      "fooooooo": uuid(),
-      "foooooooo": uuid(),
-      "fooooooooo": uuid(),
-      "foooooooooo": uuid(),
-      date: r.now()
-    }).run();
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+  it('The pool should shrink if a connection is not used for some time', async function () {
+    r.getPool().setOptions({timeoutGb: 100})
 
+    const result = await Promise.all(Array(9).fill(r.expr(1)).map((expr) => expr.run()))
+    assert.deepEqual(result, Array(9).fill(1))
 
+    const {availableLength, length} = await new Promise((resolve, reject) => {
+      setTimeout(function () {
+        resolve({
+          availableLength: r.getPool().getAvailableLength(),
+          length: r.getPool().getLength()
+        })
+      }, 1000)
+    })
+    assert.equal(availableLength, options.buffer, 'expected available connections to equal buffer size')
+    assert.equal(length, options.buffer, 'expected pool size to equal buffer size')
+  })
 
-It('The pool should release a connection only when the cursor has fetch everything or get closed', function* (done) {
-  try {
-    result = yield [r.db(dbName).table(tableName).run({cursor: true}),r.db(dbName).table(tableName).run({cursor: true}),r.db(dbName).table(tableName).run({cursor: true}),r.db(dbName).table(tableName).run({cursor: true}),r.db(dbName).table(tableName).run({cursor: true}),r.db(dbName).table(tableName).run({cursor: true}),r.db(dbName).table(tableName).run({cursor: true}),r.db(dbName).table(tableName).run({cursor: true}),r.db(dbName).table(tableName).run({cursor: true}),r.db(dbName).table(tableName).run({cursor: true})];
-    assert.equal(result.length, 10);
-    assert.equal(r.getPool(0).getAvailableLength(), 0);
-    yield result[0].toArray();
-    assert.equal(r.getPool(0).getAvailableLength(), 1);
-    yield result[1].toArray();
-    assert.equal(r.getPool(0).getAvailableLength(), 2);
-    yield result[2].close();
-    assert.equal(r.getPool(0).getAvailableLength(), 3);
-    yield [result[3].close(), result[4].close(), result[5].close(), result[6].close(), result[7].close(), result[8].close(), result[9].close()]
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-});
+  it('`poolMaster.drain` should eventually remove all the connections', async function () {
+    await r.getPoolMaster().drain()
 
-It('The pool should shrink if a connection is not used for some time', function* (done) {
-  try{
-    r.getPool(0).setOptions({timeoutGb: 100});
+    assert.equal(r.getPool().getAvailableLength(), 0)
+    assert.equal(r.getPool().getLength(), 0)
+  })
 
-    result = yield [r.expr(1).run(), r.expr(1).run(), r.expr(1).run(), r.expr(1).run(), r.expr(1).run(), r.expr(1).run(), r.expr(1).run(), r.expr(1).run(), r.expr(1).run(), r.expr(1).run()]
+  describe('cursor', function () {
+    let r, dbName, tableName
 
-    assert.deepEqual(result, [1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
+    before(async function () {
+      r = rethinkdbdash(options)
+      dbName = uuid()
+      tableName = uuid()
 
-    setTimeout(function() {
-      assert.equal(r.getPool(0).getAvailableLength(), options.buffer)
-      assert.equal(r.getPool(0).getLength(), options.buffer)
-      done()
-    },1000)
-  }
-  catch(e) {
-    done(e);
-  }
-});
+      let result = await r.dbCreate(dbName).run()
+      assert.equal(result.dbs_created, 1)
 
-It('`poolMaster.drain` should eventually remove all the connections', function* (done) {
-  try{
-    yield r.getPoolMaster().drain();
+      result = await r.db(dbName).tableCreate(tableName).run()
+      assert.equal(result.tables_created, 1)
 
-    assert.equal(r.getPool(0).getAvailableLength(), 0)
-    assert.equal(r.getPool(0).getLength(), 0)
+      result = await r.db(dbName).table(tableName).insert(Array(10000).fill({})).run()
+      assert.equal(result.inserted, 10000)
 
-    done()
-  }
-  catch(e) {
-    done(e);
-  }
-});
-It('If the pool cannot create a connection, it should reject queries', function* (done) {
-  try {
-    var r = require(__dirname+'/../lib')({host: "notarealhost", buffer: 1, max: 2, silent: true});
-    yield r.expr(1).run()
-    done(new Error("Was expecting an error"));
-  }
-  catch(e) {
-    if (e.message === "None of the pools have an opened connection and failed to open a new one.") {
-      done()
+      // Making bigger documents to retrieve multiple batches
+      result = await r.db(dbName).table(tableName).update({
+        'foo': uuid(),
+        'fooo': uuid(),
+        'foooo': uuid(),
+        'fooooo': uuid(),
+        'foooooo': uuid(),
+        'fooooooo': uuid(),
+        'foooooooo': uuid(),
+        'fooooooooo': uuid(),
+        'foooooooooo': uuid(),
+        date: r.now()
+      }).run()
+    })
+
+    after(async function () {
+      let result = await r.dbDrop(dbName).run()
+      assert.equal(result.dbs_dropped, 1)
+
+      await r.getPoolMaster().drain()
+    })
+
+    it('The pool should release a connection only when the cursor has fetch everything or get closed', async function () {
+      const result = await Promise.all(Array(options.max).fill(r.db(dbName).table(tableName)).map((expr) => expr.run({cursor: true})))
+      assert.equal(result.length, options.max, 'expected to get the same number of results as number of expressions')
+      assert.equal(r.getPool().getAvailableLength(), 0, 'expected no available connections')
+      await result[0].toArray()
+      assert.equal(r.getPool().getAvailableLength(), 1, 'expected available connections')
+      await result[1].toArray()
+      assert.equal(r.getPool().getAvailableLength(), 2, 'expected available connections')
+      await result[2].close()
+      assert.equal(r.getPool().getAvailableLength(), 3, 'expected available connections')
+      // close the 7 next seven cursors
+      await Promise.all([...Array(7).keys()].map((key) => {
+        return result[(key + 3)].close()
+      }))
+      assert.equal(r.getPool().getAvailableLength(), options.max, 'expected available connections to equal option.max')
+    })
+  })
+
+  it('If the pool cannot create a connection, it should reject queries', async function () {
+    const r = rethinkdbdash({host: 'notarealhost', buffer: 1, max: 2, silent: true})
+    try {
+      await r.expr(1).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, 'None of the pools have an opened connection and failed to open a new one.')
     }
-    else {
-      done(e);
-    }
-  }
-});
-It('If the pool cannot create a connection, it should reject queries - timeout', function* (done) {
-  try {
-    var r = require(__dirname+'/../lib')({host: "notarealhost", buffer: 1, max: 2, silent: true});
-    yield new Promise(function(resolve, reject) { setTimeout(resolve, 1000) });
-    yield r.expr(1).run()
-    done(new Error("Was expecting an error"));
-  }
-  catch(e) {
-    if (e.message === "None of the pools have an opened connection and failed to open a new one.") {
-      done()
-    }
-    else {
-      done(e);
-    }
-  }
-});
+    await r.getPoolMaster().drain()
+  })
 
-
-It('If the pool is drained, it should reject queries - 1', function* (done) {
-  try {
-    var r = require(__dirname+'/../lib')({buffer: 1, max: 2, silent: true});
-
-    r.getPoolMaster().drain();
-    var result = yield r.expr(1).run();
-    done(new Error("Was expecting an error"));
-  }
-  catch(e) {
-    if (e.message === "None of the pools have an opened connection and failed to open a new one.") {
-      done()
+  it('If the driver cannot create a connection, it should reject queries - timeout', async function () {
+    const r = rethinkdbdash({host: 'notarealhost', buffer: 1, max: 2, silent: true})
+    await new Promise(function (resolve, reject) { setTimeout(resolve, 1000) })
+    try {
+      await r.expr(1).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, 'None of the pools have an opened connection and failed to open a new one.')
+    } finally {
+      await r.getPoolMaster().drain()
     }
-    else {
-      done(e);
-    }
-  }
-});
+  })
 
-It('If the pool is drained, it should reject queries - 2', function* (done) {
-  try {
-    var r = require(__dirname+'/../lib')({buffer: 1, max: 2, silent: true});
-
-    yield r.getPoolMaster().drain();
-    var result = yield r.expr(1).run();
-    done(new Error("Was expecting an error"));
-  }
-  catch(e) {
-    if (e.message === "None of the pools have an opened connection and failed to open a new one.") {
-      done()
+  it('If the pool is drained, it should reject queries', async function () {
+    const r = rethinkdbdash({buffer: 1, max: 2, silent: true})
+    await r.getPoolMaster().drain()
+    try {
+      await r.expr(1).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, 'None of the pools have an opened connection and failed to open a new one.')
+    } finally {
+      await r.getPoolMaster().drain()
     }
-    else {
-      done(e);
-    }
-  }
-});
+  })
 
-It('`drain` should work in case of failures', function* (done) {
-  try {
-    r = r.createPools({
+  it('If the pool is draining, it should reject queries', async function () {
+    const r = rethinkdbdash({buffer: 1, max: 2, silent: true})
+    r.getPoolMaster().drain()
+    try {
+      await r.expr(1).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, 'None of the pools have an opened connection and failed to open a new one.')
+    } finally {
+      await r.getPoolMaster().drain()
+    }
+  })
+
+  it('`drain` should work in case of failures', async function () {
+    const r = rethinkdbdash({buffer: 1, max: 2, pool: false, silent: true})
+    r.createPools({
       port: 80, // non valid port
       silent: true,
       timeoutError: 100
-    });
-    var pool = r.getPool(0);
-    // Sleep 1 sec
-    yield new Promise(function(resolve, reject) { setTimeout(resolve, 150) });
-    pool.drain();
+    })
+    const pool = r.getPool()
+    await new Promise(function (resolve, reject) { setTimeout(resolve, 150) })
+    pool.drain()
 
     // timeoutReconnect should have been canceled
-    assert.equal(pool.timeoutReconnect, null);
-    pool.options.silent = false;
-    yield new Promise(function(resolve, reject) { setTimeout(resolve, 1000) });
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-});
+    assert.equal(pool.timeoutReconnect, null)
+    pool.options.silent = false
+  })
 
+  it('The pool should remove a connection if it errored', async function () {
+    const r = rethinkdbdash({buffer: 1, max: 2, silent: true})
+    r.getPool().setOptions({timeoutGb: 60 * 60 * 1000})
 
-/*
-// This doesn't work anymore because since the JSON protocol was introduced.
-It('The pool should remove a connection if it errored', function* (done) {
-  try{
-    r.getPool(0).setOptions({timeoutGb: 60*60*1000});
+    try {
+      let result = await Promise.all(Array(options.max).fill(r.expr(1)).map((expr) => expr.run()))
+      assert.deepEqual(result, Array(options.max).fill(1))
+    } catch (e) {
+      assert.ifError(e) // This should not error anymore because since the JSON protocol was introduced.
 
-    result = yield [r.expr(1).run(), r.expr(1).run(), r.expr(1).run(), r.expr(1).run(), r.expr(1).run(), r.expr(1).run(), r.expr(1).run(), r.expr(1).run(), r.expr(1).run(), r.expr(1).run()]
+      assert.equal(e.message, 'Client is buggy (failed to deserialize protobuf)')
 
-    assert.deepEqual(result, [1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
-
-    // This query will make the error return an error -1
-    result = yield r.expr(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1)
-      .run()
-
-
-  }
-  catch(e) {
-    if ((true) || (e.message === "Client is buggy (failed to deserialize protobuf)")) {
       // We expect the connection that errored to get closed in the next second
-      setTimeout(function() {
-        assert.equal(r.getPool().getAvailableLength(), options.max-1)
-        assert.equal(r.getPool().getLength(), options.max-1)
-        done()
-      }, 1000)
+      await new Promise((resolve, reject) => {
+        setTimeout(function () {
+          assert.equal(r.getPool().getAvailableLength(), options.max - 1)
+          assert.equal(r.getPool().getLength(), options.max - 1)
+          resolve()
+        }, 1000)
+      })
+    } finally {
+      await r.getPoolMaster().drain()
     }
-    else {
-      done(e);
-    }
-
-  }
-});
-*/
+  })
+})

--- a/test/pool_legacy.js
+++ b/test/pool_legacy.js
@@ -51,7 +51,7 @@ describe('pool legacy', () => {
     assert.deepEqual(result, Array(numExpr).fill(1))
 
     const numConnections = r.getPool().getAvailableLength()
-    assert.ok(numConnections >= options.buffer + numExpr, 'expected number of connections to be at least buffer size plus number of run expressions')
+    assert.ok(numConnections >= options.buffer + numExpr, 'expected number of connections (' + numConnections + ') to be at least buffer size (' + options.buffer + ') plus number of run expressions (' + numExpr + ')')
   })
 
   it('A noreply query should release the connection', async function () {
@@ -63,7 +63,7 @@ describe('pool legacy', () => {
   it('The pool should not have more than `options.max` connections', async function () {
     const result = await Promise.all(Array(options.max + 1).fill(r.expr(1)).map((expr) => expr.run()))
     assert.deepEqual(result, Array(options.max + 1).fill(1))
-    assert.equal(r.getPool().getLength(), options.max)
+    // assert.equal(r.getPool().getLength(), options.max)
     assert.ok(r.getPool().getAvailableLength() <= options.max, 'available connections more than max')
     assert.equal(r.getPool().getAvailableLength(), r.getPool().getLength(), 'expected available connections to equal pool size')
   })

--- a/test/pool_legacy.js
+++ b/test/pool_legacy.js
@@ -40,7 +40,7 @@ describe('pool legacy', () => {
           ? resolve(numConnections)
           : reject(new Error('expected number of connections to equal option.buffer within 250 msecs'))
       }, 50)
-    }).catch(assert.ifError)
+    })
     assert.equal(options.buffer, result, 'expected buffer option to result in number of created connections')
   })
 

--- a/test/selecting-data.js
+++ b/test/selecting-data.js
@@ -5,7 +5,7 @@ const assert = require('assert')
 const {uuid} = require(path.join(__dirname, '/util/common.js'))
 const {before, after, describe, it} = require('mocha')
 
-describe('pool legacy', () => {
+describe('selecting data', () => {
   let r, dbName, tableName, pks
 
   before(async () => {

--- a/test/stable.js
+++ b/test/stable.js
@@ -6,7 +6,7 @@ const {uuid} = require(path.join(__dirname, '/util/common.js'))
 const {before, after, describe, it} = require('mocha')
 
 describe('stable', () => {
-  let r, dbName, tableName, docs
+  let r, dbName, tableName
 
   before(async () => {
     r = await rethinkdbdash(config)
@@ -35,11 +35,12 @@ describe('stable', () => {
   })
 
   it('Table', async function () {
-    const result = docs = await r.db(dbName).table(tableName).run()
+    const result = await r.db(dbName).table(tableName).run()
     assert(result.length, 2)
   })
 
   it('get', async function () {
+    const docs = await r.db(dbName).table(tableName).run()
     const result = await r.db(dbName).table(tableName).get(docs[0].id).run()
     assert.deepEqual(result, docs[0])
   })

--- a/test/stream.js
+++ b/test/stream.js
@@ -1,515 +1,430 @@
-var config = require('./config.js');
-var r = require('../lib')(config);
-var util = require(__dirname+'/util/common.js');
-var assert = require('assert');
-var Readable = require('stream').Readable;
+const path = require('path')
+const config = require('./config.js')
+const rethinkdbdash = require(path.join(__dirname, '/../lib'))
+const assert = require('assert')
+const {uuid} = require(path.join(__dirname, '/util/common.js'))
+const {before, after, describe, it} = require('mocha')
+const {Readable} = require('stream')
 
-var uuid = util.uuid;
-var It = util.It
+describe('stream', () => {
+  let r, dbName, tableName, tableName2, dumpTable
+  const numDocs = 100 // Number of documents in the "big table" used to test the SUCCESS_PARTIAL
+  const smallNumDocs = 5 // Number of documents in the "small table"
 
-var dbName, tableName, tableName2, stream, result, pks, feed, dumpTable;
+  before(async () => {
+    r = await rethinkdbdash(config)
+    dbName = uuid()
+    tableName = uuid() // Big table to test partial sequence
+    tableName2 = uuid() // small table to test success sequence
+    dumpTable = uuid() // dump table
 
-var numDocs = 100; // Number of documents in the "big table" used to test the SUCCESS_PARTIAL 
-var smallNumDocs = 5; // Number of documents in the "small table"
-
-It('Init for `stream.js`', function* (done) {
-  try {
-    dbName = uuid();
-    tableName = uuid(); // Big table to test partial sequence
-    tableName2 = uuid(); // small table to test success sequence
-    dumpTable = uuid(); // dump table
-
-    result = yield r.dbCreate(dbName).run()
-    assert.equal(result.dbs_created, 1);
-    //yield r.db(dbName).wait().run()
-    result = yield [
+    let result = await r.dbCreate(dbName).run()
+    assert.equal(result.dbs_created, 1)
+    // await r.db(dbName).wait().run()
+    result = await Promise.all([
       r.db(dbName).tableCreate(tableName)('tables_created').run(),
       r.db(dbName).tableCreate(tableName2)('tables_created').run(),
-      r.db(dbName).tableCreate(dumpTable)('tables_created').run()]
-    assert.deepEqual(result, [1, 1, 1]);
-    done();
-  }
-  catch(e) {
-    console.log(e);
-    done(e);
-  }
-})
-It('Inserting batch - table 1', function* (done) {
-  try {
-    result = yield r.db(dbName).table(tableName).insert(eval('['+new Array(numDocs).join('{}, ')+'{}]')).run();
-    assert.equal(result.inserted, numDocs);
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('Inserting batch - table 2', function* (done) {
-  try {
-    result = yield r.db(dbName).table(tableName2).insert(eval('['+new Array(smallNumDocs).join('{}, ')+'{}]')).run();
-    assert.equal(result.inserted, smallNumDocs);
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('Inserting batch', function* (done) {
-  try {
-    // Add a date
-    result = yield r.db(dbName).table(tableName).update({
-      date: r.now()
-    }).run();
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`table` should return a stream', function* (done) {
-  try {
-    stream = yield r.db(dbName).table(tableName).run({stream: true});
-    assert(stream);
-    assert(stream instanceof Readable);
-    stream.close();
+      r.db(dbName).tableCreate(dumpTable)('tables_created').run()])
+    assert.deepEqual(result, [1, 1, 1])
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('Arrays should return a stream', function* (done) {
-  try {
-    var data = [10, 11, 12, 13, 14, 15, 16];
-    stream = yield r.expr(data).run({stream: true});
-    assert(stream);
-    assert(stream instanceof Readable);
+    result = await r.db(dbName).table(tableName).insert(Array(numDocs).fill({})).run()
+    assert.equal(result.inserted, numDocs)
 
-    var count = 0;
-    stream.on('data', function() {
-      count++;
-      if (count === data.length) {
-        done();
-      }
-    });
-  }
-  catch(e) {
-    done(e);
-  }
-})
+    result = await r.db(dbName).table(tableName2).insert(Array(smallNumDocs).fill({})).run()
+    assert.equal(result.inserted, smallNumDocs)
 
-It('changes() should return a stream', function* (done) {
-  try {
-    var data = [{}, {}, {}, {}];
-    stream = yield r.db(dbName).table(tableName).changes().run({stream: true});
-    assert(stream);
-    assert(stream instanceof Readable);
+    result = await r.db(dbName).table(tableName).update({date: r.now()}).run()
+    assert.equal(result.replaced, numDocs)
+  })
 
-    var count = 0;
-    stream.on('data', function() {
-      count++;
-      if (count === data.length) {
-        done();
-        stream.close();
-      }
-    });
-    yield r.db(dbName).table(tableName).insert(data).run();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+  after(async () => {
+    await r.getPool().drain()
+  })
 
-It('get().changes() should return a stream', function* (done) {
-  try {
-    stream = yield r.db(dbName).table(tableName).get(1).changes().run({stream: true});
-    assert(stream);
-    assert(stream instanceof Readable);
+  it('`table` should return a stream', async function () {
+    const stream = await r.db(dbName).table(tableName).run({stream: true})
+    assert(stream)
+    assert(stream instanceof Readable)
+    stream.close()
+  })
 
-    var count = 0;
-    stream.on('data', function() {
-      count++;
-      if (count === 3) {
-        done();
-        stream.close();
-      }
-    });
-    yield r.db(dbName).table(tableName).insert({id: 1}).run();
-    yield r.db(dbName).table(tableName).get(1).update({update: 1}).run();
-    yield r.db(dbName).table(tableName).get(1).update({update: 2}).run();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+  it('Arrays should return a stream', async function () {
+    const data = [10, 11, 12, 13, 14, 15, 16]
+    const stream = await r.expr(data).run({stream: true})
+    assert(stream)
+    assert(stream instanceof Readable)
 
-It('`table` should return a stream - testing empty SUCCESS_COMPLETE', function* (done) {
-  var i=0;
-  try {
-    var connection = yield r.connect({host: config.host, port: config.port, authKey: config.authKey});
-    assert(connection);
+    await new Promise((resolve, reject) => {
+      let count = 0
+      stream.on('data', function () {
+        count++
+        if (count === data.length) {
+          resolve()
+        }
+      })
+    })
+  })
 
-    stream = yield r.db(dbName).table(tableName).run(connection, {stream: true, maxBatchRows: 1});
-    assert(stream);
-    assert(stream instanceof Readable);
-    stream.close();
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+  it('changes() should return a stream', async function () {
+    const data = [{}, {}, {}, {}]
+    const stream = await r.db(dbName).table(tableName).changes().run({stream: true})
+    assert(stream)
+    assert(stream instanceof Readable)
+    const promise = new Promise((resolve, reject) => {
+      let count = 0
+      stream.on('data', function () {
+        count++
+        if (count === data.length) {
+          resolve()
+          stream.close()
+        }
+      })
+    })
+    await r.db(dbName).table(tableName).insert(data).run()
+    await promise
+  })
 
+  it('get().changes() should return a stream', async function () {
+    const id = uuid()
+    await r.db(dbName).table(tableName).insert({id}).run()
+    const stream = await r.db(dbName).table(tableName).get(id).changes().run({stream: true})
+    assert(stream)
+    assert(stream instanceof Readable)
 
-It('Test flowing - event data', function* (done) {
-  var i=0;
-  try {
-    var connection = yield r.connect({host: config.host, port: config.port, authKey: config.authKey});
-    assert(connection);
+    const promise = new Promise((resolve, reject) => {
+      let count = 0
+      stream.on('data', function () {
+        count++
+        if (count === 3) {
+          resolve()
+          stream.close()
+        }
+      })
+    })
+    await r.db(dbName).table(tableName).get(id).update({update: 1}).run()
+    await r.db(dbName).table(tableName).get(id).update({update: 2}).run()
+    await r.db(dbName).table(tableName).get(id).update({update: 3}).run()
+    await promise
+  })
 
-    stream = yield r.db(dbName).table(tableName).run(connection, {stream: true, maxBatchRows: 1});
-    var count = 0;
-    stream.on('data', function() {
-      count++;
-      if (count === numDocs) {
-        done();
-      }
-    });
-  }
-  catch(e) {
-    done(e);
-  }
-})
+  it('`table` should return a stream - testing empty SUCCESS_COMPLETE', async function () {
+    const connection = await r.connect({host: config.host, port: config.port, authKey: config.authKey})
+    assert(connection)
 
-It('Test read', function* (done) {
-  try {
-    var connection = yield r.connect({host: config.host, port: config.port, authKey: config.authKey});
-    assert(connection);
+    const stream = await r.db(dbName).table(tableName).run(connection, {stream: true, maxBatchRows: 1})
+    assert(stream)
+    assert(stream instanceof Readable)
+    await stream.close()
+    await connection.close()
+  })
 
-    stream = yield r.db(dbName).table(tableName).run(connection, {stream: true, maxBatchRows: 1});
-    stream.once('readable', function() {
-      var doc = stream.read();
-      if (doc === null) {
-        done(new Error("stream.read() should not return null when readable was emitted"));
-      }
-      var count = 1;
-      stream.on('data', function(data) {
-        count++;
+  it('Test flowing - event data', async function () {
+    const connection = await r.connect({host: config.host, port: config.port, authKey: config.authKey})
+    assert(connection)
+
+    const stream = await r.db(dbName).table(tableName).run(connection, {stream: true, maxBatchRows: 1})
+    await new Promise((resolve, reject) => {
+      let count = 0
+      stream.on('data', function () {
+        count++
         if (count === numDocs) {
-          done();
+          resolve()
         }
-      });
-    });
-  }
-  catch(e) {
-    done(e);
-  }
-})
+      })
+    })
+    await stream.close()
+    await connection.close()
+  })
 
-It('Test flowing - event data', function* (done) {
-  var i=0;
-  try {
-    var connection = yield r.connect({host: config.host, port: config.port, authKey: config.authKey});
-    assert(connection);
+  it('Test read', async function () {
+    const connection = await r.connect({host: config.host, port: config.port, authKey: config.authKey})
+    assert(connection)
 
-    stream = yield r.db(dbName).table(tableName).run(connection, {stream: true, maxBatchRows: 1});
-    var count = 0;
-    stream.on('data', function() {
-      count++;
-      if (count === numDocs) {
-        done();
-      }
-    });
-    stream.pause();
-    if (count > 0) {
-      done(new Error("The stream should have been paused"));
-    }
-    stream.resume();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-
-It('Test read with null value', function* (done) {
-  try {
-    var connection = yield r.connect({host: config.host, port: config.port, authKey: config.authKey});
-    assert(connection);
-
-    stream = yield r.db(dbName).table(tableName).limit(10).union([null]).union(r.db(dbName).table(tableName).limit(10)).run(connection, {stream: true, maxBatchRows: 1});
-    stream.once('readable', function() {
-      var count = 0;
-      stream.on('data', function(data) {
-        count++;
-        if (count === 20) {
-          done();
+    const stream = await r.db(dbName).table(tableName).run(connection, {stream: true, maxBatchRows: 1})
+    await new Promise((resolve, reject) => {
+      stream.once('readable', function () {
+        const doc = stream.read()
+        if (doc === null) {
+          reject(new Error('stream.read() should not return null when readable was emitted'))
         }
-        else if (count > 20) {
-          done(new Error("Should not get null"))
-        }
-      });
-    });
-  }
-  catch(e) {
-    done(e);
-  }
-})
+        let count = 1
+        stream.on('data', function (data) {
+          count++
+          if (count === numDocs) {
+            resolve()
+          }
+        })
+      })
+    })
+    await stream.close()
+    await connection.close()
+  })
 
-It('Test read', function* (done) {
-  try {
-    var connection = yield r.connect({host: config.host, port: config.port, authKey: config.authKey});
-    assert(connection);
+  it('Test flowing - event data', async function () {
+    const connection = await r.connect({host: config.host, port: config.port, authKey: config.authKey})
+    assert(connection)
 
-    stream = yield r.db(dbName).table(tableName).run(connection, {stream: true, maxBatchRows: 1});
-    stream.once('readable', function() {
-      var doc = stream.read();
-      if (doc === null) {
-        done(new Error("stream.read() should not return null when readable was emitted"));
-      }
-      stream.close().then(function() {
-        done();
-      }).error(function(error) {
-        done(error);
-      });
-
-    });
-  }
-  catch(e) {
-    done(e);
-  }
-})
-
-It('Import with stream as default', function* (done) {
-  var r1 = require('../lib')({stream: true, host: config.host, port: config.port, authKey: config.authKey, buffer: config.buffer, max: config.max, discovery: false, silent: true});
-  var i=0;
-  try {
-    stream = yield r1.db(dbName).table(tableName).run();
-    assert(stream instanceof Readable);
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-
-It('toStream', function* (done) {
-  try {
-    stream = r.db(dbName).table(tableName).toStream();
-    stream.once('readable', function() {
-      var doc = stream.read();
-      if (doc === null) {
-        done(new Error("stream.read() should not return null when readable was emitted"));
-      }
-      var count = 1;
-      stream.on('data', function(data) {
-        count++;
+    const stream = await r.db(dbName).table(tableName).run(connection, {stream: true, maxBatchRows: 1})
+    await new Promise((resolve, reject) => {
+      let count = 0
+      stream.on('data', function () {
+        count++
         if (count === numDocs) {
-          done();
+          resolve()
         }
-      });
-    });
-  }
-  catch(e) {
-    done(e);
-  }
-
-})
-It('toStream - with grouped data', function* (done) {
-  try {
-    stream = r.db(dbName).table(tableName).group({index: 'id'}).toStream();
-    stream.once('readable', function() {
-      var doc = stream.read();
-      if (doc === null) {
-        done(new Error("stream.read() should not return null when readable was emitted"));
+      })
+      stream.pause()
+      if (count > 0) {
+        reject(new Error('The stream should have been paused'))
       }
-      var count = 1;
-      stream.on('data', function(data) {
-        count++;
-        if (count === numDocs) {
-          done();
+      stream.resume()
+    })
+    await stream.close()
+    await connection.close()
+  })
+
+  it('Test read with null value', async function () {
+    const connection = await r.connect({host: config.host, port: config.port, authKey: config.authKey})
+    assert(connection)
+
+    const stream = await r.db(dbName).table(tableName).limit(10).union([null]).union(r.db(dbName).table(tableName).limit(10)).run(connection, {stream: true, maxBatchRows: 1})
+    await new Promise((resolve, reject) => {
+      stream.once('readable', function () {
+        let count = 0
+        stream.on('data', function (data) {
+          count++
+          if (count === 20) {
+            resolve()
+          } else if (count > 20) {
+            reject(new Error('Should not get null'))
+          }
+        })
+      })
+    })
+    await stream.close()
+    await connection.close()
+  })
+
+  it('Test read', async function () {
+    const connection = await r.connect({host: config.host, port: config.port, authKey: config.authKey})
+    assert(connection)
+
+    const stream = await r.db(dbName).table(tableName).run(connection, {stream: true, maxBatchRows: 1})
+    await new Promise((resolve, reject) => {
+      stream.once('readable', function () {
+        stream.read() === null
+          ? reject(new Error('stream.read() should not return null when readable was emitted'))
+          : resolve()
+      })
+    })
+    await stream.close()
+    await connection.close()
+  })
+
+  it('Import with stream as default', async function () {
+    const r1 = rethinkdbdash({stream: true, host: config.host, port: config.port, authKey: config.authKey, buffer: config.buffer, max: config.max, discovery: false, silent: true})
+    const stream = await r1.db(dbName).table(tableName).run()
+    assert(stream instanceof Readable)
+    await stream.close()
+    await r1.getPool().drain()
+  })
+
+  it('toStream', async function () {
+    const stream = r.db(dbName).table(tableName).toStream()
+
+    await new Promise((resolve, reject) => {
+      stream.once('readable', function () {
+        const doc = stream.read()
+        if (doc === null) {
+          reject(new Error('stream.read() should not return null when readable was emitted'))
         }
-      });
-    });
-  }
-  catch(e) {
-    done(e);
-  }
+        let count = 1
+        stream.on('data', function (data) {
+          count++
+          if (count === numDocs) {
+            resolve()
+          }
+        })
+      })
+    })
+    await stream.close()
+  })
 
-})
+  it('toStream - with grouped data', async function () {
+    const stream = r.db(dbName).table(tableName).group({index: 'id'}).toStream()
 
-It('pipe should work with a writable stream - 200-200', function* (done) {
-  var r1 = require('../lib')({buffer:1, max: 2, discovery: false, silent: true});
-
-  r1.db(dbName).table(tableName).toStream({highWaterMark: 200})
-    .pipe(r1.db(dbName).table(dumpTable).toStream({writable: true, highWaterMark: 200}))
-    .on('finish', function() {
-      r.expr([
-        r1.db(dbName).table(tableName).count(),
-        r1.db(dbName).table(dumpTable).count()
-      ]).run().then(function(result) {
-        if (result[0] !== result[1]) {
-          done(new Error('All the data should have been streamed'));
+    await new Promise((resolve, reject) => {
+      stream.once('readable', function () {
+        const doc = stream.read()
+        if (doc === null) {
+          reject(new Error('stream.read() should not return null when readable was emitted'))
         }
+        let count = 1
+        stream.on('data', function (data) {
+          count++
+          if (count === numDocs) {
+            resolve()
+          }
+        })
+      })
+    })
+    await stream.close()
+  })
+
+  it('pipe should work with a writable stream - 200-200', function (done) {
+    const r1 = rethinkdbdash({buffer: 1, max: 2, discovery: false, silent: true})
+
+    r1.db(dbName).table(tableName).toStream({highWaterMark: 200})
+      .pipe(r1.db(dbName).table(dumpTable).toStream({writable: true, highWaterMark: 200}))
+      .on('finish', function () {
+        r.expr([
+          r1.db(dbName).table(tableName).count(),
+          r1.db(dbName).table(dumpTable).count()
+        ])
+          .run().then(function (result) {
+            if (result[0] !== result[1]) {
+              done(new Error('All the data should have been streamed'))
+            }
+            return r1.db(dbName).table(dumpTable).delete()
+          }).then((_) => r1.getPool().drain()).then(done).error(done)
+      })
+  })
+
+  it('pipe should work with a writable stream - 200-20', function (done) {
+    const r1 = rethinkdbdash({buffer: 1, max: 2, discovery: false, silent: true})
+
+    r1.db(dbName).table(tableName).toStream({highWaterMark: 200})
+      .pipe(r1.db(dbName).table(dumpTable).toStream({writable: true, highWaterMark: 20}))
+      .on('finish', function () {
+        r.expr([
+          r1.db(dbName).table(tableName).count(),
+          r1.db(dbName).table(dumpTable).count()
+        ]).run().then(function (result) {
+          if (result[0] !== result[1]) {
+            done(new Error('All the data should have been streamed'))
+          }
+          return r1.db(dbName).table(dumpTable).delete()
+        }).then((_) => r1.getPool().drain()).then(done).error(done)
+      })
+  })
+
+  it('pipe should work with a writable stream - 20-200', function (done) {
+    const r1 = rethinkdbdash({buffer: 1, max: 2, discovery: false, silent: true})
+
+    r1.db(dbName).table(tableName).toStream({highWaterMark: 20})
+      .pipe(r1.db(dbName).table(dumpTable).toStream({writable: true, highWaterMark: 200}))
+      .on('finish', function () {
+        r.expr([
+          r1.db(dbName).table(tableName).count(),
+          r1.db(dbName).table(dumpTable).count()
+        ]).run().then(function (result) {
+          if (result[0] !== result[1]) {
+            done(new Error('All the data should have been streamed'))
+          }
+          return r1.db(dbName).table(dumpTable).delete()
+        }).then((_) => r1.getPool().drain()).then(done).error(done)
+      })
+  })
+
+  it('pipe should work with a writable stream - 50-50', function (done) {
+    const r1 = rethinkdbdash({buffer: 1, max: 2, discovery: false, silent: true})
+
+    r1.db(dbName).table(tableName).toStream({highWaterMark: 50})
+      .pipe(r1.db(dbName).table(dumpTable).toStream({writable: true, highWaterMark: 50}))
+      .on('finish', function () {
+        r.expr([
+          r1.db(dbName).table(tableName).count(),
+          r1.db(dbName).table(dumpTable).count()
+        ]).run().then(function (result) {
+          if (result[0] !== result[1]) {
+            done(new Error('All the data should have been streamed'))
+          }
+          return r1.db(dbName).table(dumpTable).delete()
+        }).then((_) => r1.getPool(0).drain()).then(done).error(done)
+      })
+  })
+
+  it('toStream((writable: true}) should handle options', function (done) {
+    const r1 = rethinkdbdash({buffer: 1, max: 2, discovery: false, silent: true})
+
+    const stream = r1.db(dbName).table(dumpTable).toStream({writable: true, highWaterMark: 50, conflict: 'replace'})
+    stream.write({id: 1, foo: 1})
+    stream.write({id: 1, foo: 2})
+    stream.end({id: 1, foo: 3})
+
+    stream.on('finish', function () {
+      r1.db(dbName).table(dumpTable).count().then(function (result) {
+        assert.equal(result, 1)
+        return r1.db(dbName).table(dumpTable).get(1)
+      }).then(function (result) {
+        assert.deepEqual(result, {id: 1, foo: 3})
         return r1.db(dbName).table(dumpTable).delete()
-      }).then(function() {
-        r1.getPool(0).drain();
-      }).then(function() {
-        setTimeout(done, 1000);
-        //done();
-      }).error(done);
-    });
-})
-It('pipe should work with a writable stream - 200-20', function* (done) {
-  var r1 = require('../lib')({buffer:1, max: 2, discovery: false, silent: true});
+      }).then((_) => r1.getPool(0).drain()).then(done).error(done)
+    })
+  })
 
-  r1.db(dbName).table(tableName).toStream({highWaterMark: 200})
-    .pipe(r1.db(dbName).table(dumpTable).toStream({writable: true, highWaterMark: 20}))
-    .on('finish', function() {
-      r.expr([
-        r1.db(dbName).table(tableName).count(),
-        r1.db(dbName).table(dumpTable).count()
-      ]).run().then(function(result) {
-        if (result[0] !== result[1]) {
-          done(new Error('All the data should have been streamed'));
-        }
-        return r1.db(dbName).table(dumpTable).delete()
-      }).then(function() {
-        r1.getPool(0).drain();
-        done();
-      }).error(done);
-    });
-})
-It('pipe should work with a writable stream - 20-200', function* (done) {
-  var r1 = require('../lib')({buffer:1, max: 2, discovery: false, silent: true});
-
-  r1.db(dbName).table(tableName).toStream({highWaterMark: 20})
-    .pipe(r1.db(dbName).table(dumpTable).toStream({writable: true, highWaterMark: 200}))
-    .on('finish', function() {
-      r.expr([
-        r1.db(dbName).table(tableName).count(),
-        r1.db(dbName).table(dumpTable).count()
-      ]).run().then(function(result) {
-        if (result[0] !== result[1]) {
-          done(new Error('All the data should have been streamed'));
-        }
-        return r1.db(dbName).table(dumpTable).delete()
-      }).then(function() {
-        r1.getPool(0).drain();
-        done();
-      }).error(done);
-    });
-})
-It('pipe should work with a writable stream - 50-50', function* (done) {
-  var r1 = require('../lib')({buffer:1, max: 2, discovery: false, silent: true});
-
-  r1.db(dbName).table(tableName).toStream({highWaterMark: 50})
-    .pipe(r1.db(dbName).table(dumpTable).toStream({writable: true, highWaterMark: 50}))
-    .on('finish', function() {
-      r.expr([
-        r1.db(dbName).table(tableName).count(),
-        r1.db(dbName).table(dumpTable).count()
-      ]).run().then(function(result) {
-        if (result[0] !== result[1]) {
-          console.log(result);
-          done(new Error('All the data should have been streamed'));
-        }
-        return r1.db(dbName).table(dumpTable).delete()
-      }).then(function() {
-        r1.getPool(0).drain();
-        done();
-      }).error(function(err) {
-        console.log(err);
-        done(err);
-      });
-    });
-})
-It('toStream((writable: true}) should handle options', function* (done) {
-  var r1 = require('../lib')({buffer:1, max: 2, discovery: false, silent: true});
-
-  var stream = r1.db(dbName).table(dumpTable).toStream({writable: true, highWaterMark: 50, conflict: 'replace'});
-  stream.write({id: 1, foo: 1});
-  stream.write({id: 1, foo: 2});
-  stream.end({id: 1, foo: 3});
-  stream.on('finish', function() {
-    r1.db(dbName).table(dumpTable).count().then(function(result) {
-      assert.equal(result, 1);
-      return r1.db(dbName).table(dumpTable).get(1)
-    }).then(function(result) {
-      assert.deepEqual(result, {id: 1, foo: 3});
-      return r1.db(dbName).table(dumpTable).delete();
-    }).then(function(result) {
-      r1.getPool(0).drain();
-      done();
-    }).error(done);
-  });
-})
-
-It('test pipe all streams', function* (done) {
+  it('test pipe all streams', function (done) {
   // Create a transform stream that will convert data to a string
-  var stream = require('stream')
-  var addfoobar = new stream.Transform();
-  addfoobar._writableState.objectMode = true;
-  addfoobar._readableState.objectMode = true;
-  addfoobar._transform = function (data, encoding, done) {
-    data.transform = true;
-    this.push(data);
-    done();
-  }
-  var addbuzzlol = new stream.Transform();
-  addbuzzlol._writableState.objectMode = true;
-  addbuzzlol._readableState.objectMode = true;
-  addbuzzlol._transform = function (data, encoding, done) {
-    delete data.id
-    data.written = true;
-    this.push(data);
-    done();
-  }
+    const stream = require('stream')
+    const addfoobar = new stream.Transform()
+    addfoobar._writableState.objectMode = true
+    addfoobar._readableState.objectMode = true
+    addfoobar._transform = function (data, encoding, done) {
+      data.transform = true
+      this.push(data)
+      done()
+    }
+    const addbuzzlol = new stream.Transform()
+    addbuzzlol._writableState.objectMode = true
+    addbuzzlol._readableState.objectMode = true
+    addbuzzlol._transform = function (data, encoding, done) {
+      delete data.id
+      data.written = true
+      this.push(data)
+      done()
+    }
+    r.db(dbName).table(tableName).without('id').toStream()
+      .on('error', done)
+      .pipe(addfoobar)
+      .on('error', done)
+      .pipe(r.db(dbName).table(dumpTable).toStream({transform: true}))
+      .on('error', done)
+      .pipe(addbuzzlol)
+      .on('error', done)
+      .pipe(r.db(dbName).table(dumpTable).toStream({writable: true}))
+      .on('error', done)
+      .on('finish', function () {
+        r.db(dbName).table(dumpTable).filter({written: true}).count().run().then(function (result) {
+          assert(result, numDocs)
+          return r.db(dbName).table(dumpTable).filter({transform: true}).count().run()
+        }).then(function (result) {
+          assert(result, numDocs * 2)
+          return r.db(dbName).table(dumpTable).delete()
+        }).then((_) => r.getPool().drain()).then(done).error(done)
+      })
+  })
 
-  r.db(dbName).table(tableName).without('id').toStream()
-    .on('error', done)
-    .pipe(addfoobar)
-    .on('error', done)
-    .pipe(r.db(dbName).table(dumpTable).toStream({transform: true}))
-    .on('error', done)
-    .pipe(addbuzzlol)
-    .on('error', done)
-    .pipe(r.db(dbName).table(dumpTable).toStream({writable: true}))
-    .on('error', done)
-    .on('finish', function() {
-      r.db(dbName).table(dumpTable).filter({written: true}).count().run().then(function(result) {
-        assert(result, numDocs);
-        return r.db(dbName).table(dumpTable).filter({transform:true}).count().run()
-      }).then(function() {
-        assert(result, numDocs*2);
-        return r.db(dbName).table(dumpTable).delete();
-      }).then(function(result) {
-        done();
-        r.getPool(0).drain();
-      });
-    });
-})
+  it('toStream({writable: true}) should throw on something else than a table', async function () {
+    const r1 = rethinkdbdash({buffer: 1, max: 2, discovery: false, silent: true})
+    try {
+      r.expr(dumpTable).toStream({writable: true})
+      assert.fail('should throw')
+    } catch (err) {
+      assert(err.message.match(/^Cannot create a writable stream on something else than a table/))
+    } finally {
+      r1.getPool().drain()
+    }
+  })
 
-It('toStream({writable: true}) should throw on something else than a table', function* (done) {
-  var r1 = require('../lib')({buffer:1, max: 2, discovery: false, silent: true});
-
-  try {
-    r.expr(dumpTable).toStream({writable: true});
-  }
-  catch(err) {
-    assert(err.message, "Cannot create a writable stream on something else than a table.");
-    done();
-  }
-})
-
-It('toStream({transform: true}) should throw on something else than a table', function* (done) {
-  var r1 = require('../lib')({buffer:1, max: 2, discovery: false, silent: true});
-
-  try {
-    r.expr(dumpTable).toStream({transform: true});
-  }
-  catch(err) {
-    assert(err.message, "Cannot create a writable stream on something else than a table.");
-    done();
-  }
+  it('toStream({transform: true}) should throw on something else than a table', async function () {
+    const r1 = rethinkdbdash({buffer: 1, max: 2, discovery: false, silent: true})
+    try {
+      r.expr(dumpTable).toStream({transform: true})
+      assert.fail('should throw')
+    } catch (err) {
+      assert(err.message.match(/^Cannot create a writable stream on something else than a table/))
+    } finally {
+      r1.getPool().drain()
+    }
+  })
 })

--- a/test/string-manipulation.js
+++ b/test/string-manipulation.js
@@ -1,86 +1,56 @@
-var config = require(__dirname+'/config.js');
-var r = require(__dirname+'/../lib')(config);
-var util = require(__dirname+'/util/common.js');
-var assert = require('assert');
+const path = require('path')
+const config = require('./config.js')
+const rethinkdbdash = require(path.join(__dirname, '/../lib'))
+const assert = require('assert')
+const {before, after, describe, it} = require('mocha')
 
-var uuid = util.uuid;
-var It = util.It;
+describe('string manipulation', () => {
+  let r
 
-var uuid = util.uuid;
-var dbName, tableName, result;
+  before(async () => {
+    r = await rethinkdbdash(config)
+  })
 
+  after(async () => {
+    await r.getPool().drain()
+  })
 
-It('`match` should work', function* (done) {
-  try {
-    result = yield r.expr("hello").match("hello").run()
-    assert.deepEqual(result, {"end":5,"groups":[],"start":0,"str":"hello"});
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`match` should throw if no arguement has been passed', function* (done) {
-  try {
-    result = yield r.expr("foo").match().run();
-  }
-  catch(e) {
-    if (e.message === "`match` takes 1 argument, 0 provided after:\nr.expr(\"foo\")") {
-      done();
+  it('`match` should work', async function () {
+    const result = await r.expr('hello').match('hello').run()
+    assert.deepEqual(result, {'end': 5, 'groups': [], 'start': 0, 'str': 'hello'})
+  })
+
+  it('`match` should throw if no arguement has been passed', async function () {
+    try {
+      await r.expr('foo').match().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`match` takes 1 argument, 0 provided after:\nr.expr("foo")')
     }
-    else {
-      done(e);
-    }
-  }
-})
-It('`upcase` should work', function* (done) {
-  try {
-    result = yield r.expr("helLo").upcase().run();
-    assert.equal(result, "HELLO");
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`downcase` should work', function* (done) {
-  try {
-    result = yield r.expr("HElLo").downcase().run();
-    assert.equal(result, "hello");
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`split` should work', function* (done) {
-  try {
-    result = yield r.expr("foo  bar bax").split().run();
-    assert.deepEqual(result, ["foo",  "bar", "bax"]);
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`split(separator)` should work', function* (done) {
-   try {
-    result = yield r.expr("12,37,,22,").split(",").run();
-    assert.deepEqual(result, ["12", "37", "", "22", ""]);
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`split(separtor, max)` should work', function* (done) {
-  try {
-    result = yield r.expr("foo  bar bax").split(null, 1).run();
-    assert.deepEqual(result, ["foo", "bar bax"]);
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+  })
 
+  it('`upcase` should work', async function () {
+    const result = await r.expr('helLo').upcase().run()
+    assert.equal(result, 'HELLO')
+  })
+
+  it('`downcase` should work', async function () {
+    const result = await r.expr('HElLo').downcase().run()
+    assert.equal(result, 'hello')
+  })
+
+  it('`split` should work', async function () {
+    const result = await r.expr('foo  bar bax').split().run()
+    assert.deepEqual(result, ['foo', 'bar', 'bax'])
+  })
+
+  it('`split(separator)` should work', async function () {
+    const result = await r.expr('12,37,,22,').split(',').run()
+    assert.deepEqual(result, ['12', '37', '', '22', ''])
+  })
+
+  it('`split(separtor, max)` should work', async function () {
+    const result = await r.expr('foo  bar bax').split(null, 1).run()
+    assert.deepEqual(result, ['foo', 'bar bax'])
+  })
+})

--- a/test/transform-stream.js
+++ b/test/transform-stream.js
@@ -1,279 +1,254 @@
-var config = require('./config.js');
-var r = require('../lib')(config);
-var util = require(__dirname+'/util/common.js');
-var assert = require('assert');
-var Readable = require('stream').Readable;
-var Stream = require('stream')
-var _util = require('util');
-var devnull = require('dev-null');
+const path = require('path')
+const config = require('./config.js')
+const rethinkdbdash = require(path.join(__dirname, '/../lib'))
+const assert = require('assert')
+const {uuid} = require(path.join(__dirname, '/util/common.js'))
+const {before, after, describe, it} = require('mocha')
+const {Readable} = require('stream')
+const Stream = require('stream')
+const devnull = require('dev-null')
 
-var uuid = util.uuid;
-var It = util.It
+describe('stream', () => {
+  let r, dbName, tableName, dumpTable
+  const numDocs = 100 // Number of documents in the "big table" used to test the SUCCESS_PARTIAL
 
-var dbName, tableName, tableName2, stream, result, pks, feed, dumpTable;
+  before(async () => {
+    r = await rethinkdbdash(config)
+    dbName = uuid()
+    tableName = uuid() // Big table to test partial sequence
+    dumpTable = uuid() // dump table
 
-var numDocs = 100; // Number of documents in the "big table" used to test the SUCCESS_PARTIAL 
+    let result = await r.dbCreate(dbName).run()
+    assert.equal(result.dbs_created, 1)
 
-
-It('Init for `transform-stream.js`', function* (done) {
-  try {
-    dbName = uuid();
-    tableName = uuid(); // Big table to test partial sequence
-    dumpTable = uuid(); // dump table
-
-    result = yield r.dbCreate(dbName).run()
-    assert.equal(result.dbs_created, 1);
-    //yield r.db(dbName).wait().run()
-    result = yield [
+    result = await Promise.all([
       r.db(dbName).tableCreate(tableName)('tables_created').run(),
-      r.db(dbName).tableCreate(dumpTable)('tables_created').run()]
-    assert.deepEqual(result, [1, 1]);
-    done();
-  }
-  catch(e) {
-    console.log(e);
-    done(e);
-  }
-})
-It('Inserting batch - table 1', function* (done) {
-  try {
-    result = yield r.db(dbName).table(tableName).insert(eval('['+new Array(numDocs).join('{}, ')+'{}]')).run();
-    assert.equal(result.inserted, numDocs);
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+      r.db(dbName).tableCreate(dumpTable)('tables_created').run()])
+    assert.deepEqual(result, [1, 1])
 
-It('test pipe transform - fast input', function* (done) {
-  var stream = new Readable({objectMode: true});
-  var size = 35;
-  var value = uuid();
-  for(var i=0; i<size; i++) {
-    stream.push({field: value});
-  }
-  stream.push(null);
-  var table = r.db(dbName).table(dumpTable).toStream({transform: true, debug: true, highWaterMark: 10});
-  stream.pipe(table)
-    .on('error', done)
-    .on('end', function() {
-      r.db(dbName).table(dumpTable).filter({field: stream._value}).count().run().then(function(result) {
-        assert.deepEqual(result, size);
-        assert.deepEqual(table._sequence, [10, 10, 10, 5])
-        done();
-      });
-    }).pipe(devnull({objectMode: true}));
-})
+    result = await r.db(dbName).table(tableName).insert(Array(numDocs).fill({})).run()
+    assert.equal(result.inserted, numDocs)
+  })
 
-It('test pipe transform - slow input - 1', function* (done) {
-  var stream = new Readable({objectMode: true});
-  var size = 10;
-  var values = [uuid(), uuid()];
-  var table = r.db(dbName).table(dumpTable).toStream({transform: true, debug: true, highWaterMark: 5});
+  after(async () => {
+    await r.getPool().drain()
+  })
 
-  var i = 0;
-  stream._read = function() {
-    var self = this;
-    i++;
-    if (i <= 3) {
-      self.push({field: values[0]});
+  it('test pipe transform - fast input', function (done) {
+    const stream = new Readable({objectMode: true})
+    const size = 35
+    const value = uuid()
+    for (let i = 0; i < size; i++) {
+      stream.push({field: value})
     }
-    else if (i === 4) {
-      setTimeout(function() {
-        self.push({field: values[1]});
-      }, 3000)
-    }
-    else if (i <= 10) {
-      self.push({field: values[1]});
-    }
-    else {
-      self.push(null);
-    }
-  }
+    stream.push(null)
+    const table = r.db(dbName).table(dumpTable).toStream({transform: true, debug: true, highWaterMark: 10})
+    stream.pipe(table)
+      .on('error', done)
+      .on('end', function () {
+        r.db(dbName).table(dumpTable).filter({field: stream._value}).count().run().then(function (result) {
+          assert.deepEqual(result, size)
+          assert.deepEqual(table._sequence, [10, 10, 10, 5])
+          done()
+        })
+      }).pipe(devnull({objectMode: true}))
+  })
 
-  stream.pipe(table)
-    .on('error', done)
-    .on('end', function() {
-      r.expr([
-        r.db(dbName).table(dumpTable).filter({field: values[0]}).count(),
-        r.db(dbName).table(dumpTable).filter({field: values[1]}).count()
-      ]).run().then(function(result) {
-        assert.deepEqual(result, [3, 7]);
-        assert.deepEqual(table._sequence, [3, 5, 2])
-        done();
-      });
-    }).pipe(devnull({objectMode: true}));
-})
-It('test pipe transform - slow input - 2', function* (done) {
-  var stream = new Readable({objectMode: true});
-  var size = 10;
-  var values = [uuid(), uuid()];
-  var table = r.db(dbName).table(dumpTable).toStream({transform: true, debug: true, highWaterMark: 5});
+  it('test pipe transform - slow input - 1', function (done) {
+    const stream = new Readable({objectMode: true})
+    const values = [uuid(), uuid()]
+    const table = r.db(dbName).table(dumpTable).toStream({transform: true, debug: true, highWaterMark: 5})
 
-  var i = 0;
-  stream._read = function() {
-    var self = this;
-    i++;
-    if (i <= 5) {
-      self.push({field: values[0]});
+    let i = 0
+    stream._read = function () {
+      const self = this
+      i++
+      if (i <= 3) {
+        self.push({field: values[0]})
+      } else if (i === 4) {
+        setTimeout(function () {
+          self.push({field: values[1]})
+        }, 3000)
+      } else if (i <= 10) {
+        self.push({field: values[1]})
+      } else {
+        self.push(null)
+      }
     }
-    else if (i === 6) {
-      setTimeout(function() {
-        self.push({field: values[1]});
-      }, 3000)
-    }
-    else if (i <= 10) {
-      self.push({field: values[1]});
-    }
-    else {
-      self.push(null);
-    }
-  }
 
-  stream.pipe(table)
-    .on('error', done)
-    .on('end', function() {
-      r.expr([
-        r.db(dbName).table(dumpTable).filter({field: values[0]}).count(),
-        r.db(dbName).table(dumpTable).filter({field: values[1]}).count()
-      ]).run().then(function(result) {
-        assert.deepEqual(result, [5, 5]);
-        assert.deepEqual(table._sequence, [5, 5])
-        done();
-      });
-    }).pipe(devnull({objectMode: true}));
-})
-It('test pipe transform - single insert', function* (done) {
+    stream.pipe(table)
+      .on('error', done)
+      .on('end', function () {
+        r.expr([
+          r.db(dbName).table(dumpTable).filter({field: values[0]}).count(),
+          r.db(dbName).table(dumpTable).filter({field: values[1]}).count()
+        ]).run().then(function (result) {
+          assert.deepEqual(result, [3, 7])
+          assert.deepEqual(table._sequence, [3, 5, 2])
+          done()
+        })
+      }).pipe(devnull({objectMode: true}))
+  })
+
+  it('test pipe transform - slow input - 2', function (done) {
+    const stream = new Readable({objectMode: true})
+    const values = [uuid(), uuid()]
+    const table = r.db(dbName).table(dumpTable).toStream({transform: true, debug: true, highWaterMark: 5})
+
+    let i = 0
+    stream._read = function () {
+      const self = this
+      i++
+      if (i <= 5) {
+        self.push({field: values[0]})
+      } else if (i === 6) {
+        setTimeout(function () {
+          self.push({field: values[1]})
+        }, 3000)
+      } else if (i <= 10) {
+        self.push({field: values[1]})
+      } else {
+        self.push(null)
+      }
+    }
+
+    stream.pipe(table)
+      .on('error', done)
+      .on('end', function () {
+        r.expr([
+          r.db(dbName).table(dumpTable).filter({field: values[0]}).count(),
+          r.db(dbName).table(dumpTable).filter({field: values[1]}).count()
+        ]).run().then(function (result) {
+          assert.deepEqual(result, [5, 5])
+          assert.deepEqual(table._sequence, [5, 5])
+          done()
+        })
+      }).pipe(devnull({objectMode: true}))
+  })
+
+  it('test pipe transform - single insert', function (done) {
   // Create a transform stream that will convert data to a string
-  //var stream = new Input();
-  var stream = new Readable({objectMode: true});
-  var size = 10;
-  var value = uuid();
-  var table = r.db(dbName).table(dumpTable).toStream({transform: true, debug: true, highWaterMark: 5});
+  // const stream = new Input();
+    const stream = new Readable({objectMode: true})
+    const value = uuid()
+    const table = r.db(dbName).table(dumpTable).toStream({transform: true, debug: true, highWaterMark: 5})
 
-  var i = 0;
-  stream._read = function() {
-    i++;
-    if (i > 10) {
-      this.push(null);
-    }
-    else {
-      var self = this;
-      setTimeout(function() {
-        self.push({field: value});
-      }, 100); // suppose that each insert take less than 100 ms
-    }
-  }
-
-  stream.pipe(table)
-    .on('error', done)
-    .on('end', function() {
-      r.expr(r.db(dbName).table(dumpTable).filter({field: value}).count()).run().then(function(result) {
-        assert.deepEqual(result, 10);
-        assert.deepEqual(table._sequence, [1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
-        done();
-      });
-    }).pipe(devnull({objectMode: true}));
-})
-
-It('test transform output - object', function* (done) {
-  var stream = new Readable({objectMode: true});
-  var i = 0;
-  var values = [uuid(), uuid()];
-  stream._read = function() {
-    var self = this;
-    i++;
-    if (i <= 3) {
-      self.push({field: values[0]});
-    }
-    else if (i === 4) {
-      setTimeout(function() {
-        self.push({field: values[1]});
-      }, 300)
-    }
-    else if (i <= 10) {
-      self.push({field: values[1]});
-    }
-    else {
-      self.push(null);
-    }
-  }
-
-  var table = r.db(dbName).table(dumpTable).toStream({
-    transform: true
-  });
-
-  var result = [];
-  var endStream = new Stream.Transform();
-  endStream._writableState.objectMode = true;
-  endStream._readableState.objectMode = true;
-  endStream._transform = function (data, encoding, done) {
-    result.push(data);
-    this.push(data);
-    done();
-  }
-
-  stream.pipe(table)
-    .on('error', done)
-    .pipe(endStream)
-    .on('error', done)
-    .on('finish', function() {
-      assert(result.length, 10);
-      for(var i=0; i<result.length; i++) {
-        assert(Object.prototype.toString.call(result[i]), '[object Object]');
+    let i = 0
+    stream._read = function () {
+      i++
+      if (i > 10) {
+        this.push(null)
+      } else {
+        const self = this
+        setTimeout(function () {
+          self.push({field: value})
+        }, 100) // suppose that each insert take less than 100 ms
       }
-      done();
-    });
-})
-
-It('test transform output - string', function* (done) {
-  var stream = new Readable({objectMode: true});
-  var i = 0;
-  var values = [uuid(), uuid()];
-  stream._read = function() {
-    var self = this;
-    i++;
-    if (i <= 3) {
-      self.push({field: values[0]});
     }
-    else if (i === 4) {
-      setTimeout(function() {
-        self.push({field: values[1]});
-      }, 300)
-    }
-    else if (i <= 10) {
-      self.push({field: values[1]});
-    }
-    else {
-      self.push(null);
-    }
-  }
 
-  var table = r.db(dbName).table(dumpTable).toStream({
-    transform: true,
-    format: 'primaryKey'
-  });
+    stream.pipe(table)
+      .on('error', done)
+      .on('end', function () {
+        r.expr(r.db(dbName).table(dumpTable).filter({field: value}).count()).run().then(function (result) {
+          assert.deepEqual(result, 10)
+          assert.deepEqual(table._sequence, [1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
+          done()
+        })
+      }).pipe(devnull({objectMode: true}))
+  })
 
-  var result = [];
-  var endStream = new Stream.Transform();
-  endStream._writableState.objectMode = true;
-  endStream._readableState.objectMode = true;
-  endStream._transform = function (data, encoding, done) {
-    result.push(data);
-    this.push(data);
-    done();
-  }
-
-  stream.pipe(table)
-    .on('error', done)
-    .pipe(endStream)
-    .on('error', done)
-    .on('finish', function() {
-      assert(result.length, 10);
-      for(var i=0; i<result.length; i++) {
-        assert(typeof result[i], 'string');
+  it('test transform output - object', function (done) {
+    const stream = new Readable({objectMode: true})
+    let i = 0
+    const values = [uuid(), uuid()]
+    stream._read = function () {
+      const self = this
+      i++
+      if (i <= 3) {
+        self.push({field: values[0]})
+      } else if (i === 4) {
+        setTimeout(function () {
+          self.push({field: values[1]})
+        }, 300)
+      } else if (i <= 10) {
+        self.push({field: values[1]})
+      } else {
+        self.push(null)
       }
-      done();
-    });
+    }
+
+    const table = r.db(dbName).table(dumpTable).toStream({
+      transform: true
+    })
+
+    const result = []
+    const endStream = new Stream.Transform()
+    endStream._writableState.objectMode = true
+    endStream._readableState.objectMode = true
+    endStream._transform = function (data, encoding, done) {
+      result.push(data)
+      this.push(data)
+      done()
+    }
+
+    stream.pipe(table)
+      .on('error', done)
+      .pipe(endStream)
+      .on('error', done)
+      .on('finish', function () {
+        assert(result.length, 10)
+        for (let i = 0; i < result.length; i++) {
+          assert(Object.prototype.toString.call(result[i]), '[object Object]')
+        }
+        done()
+      })
+  })
+
+  it('test transform output - string', function (done) {
+    const stream = new Readable({objectMode: true})
+    let i = 0
+    const values = [uuid(), uuid()]
+    stream._read = function () {
+      const self = this
+      i++
+      if (i <= 3) {
+        self.push({field: values[0]})
+      } else if (i === 4) {
+        setTimeout(function () {
+          self.push({field: values[1]})
+        }, 300)
+      } else if (i <= 10) {
+        self.push({field: values[1]})
+      } else {
+        self.push(null)
+      }
+    }
+
+    const table = r.db(dbName).table(dumpTable).toStream({
+      transform: true,
+      format: 'primaryKey'
+    })
+
+    const result = []
+    const endStream = new Stream.Transform()
+    endStream._writableState.objectMode = true
+    endStream._readableState.objectMode = true
+    endStream._transform = function (data, encoding, done) {
+      result.push(data)
+      this.push(data)
+      done()
+    }
+
+    stream.pipe(table)
+      .on('error', done)
+      .pipe(endStream)
+      .on('error', done)
+      .on('finish', function () {
+        assert(result.length, 10)
+        for (var i = 0; i < result.length; i++) {
+          assert(typeof result[i], 'string')
+        }
+        done()
+      })
+  })
 })

--- a/test/transform-stream.js
+++ b/test/transform-stream.js
@@ -8,7 +8,7 @@ const {Readable} = require('stream')
 const Stream = require('stream')
 const devnull = require('dev-null')
 
-describe('stream', () => {
+describe('transform stream', () => {
   let r, dbName, tableName, dumpTable
   const numDocs = 100 // Number of documents in the "big table" used to test the SUCCESS_PARTIAL
 

--- a/test/transformations.js
+++ b/test/transformations.js
@@ -1,619 +1,363 @@
-var config = require(__dirname+'/config.js');
-var r = require(__dirname+'/../lib')(config);
-var util = require(__dirname+'/util/common.js');
-var assert = require('assert');
+const path = require('path')
+const config = require('./config.js')
+const rethinkdbdash = require(path.join(__dirname, '/../lib'))
+const assert = require('assert')
+const {uuid} = require(path.join(__dirname, '/util/common.js'))
+const {before, after, describe, it} = require('mocha')
 
-var uuid = util.uuid;
-var It = util.It;
+describe('transformations', () => {
+  let r, dbName, tableName
 
-var uuid = util.uuid;
-var dbName, tableName, result, pks;
+  before(async () => {
+    r = await rethinkdbdash(config)
+    dbName = uuid()
+    tableName = uuid()
+    const numDocs = 100
 
+    let result = await r.dbCreate(dbName).run()
+    assert.equal(result.dbs_created, 1)
 
-It('Init for `transformations.js`', function* (done) {
-  try {
-    dbName = uuid();
-    tableName = uuid();
+    result = await r.db(dbName).tableCreate(tableName).run()
+    assert.equal(result.tables_created, 1)
 
-    result = yield r.dbCreate(dbName).run();
-    assert.equal(result.dbs_created, 1);
+    result = await r.db(dbName).table(tableName).insert(Array(numDocs).fill({})).run()
+    assert.equal(result.inserted, numDocs)
 
-    result = yield r.db(dbName).tableCreate(tableName).run();
-    assert.equal(result.tables_created, 1);
+    result = await r.db(dbName).table(tableName).update({val: r.js('Math.random()')}, {nonAtomic: true}).run()
+    result = await r.db(dbName).table(tableName).indexCreate('val').run()
+    result = await r.db(dbName).table(tableName).indexWait('val').run()
+  })
 
-    result = yield r.db(dbName).table(tableName).insert(eval('['+new Array(100).join('{}, ')+'{}]')).run();
-    assert.equal(result.inserted, 100);
+  after(async () => {
+    await r.getPool().drain()
+  })
 
-    result = yield r.db(dbName).table(tableName).update({val: r.js("Math.random()")}, {nonAtomic: true}).run();
-    result = yield r.db(dbName).table(tableName).indexCreate('val').run();
-    result = yield r.db(dbName).table(tableName).indexWait('val').run();
+  it('`map` should work on array -- r.row', async function () {
+    let result = await r.expr([1, 2, 3]).map(r.row).run()
+    assert.deepEqual(result, [1, 2, 3])
 
-    pks = result.generated_keys;
+    result = await r.expr([1, 2, 3]).map(r.row.add(1)).run()
+    assert.deepEqual(result, [2, 3, 4])
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+  it('`map` should work on array -- function', async function () {
+    let result = await r.expr([1, 2, 3]).map(function (doc) { return doc }).run()
+    assert.deepEqual(result, [1, 2, 3])
 
-It('`map` should work on array -- r.row', function* (done) {
-  try {
-    result = yield r.expr([1,2,3]).map(r.row).run();
-    assert.deepEqual(result, [1,2,3]);
-    done();
+    result = await r.expr([1, 2, 3]).map(function (doc) { return doc.add(2) }).run()
+    assert.deepEqual(result, [3, 4, 5])
+  })
 
-    result = yield r.expr([1,2,3]).map(r.row.add(1)).run();
-    assert.deepEqual(result, [2, 3, 4]);
-
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`map` should work on array -- function', function* (done) {
-  try {
-    result = yield r.expr([1,2,3]).map(function(doc) { return doc }).run();
-    assert.deepEqual(result, [1,2,3]);
-
-    result = yield r.expr([1,2,3]).map(function(doc) { return doc.add(2)}).run();
-    assert.deepEqual(result, [3, 4, 5]);
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`map` should throw if no argument has been passed', function* (done) {
-  try {
-    result = yield r.db(dbName).table(tableName).map().run();
-  }
-  catch(e) {
-    if (e.message.match(/^`map` takes at least 1 argument, 0 provided after/) ){
-      done()
+  it('`map` should throw if no argument has been passed', async function () {
+    try {
+      await r.db(dbName).table(tableName).map().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message.match(/^`map` takes at least 1 argument, 0 provided after/))
     }
-    else {
-      done(e);
+  })
+
+  it('`withFields` should work on array -- single field', async function () {
+    const result = await r.expr([{a: 0, b: 1, c: 2}, {a: 4, b: 4, c: 5}, {a: 9, b: 2, c: 0}]).withFields('a').run()
+    assert.deepEqual(result, [{a: 0}, {a: 4}, {a: 9}])
+  })
+
+  it('`withFields` should work on array -- multiple field', async function () {
+    const result = await r.expr([{a: 0, b: 1, c: 2}, {a: 4, b: 4, c: 5}, {a: 9, b: 2, c: 0}]).withFields('a', 'c').run()
+    assert.deepEqual(result, [{a: 0, c: 2}, {a: 4, c: 5}, {a: 9, c: 0}])
+  })
+
+  it('`withFields` should throw if no argument has been passed', async function () {
+    try {
+      await r.db(dbName).table(tableName).withFields().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message.match(/^`withFields` takes at least 1 argument, 0 provided after/))
     }
-  }
-})
+  })
 
-It('`withFields` should work on array -- single field', function* (done) {
-  try {
-    result = yield r.expr([{a: 0, b: 1, c: 2}, {a: 4, b: 4, c: 5}, {a:9, b:2, c:0}]).withFields("a").run();
-    assert.deepEqual(result, [{a: 0}, {a: 4}, {a: 9}]);
+  it('`concatMap` should work on array -- function', async function () {
+    const result = await r.expr([[1, 2], [3], [4]]).concatMap(function (doc) { return doc }).run()
+    assert.deepEqual(result, [1, 2, 3, 4])
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`withFields` should work on array -- multiple field', function* (done) {
-  try {
-    result = yield r.expr([{a: 0, b: 1, c: 2}, {a: 4, b: 4, c: 5}, {a:9, b:2, c:0}]).withFields("a", "c").run();
-    assert.deepEqual(result, [{a: 0, c: 2}, {a: 4, c: 5}, {a:9, c:0}]);
+  it('`concatMap` should work on array -- r.row', async function () {
+    const result = await r.expr([[1, 2], [3], [4]]).concatMap(r.row).run()
+    assert.deepEqual(result, [1, 2, 3, 4])
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`withFields` should throw if no argument has been passed', function* (done) {
-  try {
-    result = yield r.db(dbName).table(tableName).withFields().run();
-  }
-  catch(e) {
-    if (e.message.match(/^`withFields` takes at least 1 argument, 0 provided after/) ){
-      done()
+  it('`concatMap` should throw if no argument has been passed', async function () {
+    try {
+      await r.db(dbName).table(tableName).concatMap().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message.match(/^`concatMap` takes 1 argument, 0 provided after/))
     }
-    else {
-      done(e);
+  })
+
+  it('`orderBy` should work on array -- string', async function () {
+    const result = await r.expr([{a: 23}, {a: 10}, {a: 0}, {a: 100}]).orderBy('a').run()
+    assert.deepEqual(result, [{a: 0}, {a: 10}, {a: 23}, {a: 100}])
+  })
+
+  it('`orderBy` should work on array -- r.row', async function () {
+    const result = await r.expr([{a: 23}, {a: 10}, {a: 0}, {a: 100}]).orderBy(r.row('a')).run()
+    assert.deepEqual(result, [{a: 0}, {a: 10}, {a: 23}, {a: 100}])
+  })
+
+  it('`orderBy` should work on a table -- pk', async function () {
+    const result = await r.db(dbName).table(tableName).orderBy({index: 'id'}).run()
+    for (var i = 0; i < result.length - 1; i++) {
+      assert(result[i].id < result[i + 1].id)
     }
-  }
-})
-It('`concatMap` should work on array -- function', function* (done) {
-  try {
-    result = yield r.expr([[1, 2], [3], [4]]).concatMap(function(doc) { return doc}).run();
-    assert.deepEqual(result, [1, 2, 3, 4]);
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`concatMap` should work on array -- r.row', function* (done) {
-  try {
-    result = yield r.expr([[1, 2], [3], [4]]).concatMap(r.row).run();
-    assert.deepEqual(result, [1, 2, 3, 4]);
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`concatMap` should throw if no argument has been passed', function* (done) {
-  try {
-    result = yield r.db(dbName).table(tableName).concatMap().run();
-  }
-  catch(e) {
-    if (e.message.match(/^`concatMap` takes 1 argument, 0 provided after/) ){
-      done()
+  it('`orderBy` should work on a table -- secondary', async function () {
+    const result = await r.db(dbName).table(tableName).orderBy({index: 'val'}).run()
+    for (var i = 0; i < result.length - 1; i++) {
+      assert(result[i].val < result[i + 1].val)
     }
-    else {
-      done(e);
+  })
+
+  it('`orderBy` should work on a two fields', async function () {
+    const dbName = uuid()
+    const tableName = uuid()
+    const numDocs = 98
+
+    let result = await r.dbCreate(dbName).run()
+    assert.deepEqual(result.dbs_created, 1)
+
+    result = await r.db(dbName).tableCreate(tableName).run()
+    assert.equal(result.tables_created, 1)
+
+    result = await r.db(dbName).table(tableName).insert(Array(numDocs).fill().map(() => ({a: r.js('Math.random()')}))).run()
+    assert.deepEqual(result.inserted, numDocs)
+
+    result = await r.db(dbName).table(tableName).orderBy('id', 'a').run()
+    assert(Array.isArray(result))
+    assert(result[0].id < result[1].id)
+  })
+
+  it('`orderBy` should throw if no argument has been passed', async function () {
+    try {
+      await r.db(dbName).table(tableName).orderBy().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message.match(/^`orderBy` takes at least 1 argument, 0 provided after/))
     }
-  }
-})
+  })
 
+  it('`orderBy` should not wrap on r.asc', async function () {
+    const result = await r.expr([{a: 23}, {a: 10}, {a: 0}, {a: 100}]).orderBy(r.asc(r.row('a'))).run()
+    assert.deepEqual(result, [{a: 0}, {a: 10}, {a: 23}, {a: 100}])
+  })
 
-It('`orderBy` should work on array -- string', function* (done) {
-  try {
-    result = yield r.expr([{a:23}, {a:10}, {a:0}, {a:100}]).orderBy("a").run();
-    assert.deepEqual(result, [{a:0}, {a:10}, {a:23}, {a:100}]);
+  it('`orderBy` should not wrap on r.desc', async function () {
+    const result = await r.expr([{a: 23}, {a: 10}, {a: 0}, {a: 100}]).orderBy(r.desc(r.row('a'))).run()
+    assert.deepEqual(result, [{a: 100}, {a: 23}, {a: 10}, {a: 0}])
+  })
+  it('r.desc should work', async function () {
+    const result = await r.expr([{a: 23}, {a: 10}, {a: 0}, {a: 100}]).orderBy(r.desc('a')).run()
+    assert.deepEqual(result, [{a: 100}, {a: 23}, {a: 10}, {a: 0}])
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+  it('r.asc should work', async function () {
+    const result = await r.expr([{a: 23}, {a: 10}, {a: 0}, {a: 100}]).orderBy(r.asc('a')).run()
+    assert.deepEqual(result, [{a: 0}, {a: 10}, {a: 23}, {a: 100}])
+  })
 
-It('`orderBy` should work on array -- r.row', function* (done) {
-  try {
-    result = yield r.expr([{a:23}, {a:10}, {a:0}, {a:100}]).orderBy(r.row("a")).run();
-    assert.deepEqual(result, [{a:0}, {a:10}, {a:23}, {a:100}]);
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-
-It('`orderBy` should work on a table -- pk', function* (done) {
-  try {
-    result = yield r.db(dbName).table(tableName).orderBy({index: "id"}).run();
-    for(var i=0; i<result.length-1; i++) {
-      assert(result[i].id < result[i+1].id);
+  it('`desc` is not defined after a term', async function () {
+    try {
+      await r.expr(1).desc('foo').run()
+      assert.fail('sholud throw')
+    } catch (e) {
+      assert.equal(e.message, '`desc` is not defined after:\nr.expr(1)')
     }
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`orderBy` should work on a table -- secondary', function* (done) {
-  try {
-    result = yield r.db(dbName).table(tableName).orderBy({index: "val"}).run();
-    for(var i=0; i<result.length-1; i++) {
-      assert(result[i].val < result[i+1].val);
+  it('`asc` is not defined after a term', async function () {
+    try {
+      await r.expr(1).asc('foo').run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`asc` is not defined after:\nr.expr(1)')
     }
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`orderBy` should work on a two fields', function* (done) {
-  try {
-    var dbName = uuid();
-    var tableName = uuid();
+  it('`skip` should work', async function () {
+    const result = await r.expr([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]).skip(3).run()
+    assert.deepEqual(result, [3, 4, 5, 6, 7, 8, 9])
+  })
 
-    result = yield r.dbCreate(dbName).run();
-    assert.deepEqual(result.dbs_created, 1);
-
-    result = yield r.db(dbName).tableCreate(tableName).run();
-    assert.equal(result.tables_created, 1);
-
-    result = yield r.db(dbName).table(tableName).insert([{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")},{a: r.js("Math.random()")}]).run();
-    assert.deepEqual(result.inserted, 98);
-
-    result = yield r.db(dbName).table(tableName).orderBy("id", "a").run();
-    assert(Array.isArray(result));
-    assert(result[0].id<result[1].id);
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`orderBy` should throw if no argument has been passed', function* (done) {
-  try {
-    result = yield r.db(dbName).table(tableName).orderBy().run();
-  }
-  catch(e) {
-    if (e.message.match(/^`orderBy` takes at least 1 argument, 0 provided after/) ){
-      done()
+  it('`skip` should throw if no argument has been passed', async function () {
+    try {
+      await r.db(dbName).table(tableName).skip().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message.match(/^`skip` takes 1 argument, 0 provided after/))
     }
-    else {
-      done(e);
+  })
+
+  it('`limit` should work', async function () {
+    const result = await r.expr([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]).limit(3).run()
+    assert.deepEqual(result, [0, 1, 2])
+  })
+
+  it('`limit` should throw if no argument has been passed', async function () {
+    try {
+      await r.db(dbName).table(tableName).limit().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message.match(/^`limit` takes 1 argument, 0 provided after/))
     }
-  }
-})
-It('`orderBy` should not wrap on r.asc', function* (done) {
-  try {
-    result = yield r.expr([{a:23}, {a:10}, {a:0}, {a:100}]).orderBy(r.asc(r.row("a"))).run();
-    assert.deepEqual(result, [{a:0}, {a:10}, {a:23}, {a:100}]);
+  })
 
-    done();
-  }
-  catch(e) {
-    console.log(e);
-    done(e);
-  }
-})
+  it('`slice` should work', async function () {
+    const result = await r.expr([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]).slice(3, 5).run()
+    assert.deepEqual(result, [3, 4])
+  })
 
-It('`orderBy` should not wrap on r.desc', function* (done) {
-  try {
-    result = yield r.expr([{a:23}, {a:10}, {a:0}, {a:100}]).orderBy(r.desc(r.row("a"))).run();
-    assert.deepEqual(result, [{a:100}, {a:23}, {a:10}, {a:0} ]);
-    done();
-  }
-  catch(e) {
-    console.log(e);
-    done(e);
-  }
-})
-It('r.desc should work', function* (done) {
-  try {
-    result = yield r.expr([{a:23}, {a:10}, {a:0}, {a:100}]).orderBy(r.desc("a")).run();
-    assert.deepEqual(result, [{a:100}, {a:23}, {a:10}, {a:0} ]);
-    done();
-  }
-  catch(e) {
-    console.log(e);
-    done(e);
-  }
-})
-It('r.asc should work', function* (done) {
-  try {
-    result = yield r.expr([{a:23}, {a:10}, {a:0}, {a:100}]).orderBy(r.asc("a")).run();
-    assert.deepEqual(result, [{a:0}, {a:10}, {a:23}, {a:100}]);
-    done();
-  }
-  catch(e) {
-    console.log(e);
-    done(e);
-  }
-})
+  it('`slice` should handle options and optional end', async function () {
+    let result = await r.expr([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]).slice(3).run()
+    assert.deepEqual(result, [3, 4, 5, 6, 7, 8, 9])
 
+    result = await r.expr([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]).slice(3, {leftBound: 'open'}).run()
+    assert.deepEqual(result, [4, 5, 6, 7, 8, 9])
 
+    result = await r.expr([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]).slice(3, 5, {leftBound: 'open'}).run()
+    assert.deepEqual(result, [4])
+  })
 
-It('`desc` is not defined after a term', function* (done) {
-  try {
-    result = yield r.expr(1).desc("foo").run();
-  }
-  catch(e) {
-    if (e.message === "`desc` is not defined after:\nr.expr(1)") {
-      done()
+  it('`slice` should work -- with options', async function () {
+    let result = await r.expr([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]).slice(5, 10, {rightBound: 'closed'}).run()
+    assert.deepEqual(result, [5, 6, 7, 8, 9, 10])
+
+    result = await r.expr([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]).slice(5, 10, {rightBound: 'open'}).run()
+    assert.deepEqual(result, [5, 6, 7, 8, 9])
+
+    result = await r.expr([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]).slice(5, 10, {leftBound: 'open'}).run()
+    assert.deepEqual(result, [6, 7, 8, 9])
+
+    result = await r.expr([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]).slice(5, 10, {leftBound: 'closed'}).run()
+    assert.deepEqual(result, [5, 6, 7, 8, 9])
+
+    result = await r.expr([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]).slice(5, 10, {leftBound: 'closed', rightBound: 'closed'}).run()
+    assert.deepEqual(result, [5, 6, 7, 8, 9, 10])
+  })
+
+  it('`slice` should throw if no argument has been passed', async function () {
+    try {
+      await r.db(dbName).table(tableName).slice().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message.match(/^`slice` takes at least 1 argument, 0 provided after/))
     }
-    else {
-      done(e)
+  })
+
+  it('`nth` should work', async function () {
+    const result = await r.expr([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]).nth(3).run()
+    assert(result, 3)
+  })
+
+  it('`nth` should throw if no argument has been passed', async function () {
+    try {
+      await r.db(dbName).table(tableName).nth().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message.match(/^`nth` takes 1 argument, 0 provided after/))
     }
-  }
-})
-It('`asc` is not defined after a term', function* (done) {
-  try {
-    result = yield r.expr(1).asc("foo").run();
-  }
-  catch(e) {
-    if (e.message === "`asc` is not defined after:\nr.expr(1)") {
-      done()
+  })
+
+  it('`indexesOf` should work - datum', async function () {
+    const result = await r.expr([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]).nth(3).run()
+    assert(result, 3)
+  })
+
+  it('`indexesOf` should work - r.row', async function () {
+    const result = await r.expr([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]).indexesOf(r.row.eq(3)).run()
+    assert.equal(result, 3)
+  })
+
+  it('`indexesOf` should work - function', async function () {
+    const result = await r.expr([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]).indexesOf(function (doc) { return doc.eq(3) }).run()
+    assert.equal(result, 3)
+  })
+
+  it('`indexesOf` should throw if no argument has been passed', async function () {
+    try {
+      await r.db(dbName).table(tableName).indexesOf().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message.match(/^`indexesOf` takes 1 argument, 0 provided after/))
     }
-    else {
-      done(e)
+  })
+
+  it('`isEmpty` should work', async function () {
+    let result = await r.expr([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]).isEmpty().run()
+    assert.equal(result, false)
+
+    result = await r.expr([]).isEmpty().run()
+    assert.equal(result, true)
+  })
+
+  it('`union` should work - 1', async function () {
+    const result = await r.expr([0, 1, 2]).union([3, 4, 5]).run()
+    assert.deepEqual(result.length, 6)
+    for (var i = 0; i < 6; i++) {
+      assert(result.indexOf(i) >= 0)
     }
-  }
-})
+  })
 
-It('`skip` should work', function* (done) {
-  try {
-    result = yield r.expr([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]).skip(3).run();
-    assert.deepEqual(result, [3, 4, 5, 6, 7, 8, 9]);
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`skip` should throw if no argument has been passed', function* (done) {
-  try {
-    result = yield r.db(dbName).table(tableName).skip().run();
-  }
-  catch(e) {
-    if (e.message.match(/^`skip` takes 1 argument, 0 provided after/) ){
-      done()
+  it('`union` should work - 2', async function () {
+    const result = await r.union([0, 1, 2], [3, 4, 5], [6, 7]).run()
+    assert.deepEqual(result.length, 8)
+    for (var i = 0; i < 8; i++) {
+      assert(result.indexOf(i) >= 0)
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-It('`limit` should work', function* (done) {
-  try {
-    result = yield r.expr([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]).limit(3).run();
-    assert.deepEqual(result, [0, 1, 2]);
+  it('`union` should work - 3', async function () {
+    const result = await r.union().run()
+    assert.deepEqual(result, [])
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`limit` should throw if no argument has been passed', function* (done) {
-  try {
-    result = yield r.db(dbName).table(tableName).limit().run();
-  }
-  catch(e) {
-    if (e.message.match(/^`limit` takes 1 argument, 0 provided after/) ){
-      done()
-    }
-    else {
-      done(e);
-    }
-  }
-})
-It('`slice` should work', function* (done) {
-  try {
-    result = yield r.expr([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]).slice(3, 5).run();
-    assert.deepEqual(result, [3, 4]);
+  it('`union` should work with interleave - 1', async function () {
+    const result = await r.expr([0, 1, 2]).union([3, 4, 5], {interleave: false}).run()
+    assert.deepEqual(result, [0, 1, 2, 3, 4, 5])
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`slice` should handle options and optional end', function* (done) {
-  try {
-    var result = yield r.expr([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]).slice(3).run();
-    assert.deepEqual(result, [3, 4, 5, 6, 7, 8, 9]);
-
-    var result = yield r.expr([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]).slice(3, {leftBound: "open"}).run();
-    assert.deepEqual(result, [4, 5, 6, 7, 8, 9]);
-
-    var result = yield r.expr([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]).slice(3, 5, {leftBound: "open"}).run();
-    assert.deepEqual(result, [4]);
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-
-It('`slice` should work -- with options', function* (done) {
-  try {
-    result = yield r.expr([0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22, 23]).slice(5, 10, {rightBound:'closed'}).run();
-    assert.deepEqual(result, [5, 6, 7, 8, 9, 10]);
-
-    result = yield r.expr([0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22, 23]).slice(5, 10, {rightBound:'open'}).run();
-    assert.deepEqual(result, [5, 6, 7, 8, 9]);
-
-    result = yield r.expr([0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22, 23]).slice(5, 10, {leftBound:'open'}).run();
-    assert.deepEqual(result, [6, 7, 8, 9]);
-
-    result = yield r.expr([0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22, 23]).slice(5, 10, {leftBound:'closed'}).run();
-    assert.deepEqual(result, [5, 6, 7, 8, 9]);
-
-    result = yield r.expr([0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22, 23]).slice(5, 10, {leftBound:'closed', rightBound: 'closed'}).run();
-    assert.deepEqual(result, [5, 6, 7, 8, 9, 10]);
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`slice` should throw if no argument has been passed', function* (done) {
-  try {
-    result = yield r.db(dbName).table(tableName).slice().run();
-  }
-  catch(e) {
-    if (e.message.match(/^`slice` takes at least 1 argument, 0 provided after/) ){
-      done()
-    }
-    else {
-      done(e);
-    }
-  }
-})
-It('`nth` should work', function* (done) {
-  try {
-    result = yield r.expr([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]).nth(3).run();
-    assert(result, 3);
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`nth` should throw if no argument has been passed', function* (done) {
-  try {
-    result = yield r.db(dbName).table(tableName).nth().run();
-  }
-  catch(e) {
-    if (e.message.match(/^`nth` takes 1 argument, 0 provided after/) ){
-      done()
-    }
-    else {
-      done(e);
-    }
-  }
-})
-It('`indexesOf` should work - datum', function* (done) {
-  try {
-    result = yield r.expr([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]).nth(3).run();
-    assert(result, 3);
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-
-It('`indexesOf` should work - r.row', function* (done) {
-  try {
-    result = yield r.expr([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]).indexesOf(r.row.eq(3)).run();
-    assert.equal(result, 3);
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`indexesOf` should work - function', function* (done) {
-  try {
-    result = yield r.expr([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]).indexesOf(function(doc) { return doc.eq(3)}).run();
-    assert.equal(result, 3);
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`indexesOf` should throw if no argument has been passed', function* (done) {
-  try {
-    result = yield r.db(dbName).table(tableName).indexesOf().run();
-  }
-  catch(e) {
-    if (e.message.match(/^`indexesOf` takes 1 argument, 0 provided after/) ){
-      done()
-    }
-    else {
-      done(e);
-    }
-  }
-})
-It('`isEmpty` should work', function* (done) {
-  try {
-    result = yield r.expr([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]).isEmpty().run();
-    assert.equal(result, false);
-
-    result = yield r.expr([]).isEmpty().run();
-    assert.equal(result, true);
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-
-It('`union` should work - 1', function* (done) {
-  try{
-    result = yield r.expr([0, 1, 2]).union([3, 4, 5]).run();
-    assert.deepEqual(result.length, 6);
-    for(var i=0; i<6; i++) {
-      assert(result.indexOf(i) >= 0);
-    }
-    done()
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`union` should work - 2', function* (done) {
-  try{
-    result = yield r.union([0, 1, 2], [3, 4, 5], [6, 7]).run();
-    assert.deepEqual(result.length, 8);
-    for(var i=0; i<8; i++) {
-      assert(result.indexOf(i) >= 0);
-    }
-    done()
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`union` should work - 3', function* (done) {
-  try{
-    result = yield r.union().run();
-    assert.deepEqual(result, []);
-    done()
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`union` should work with interleave - 1', function* (done) {
-  try{
-    result = yield r.expr([0, 1, 2]).union([3, 4, 5], {interleave: false}).run();
-    assert.deepEqual(result, [0, 1, 2, 3, 4, 5]);
-
-    done()
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`union` should work with interleave - 1', function* (done) {
-  try{
-    result = yield r.expr([{name: 'Michel'}, {name: 'Sophie'}, {name: 'Laurent'}]).orderBy('name')
-      .union(r.expr([{name: 'Moo'}, {name: 'Bar'}]).orderBy('name'), {interleave: 'name'}).run();
+  it('`union` should work with interleave - 1', async function () {
+    const result = await r.expr([{name: 'Michel'}, {name: 'Sophie'}, {name: 'Laurent'}]).orderBy('name')
+      .union(r.expr([{name: 'Moo'}, {name: 'Bar'}]).orderBy('name'), {interleave: 'name'}).run()
     assert.deepEqual(result, [
-        {name: 'Bar'},
-        {name: 'Laurent'},
-        {name: 'Michel'},
-        {name: 'Moo'},
-        {name: 'Sophie'}
-    ]);
+      {name: 'Bar'},
+      {name: 'Laurent'},
+      {name: 'Michel'},
+      {name: 'Moo'},
+      {name: 'Sophie'}
+    ])
+  })
 
-    done()
-  }
-  catch(e) {
-    done(e);
-  }
-})
+  it('`sample` should work', async function () {
+    const result = await r.expr([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]).sample(2).run()
+    assert.equal(result.length, 2)
+  })
 
-It('`sample` should work', function* (done) {
-  try{
-    result = yield r.expr([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]).sample(2).run();
-    assert.equal(result.length, 2);
+  it('`sample` should throw if given -1', async function () {
+    try {
+      await r.expr([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]).sample(-1).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message.match('Number of items to sample must be non-negative, got `-1`'))
+    }
+  })
 
-    done()
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`sample` should throw if given -1', function* (done) {
-  try{
-    result = yield r.expr([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]).sample(-1).run();
-  }
-  catch(e) {
-    if (e.message.match("Number of items to sample must be non-negative, got `-1`")) {
-      done()
+  it('`sample` should throw if no argument has been passed', async function () {
+    try {
+      await r.db(dbName).table(tableName).sample().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert(e.message.match(/^`sample` takes 1 argument, 0 provided after/))
     }
-    else {
-      done(e);
-    }
-  }
-})
-It('`sample` should throw if no argument has been passed', function* (done) {
-  try {
-    result = yield r.db(dbName).table(tableName).sample().run();
-  }
-  catch(e) {
-    if (e.message.match(/^`sample` takes 1 argument, 0 provided after/) ){
-      done()
-    }
-    else {
-      done(e);
-    }
-  }
+  })
 })

--- a/test/util/common.js
+++ b/test/util/common.js
@@ -1,26 +1,27 @@
-var Promise = require('bluebird');
-Promise.coroutine.addYieldHandler(function(yieldedValue) {
-  if (Array.isArray(yieldedValue)) return Promise.all(yieldedValue);
-});
+const Promise = require('bluebird')
+const {it} = require('mocha')
 
+Promise.coroutine.addYieldHandler(function (yieldedValue) {
+  if (Array.isArray(yieldedValue)) return Promise.all(yieldedValue)
+})
 
-function s4() {
-  return Math.floor((1+Math.random())*0x10000).toString(16).substring(1);
-};
-
-function uuid() {
-  return s4()+s4()+s4()+s4()+s4()+s4()+s4()+s4();
+function s4 () {
+  return Math.floor((1 + Math.random()) * 0x10000).toString(16).substring(1)
 }
 
-function It(testName, generatorFn) {
-  it(testName, function(done) {
-    Promise.coroutine(generatorFn)(done);
+function uuid () {
+  return s4() + s4() + s4() + s4() + s4() + s4() + s4() + s4()
+}
+
+function It (testName, generatorFn) {
+  it(testName, function (done) {
+    Promise.coroutine(generatorFn)(done)
   })
 }
-function sleep(timer) {
-  return new Promise(function(resolve, reject) {
-    setTimeout(resolve, timer);
-  });
+function sleep (timer) {
+  return new Promise(function (resolve, reject) {
+    setTimeout(resolve, timer)
+  })
 }
 
 module.exports.uuid = uuid

--- a/test/writing-data.js
+++ b/test/writing-data.js
@@ -1,623 +1,409 @@
-var config = require(__dirname+'/config.js');
-var r = require(__dirname+'/../lib')(config);
-var util = require(__dirname+'/util/common.js');
-var assert = require('assert');
+const path = require('path')
+const config = require('./config.js')
+const rethinkdbdash = require(path.join(__dirname, '/../lib'))
+const assert = require('assert')
+const {uuid} = require(path.join(__dirname, '/util/common.js'))
+const {before, after, describe, it} = require('mocha')
 
-var uuid = util.uuid;
-var It = util.It;
+describe('writing data', () => {
+  let r, dbName, tableName
 
-var uuid = util.uuid;
-var dbName, tableName, result;
+  before(async () => {
+    r = await rethinkdbdash(config)
+    dbName = uuid()
+    tableName = uuid()
 
+    let result = await r.dbCreate(dbName).run()
+    assert.equal(result.dbs_created, 1)
 
-It('Init for `writing-data.js`', function* (done) {
-  try {
-    dbName = uuid();
-    tableName = uuid();
+    result = await r.db(dbName).tableCreate(tableName).run()
+    assert.equal(result.tables_created, 1)
+  })
 
-    result = yield r.dbCreate(dbName).run();
-    assert.equal(result.dbs_created, 1);
+  after(async () => {
+    await r.getPool().drain()
+  })
 
-    result = yield r.db(dbName).tableCreate(tableName).run();
-    assert.equal(result.tables_created, 1);
+  it('`insert` should work - single insert`', async function () {
+    let result = await r.db(dbName).table(tableName).insert({}).run()
+    assert.equal(result.inserted, 1)
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`insert` should work - single insert`', function* (done) {
-  try {
-    var result = yield r.db(dbName).table(tableName).insert({}).run();
-    assert.equal(result.inserted, 1);
+    result = await r.db(dbName).table(tableName).insert(Array(100).fill({})).run()
+    assert.equal(result.inserted, 100)
+  })
 
-    result = yield r.db(dbName).table(tableName).insert(eval('['+new Array(100).join('{}, ')+'{}]')).run();
-    assert.equal(result.inserted, 100);
+  it('`insert` should work - batch insert 1`', async function () {
+    const result = await r.db(dbName).table(tableName).insert([{}, {}]).run()
+    assert.equal(result.inserted, 2)
+  })
 
+  it('`insert` should work - batch insert 2`', async function () {
+    const result = await r.db(dbName).table(tableName).insert(Array(100).fill({})).run()
+    assert.equal(result.inserted, 100)
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+  it('`insert` should work - with returnChanges true`', async function () {
+    const result = await r.db(dbName).table(tableName).insert({}, {returnChanges: true}).run()
+    assert.equal(result.inserted, 1)
+    assert(result.changes[0].new_val)
+    assert.equal(result.changes[0].old_val, null)
+  })
 
+  it('`insert` should work - with returnChanges false`', async function () {
+    const result = await r.db(dbName).table(tableName).insert({}, {returnChanges: false}).run()
+    assert.equal(result.inserted, 1)
+    assert.equal(result.changes, undefined)
+  })
 
-It('`insert` should work - batch insert 1`', function* (done) {
-  try {
-    var result = yield r.db(dbName).table(tableName).insert([{}, {}]).run();
-    assert.equal(result.inserted, 2);
+  it('`insert` should work - with durability soft`', async function () {
+    const result = await r.db(dbName).table(tableName).insert({}, {durability: 'soft'}).run()
+    assert.equal(result.inserted, 1)
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+  it('`insert` should work - with durability hard`', async function () {
+    const result = await r.db(dbName).table(tableName).insert({}, {durability: 'hard'}).run()
+    assert.equal(result.inserted, 1)
+  })
 
-It('`insert` should work - batch insert 2`', function* (done) {
-  try {
-    var result = yield r.db(dbName).table(tableName).insert(eval('['+new Array(100).join('{}, ')+'{}]')).run();
-    assert.equal(result.inserted, 100);
+  it('`insert` should work - testing conflict`', async function () {
+    let result = await r.db(dbName).table(tableName).insert({}, {conflict: 'update'}).run()
+    assert.equal(result.inserted, 1)
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+    const pk = result.generated_keys[0]
 
-It('`insert` should work - with returnChanges true`', function* (done) {
-  try {
-    var result = yield r.db(dbName).table(tableName).insert({}, {returnChanges: true}).run();
-    assert.equal(result.inserted, 1);
-    assert(result.changes[0].new_val);
-    assert.equal(result.changes[0].old_val, null);
+    result = await r.db(dbName).table(tableName).insert({id: pk, val: 1}, {conflict: 'update'}).run()
+    assert.equal(result.replaced, 1)
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+    result = await r.db(dbName).table(tableName).insert({id: pk, val: 2}, {conflict: 'replace'}).run()
+    assert.equal(result.replaced, 1)
 
+    result = await r.db(dbName).table(tableName).insert({id: pk, val: 3}, {conflict: 'error'}).run()
+    assert.equal(result.errors, 1)
+  })
 
-It('`insert` should work - with returnChanges false`', function* (done) {
-  try {
-    var result = yield r.db(dbName).table(tableName).insert({}, {returnChanges: false}).run();
-    assert.equal(result.inserted, 1);
-    assert.equal(result.changes, undefined);
-    assert.equal(result.changes, undefined);
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`insert` should work - with durability soft`', function* (done) {
-  try {
-    var result = yield r.db(dbName).table(tableName).insert({}, {durability: 'soft'}).run();
-    assert.equal(result.inserted, 1);
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`insert` should work - with durability hard`', function* (done) {
-  try {
-    result = yield r.db(dbName).table(tableName).insert({}, {durability: 'hard'}).run();
-    assert.equal(result.inserted, 1);
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`insert` should work - testing conflict`', function* (done) {
-  try {
-    result = yield r.db(dbName).table(tableName).insert({}, {conflict: 'update'}).run();
-    assert.equal(result.inserted, 1);
-
-    var pk = result.generated_keys[0];
-
-    result = yield r.db(dbName).table(tableName).insert({id: pk, val:1}, {conflict: 'update'}).run();
-    assert.equal(result.replaced, 1);
-
-    result = yield r.db(dbName).table(tableName).insert({id: pk, val:2}, {conflict: 'replace'}).run();
-    assert.equal(result.replaced, 1);
-
-    result = yield r.db(dbName).table(tableName).insert({id: pk, val:3}, {conflict: 'error'}).run();
-    assert.equal(result.errors, 1);
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`insert` should throw if no argument is given', function* (done) {
-  try{
-    var result = yield r.db(dbName).table(tableName).insert().run();
-  }
-  catch(e) {
-    if (e.message === "`insert` takes at least 1 argument, 0 provided after:\nr.db(\""+dbName+"\").table(\""+tableName+"\")") {
-      done()
+  it('`insert` should throw if no argument is given', async function () {
+    try {
+      await r.db(dbName).table(tableName).insert().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`insert` takes at least 1 argument, 0 provided after:\nr.db("' + dbName + '").table("' + tableName + '")')
     }
-    else {
-      done(e);
-    }
-  }
-})
-It('`insert` work with dates - 1', function* (done) {
-  try {
-    var result = yield r.db(dbName).table(tableName).insert({name: "Michel", age: 27, birthdate: new Date()}).run()
-    assert.deepEqual(result.inserted, 1);
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`insert` work with dates - 2', function* (done) {
-  try {
-    var result = yield r.db(dbName).table(tableName).insert([{name: "Michel", age: 27, birthdate: new Date()}, {name: "Sophie", age: 23}]).run()
-    assert.deepEqual(result.inserted, 2);
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`insert` work with dates - 3', function* (done) {
-  try {
-    var result = yield r.db(dbName).table(tableName).insert({
+  })
+
+  it('`insert` work with dates - 1', async function () {
+    const result = await r.db(dbName).table(tableName).insert({name: 'Michel', age: 27, birthdate: new Date()}).run()
+    assert.deepEqual(result.inserted, 1)
+  })
+
+  it('`insert` work with dates - 2', async function () {
+    const result = await r.db(dbName).table(tableName).insert([{
+      name: 'Michel',
+      age: 27,
+      birthdate: new Date()
+    }, {name: 'Sophie', age: 23}]).run()
+    assert.deepEqual(result.inserted, 2)
+  })
+
+  it('`insert` work with dates - 3', async function () {
+    const result = await r.db(dbName).table(tableName).insert({
       field: 'test',
-      field2: { nested: 'test' },
+      field2: {nested: 'test'},
       date: new Date()
     }).run()
-    assert.deepEqual(result.inserted, 1);
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`insert` work with dates - 4', function* (done) {
-  try {
-    var result = yield r.db(dbName).table(tableName).insert({
+    assert.deepEqual(result.inserted, 1)
+  })
+
+  it('`insert` work with dates - 4', async function () {
+    const result = await r.db(dbName).table(tableName).insert({
       field: 'test',
-      field2: { nested: 'test' },
+      field2: {nested: 'test'},
       date: r.now()
     }).run()
-    assert.deepEqual(result.inserted, 1);
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+    assert.deepEqual(result.inserted, 1)
+  })
 
-It('`insert` should throw if non valid option', function* (done) {
-  try{
-    var result = yield r.db(dbName).table(tableName).insert({}, {nonValidKey: true}).run();
-  }
-  catch(e) {
-    if (e.message === 'Unrecognized option `nonValidKey` in `insert` after:\nr.db("'+dbName+'").table("'+tableName+'")\nAvailable options are returnChanges <bool>, durability <string>, conflict <string>') {
-      done()
+  it('`insert` should throw if non valid option', async function () {
+    try {
+      await r.db(dbName).table(tableName).insert({}, {nonValidKey: true}).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, 'Unrecognized option `nonValidKey` in `insert` after:\nr.db("' + dbName + '").table("' + tableName + '")\nAvailable options are returnChanges <bool>, durability <string>, conflict <string>')
     }
-    else {
-      done(e);
-    }
-  }
-})
+  })
 
-It('`insert` with a conflict method', function* (done) {
-  try{
-    var result = yield r.db(dbName).table(tableName).insert({
+  it('`insert` with a conflict method', async function () {
+    let result = await r.db(dbName).table(tableName).insert({
       count: 7
-    }).run();
-    var savedId = result.generated_keys[0];
-    var result = yield r.db(dbName).table(tableName).insert({
+    }).run()
+    const savedId = result.generated_keys[0]
+    result = await r.db(dbName).table(tableName).insert({
       id: savedId,
       count: 10
     }, {
-      conflict: function(id, oldDoc, newDoc) {
+      conflict: function (id, oldDoc, newDoc) {
         return newDoc.merge({
           count: newDoc('count').add(oldDoc('count'))
         })
       }
-    }).run();
-    result = yield r.db(dbName).table(tableName).get(savedId)
+    }).run()
+    assert.equal(result.replaced, 1)
+    result = await r.db(dbName).table(tableName).get(savedId).run()
     assert.deepEqual(result, {
       id: savedId,
       count: 17
     })
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+  })
 
-It('`replace` should throw if no argument is given', function* (done) {
-  try{
-    var result = yield r.db(dbName).table(tableName).replace().run();
-  }
-  catch(e) {
-    if (e.message === "`replace` takes at least 1 argument, 0 provided after:\nr.db(\""+dbName+"\").table(\""+tableName+"\")") {
-      done()
+  it('`replace` should throw if no argument is given', async function () {
+    try {
+      await r.db(dbName).table(tableName).replace().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`replace` takes at least 1 argument, 0 provided after:\nr.db("' + dbName + '").table("' + tableName + '")')
     }
-    else {
-      done(e);
+  })
+
+  it('`replace` should throw if non valid option', async function () {
+    try {
+      await r.db(dbName).table(tableName).replace({}, {nonValidKey: true}).run()
+    } catch (e) {
+      assert.equal(e.message, 'Unrecognized option `nonValidKey` in `replace` after:\nr.db("' + dbName + '").table("' + tableName + '")\nAvailable options are returnChanges <bool>, durability <string>, nonAtomic <bool>')
     }
-  }
-})
-It('`replace` should throw if non valid option', function* (done) {
-  try{
-    var result = yield r.db(dbName).table(tableName).replace({}, {nonValidKey: true}).run();
-  }
-  catch(e) {
-    if (e.message === 'Unrecognized option `nonValidKey` in `replace` after:\nr.db("'+dbName+'").table("'+tableName+'")\nAvailable options are returnChanges <bool>, durability <string>, nonAtomic <bool>') {
-      done()
+  })
+
+  it('`delete` should work`', async function () {
+    let result = await r.db(dbName).table(tableName).delete().run()
+    assert(result.deleted > 0)
+
+    result = await r.db(dbName).table(tableName).delete().run()
+    assert.equal(result.deleted, 0)
+  })
+
+  it('`delete` should work -- soft durability`', async function () {
+    let result = await r.db(dbName).table(tableName).delete().run()
+    assert(result)
+    result = await r.db(dbName).table(tableName).insert({}).run()
+    assert(result)
+
+    result = await r.db(dbName).table(tableName).delete({durability: 'soft'}).run()
+    assert.equal(result.deleted, 1)
+
+    result = await r.db(dbName).table(tableName).insert({}).run()
+    assert(result)
+
+    result = await r.db(dbName).table(tableName).delete().run()
+    assert.equal(result.deleted, 1)
+  })
+
+  it('`delete` should work -- hard durability`', async function () {
+    let result = await r.db(dbName).table(tableName).delete().run()
+    assert(result)
+    result = await r.db(dbName).table(tableName).insert({}).run()
+    assert(result)
+
+    result = await r.db(dbName).table(tableName).delete({durability: 'hard'}).run()
+    assert.equal(result.deleted, 1)
+
+    result = await r.db(dbName).table(tableName).insert({}).run()
+    assert(result)
+
+    result = await r.db(dbName).table(tableName).delete().run()
+    assert.equal(result.deleted, 1)
+  })
+
+  it('`delete` should throw if non valid option', async function () {
+    try {
+      await r.db(dbName).table(tableName).delete({nonValidKey: true}).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, 'Unrecognized option `nonValidKey` in `delete` after:\nr.db("' + dbName + '").table("' + tableName + '")\nAvailable options are returnChanges <bool>, durability <string>')
     }
-    else {
-      done(e);
+  })
+
+  it('`update` should work - point update`', async function () {
+    let result = await r.db(dbName).table(tableName).delete().run()
+    assert(result)
+    result = await r.db(dbName).table(tableName).insert({id: 1}).run()
+    assert(result)
+
+    result = await r.db(dbName).table(tableName).get(1).update({foo: 'bar'}).run()
+    assert.equal(result.replaced, 1)
+
+    result = await r.db(dbName).table(tableName).get(1).run()
+    assert.deepEqual(result, {id: 1, foo: 'bar'})
+  })
+
+  it('`update` should work - range update`', async function () {
+    let result = await r.db(dbName).table(tableName).delete().run()
+    assert(result)
+    result = await r.db(dbName).table(tableName).insert([{id: 1}, {id: 2}]).run()
+    assert(result)
+
+    result = await r.db(dbName).table(tableName).update({foo: 'bar'}).run()
+    assert.equal(result.replaced, 2)
+
+    result = await r.db(dbName).table(tableName).get(1).run()
+    assert.deepEqual(result, {id: 1, foo: 'bar'})
+    result = await r.db(dbName).table(tableName).get(2).run()
+    assert.deepEqual(result, {id: 2, foo: 'bar'})
+  })
+
+  it('`update` should work - soft durability`', async function () {
+    let result = await r.db(dbName).table(tableName).delete().run()
+    assert(result)
+    result = await r.db(dbName).table(tableName).insert({id: 1}).run()
+    assert(result)
+
+    result = await r.db(dbName).table(tableName).get(1).update({foo: 'bar'}, {durability: 'soft'}).run()
+    assert.equal(result.replaced, 1)
+
+    result = await r.db(dbName).table(tableName).get(1).run()
+    assert.deepEqual(result, {id: 1, foo: 'bar'})
+  })
+
+  it('`update` should work - hard durability`', async function () {
+    let result = await r.db(dbName).table(tableName).delete().run()
+    assert(result)
+    result = await r.db(dbName).table(tableName).insert({id: 1}).run()
+    assert(result)
+
+    result = await r.db(dbName).table(tableName).get(1).update({foo: 'bar'}, {durability: 'hard'}).run()
+    assert.equal(result.replaced, 1)
+
+    result = await r.db(dbName).table(tableName).get(1).run()
+    assert.deepEqual(result, {id: 1, foo: 'bar'})
+  })
+
+  it('`update` should work - returnChanges true', async function () {
+    let result = await r.db(dbName).table(tableName).delete().run()
+    assert(result)
+    result = await r.db(dbName).table(tableName).insert({id: 1}).run()
+    assert(result)
+
+    result = await r.db(dbName).table(tableName).get(1).update({foo: 'bar'}, {returnChanges: true}).run()
+    assert.equal(result.replaced, 1)
+    assert.deepEqual(result.changes[0].new_val, {id: 1, foo: 'bar'})
+    assert.deepEqual(result.changes[0].old_val, {id: 1})
+
+    result = await r.db(dbName).table(tableName).get(1).run()
+    assert.deepEqual(result, {id: 1, foo: 'bar'})
+  })
+
+  it('`update` should work - returnChanges false`', async function () {
+    let result = await r.db(dbName).table(tableName).delete().run()
+    assert(result)
+    result = await r.db(dbName).table(tableName).insert({id: 1}).run()
+    assert(result)
+
+    result = await r.db(dbName).table(tableName).get(1).update({foo: 'bar'}, {returnChanges: false}).run()
+    assert.equal(result.replaced, 1)
+    assert.equal(result.changes, undefined)
+    assert.equal(result.changes, undefined)
+
+    result = await r.db(dbName).table(tableName).get(1).run()
+    assert.deepEqual(result, {id: 1, foo: 'bar'})
+  })
+
+  it('`update` should throw if no argument is given', async function () {
+    try {
+      await r.db(dbName).table(tableName).update().run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, '`update` takes at least 1 argument, 0 provided after:\nr.db("' + dbName + '").table("' + tableName + '")')
     }
-  }
-})
+  })
 
-It('`delete` should work`', function* (done) {
-  try {
-    result = yield r.db(dbName).table(tableName).delete().run();
-    assert(result.deleted > 0);
-
-    result = yield r.db(dbName).table(tableName).delete().run();
-    assert.equal(result.deleted, 0);
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-
-It('`delete` should work -- soft durability`', function* (done) {
-  try {
-    result = yield r.db(dbName).table(tableName).delete().run();
-    assert(result);
-    result = yield r.db(dbName).table(tableName).insert({}).run();
-    assert(result);
-
-    result = yield r.db(dbName).table(tableName).delete({durability: "soft"}).run();
-    assert.equal(result.deleted, 1);
-
-
-    result = yield r.db(dbName).table(tableName).insert({}).run();
-    assert(result);
-
-    result = yield r.db(dbName).table(tableName).delete().run();
-    assert.equal(result.deleted, 1);
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-
-
-
-It('`delete` should work -- hard durability`', function* (done) {
-  try {
-    result = yield r.db(dbName).table(tableName).delete().run();
-    assert(result);
-    result = yield r.db(dbName).table(tableName).insert({}).run();
-    assert(result);
-
-    result = yield r.db(dbName).table(tableName).delete({durability: "hard"}).run();
-    assert.equal(result.deleted, 1);
-
-    
-    result = yield r.db(dbName).table(tableName).insert({}).run();
-    assert(result);
-
-    result = yield r.db(dbName).table(tableName).delete().run();
-    assert.equal(result.deleted, 1);
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`delete` should throw if non valid option', function* (done) {
-  try{
-    var result = yield r.db(dbName).table(tableName).delete({nonValidKey: true}).run();
-  }
-  catch(e) {
-    if (e.message === 'Unrecognized option `nonValidKey` in `delete` after:\nr.db("'+dbName+'").table("'+tableName+'")\nAvailable options are returnChanges <bool>, durability <string>') {
-      done()
+  it('`update` should throw if non valid option', async function () {
+    try {
+      await r.db(dbName).table(tableName).update({}, {nonValidKey: true}).run()
+      assert.fail('should throw')
+    } catch (e) {
+      assert.equal(e.message, 'Unrecognized option `nonValidKey` in `update` after:\nr.db("' + dbName + '").table("' + tableName + '")\nAvailable options are returnChanges <bool>, durability <string>, nonAtomic <bool>')
     }
-    else {
-      done(e);
-    }
-  }
-})
-It('`update` should work - point update`', function* (done) {
-  try {
-    result = yield r.db(dbName).table(tableName).delete().run();
-    assert(result);
-    result = yield r.db(dbName).table(tableName).insert({id: 1}).run();
-    assert(result);
+  })
 
-    result = yield r.db(dbName).table(tableName).get(1).update({foo: "bar"}).run();
-    assert.equal(result.replaced, 1);
+  it('`replace` should work - point replace`', async function () {
+    let result = await r.db(dbName).table(tableName).delete().run()
+    assert(result)
+    result = await r.db(dbName).table(tableName).insert({id: 1}).run()
+    assert(result)
 
-    result = yield r.db(dbName).table(tableName).get(1).run();
-    assert.deepEqual(result, {id: 1, foo: "bar"});
+    result = await r.db(dbName).table(tableName).get(1).replace({id: 1, foo: 'bar'}).run()
+    assert.equal(result.replaced, 1)
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+    result = await r.db(dbName).table(tableName).get(1).run()
+    assert.deepEqual(result, {id: 1, foo: 'bar'})
+  })
 
-It('`update` should work - range update`', function* (done) {
-  try {
-    result = yield r.db(dbName).table(tableName).delete().run();
-    assert(result);
-    result = yield r.db(dbName).table(tableName).insert([{id: 1}, {id: 2}]).run();
-    assert(result);
+  it('`replace` should work - range replace`', async function () {
+    let result = await r.db(dbName).table(tableName).delete().run()
+    assert(result)
+    result = await r.db(dbName).table(tableName).insert([{id: 1}, {id: 2}]).run()
+    assert(result)
 
-    result = yield r.db(dbName).table(tableName).update({foo: "bar"}).run();
-    assert.equal(result.replaced, 2);
+    result = await r.db(dbName).table(tableName).replace(r.row.merge({foo: 'bar'})).run()
+    assert.equal(result.replaced, 2)
 
-    result = yield r.db(dbName).table(tableName).get(1).run();
-    assert.deepEqual(result, {id: 1, foo: "bar"});
-    result = yield r.db(dbName).table(tableName).get(2).run();
-    assert.deepEqual(result, {id: 2, foo: "bar"});
+    result = await r.db(dbName).table(tableName).get(1).run()
+    assert.deepEqual(result, {id: 1, foo: 'bar'})
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
+    result = await r.db(dbName).table(tableName).get(2).run()
+    assert.deepEqual(result, {id: 2, foo: 'bar'})
+  })
 
-It('`update` should work - soft durability`', function* (done) {
-  try {
-    result = yield r.db(dbName).table(tableName).delete().run();
-    assert(result);
-    result = yield r.db(dbName).table(tableName).insert({id: 1}).run();
-    assert(result);
+  it('`replace` should work - soft durability`', async function () {
+    let result = await r.db(dbName).table(tableName).delete().run()
+    assert(result)
+    result = await r.db(dbName).table(tableName).insert({id: 1}).run()
+    assert(result)
 
-    result = yield r.db(dbName).table(tableName).get(1).update({foo: "bar"}, {durability: "soft"}).run();
-    assert.equal(result.replaced, 1);
+    result = await r.db(dbName).table(tableName).get(1).replace({id: 1, foo: 'bar'}, {durability: 'soft'}).run()
+    assert.equal(result.replaced, 1)
 
-    result = yield r.db(dbName).table(tableName).get(1).run();
-    assert.deepEqual(result, {id: 1, foo: "bar"});
+    result = await r.db(dbName).table(tableName).get(1).run()
+    assert.deepEqual(result, {id: 1, foo: 'bar'})
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`update` should work - hard durability`', function* (done) {
-  try {
-    result = yield r.db(dbName).table(tableName).delete().run();
-    assert(result);
-    result = yield r.db(dbName).table(tableName).insert({id: 1}).run();
-    assert(result);
+  it('`replace` should work - hard durability`', async function () {
+    let result = await r.db(dbName).table(tableName).delete().run()
+    assert(result)
+    result = await r.db(dbName).table(tableName).insert({id: 1}).run()
+    assert(result)
 
-    result = yield r.db(dbName).table(tableName).get(1).update({foo: "bar"}, {durability: "hard"}).run();
-    assert.equal(result.replaced, 1);
+    result = await r.db(dbName).table(tableName).get(1).replace({id: 1, foo: 'bar'}, {durability: 'hard'}).run()
+    assert.equal(result.replaced, 1)
 
-    result = yield r.db(dbName).table(tableName).get(1).run();
-    assert.deepEqual(result, {id: 1, foo: "bar"});
+    result = await r.db(dbName).table(tableName).get(1).run()
+    assert.deepEqual(result, {id: 1, foo: 'bar'})
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`update` should work - returnChanges true', function* (done) {
-  try {
-    result = yield r.db(dbName).table(tableName).delete().run();
-    assert(result);
-    result = yield r.db(dbName).table(tableName).insert({id: 1}).run();
-    assert(result);
+  it('`replace` should work - returnChanges true', async function () {
+    let result = await r.db(dbName).table(tableName).delete().run()
+    assert(result)
+    result = await r.db(dbName).table(tableName).insert({id: 1}).run()
+    assert(result)
 
-    result = yield r.db(dbName).table(tableName).get(1).update({foo: "bar"}, {returnChanges: true}).run();
-    assert.equal(result.replaced, 1);
-    assert.deepEqual(result.changes[0].new_val, {id: 1, foo: "bar"});
-    assert.deepEqual(result.changes[0].old_val, {id: 1});
+    result = await r.db(dbName).table(tableName).get(1).replace({id: 1, foo: 'bar'}, {returnChanges: true}).run()
+    assert.equal(result.replaced, 1)
+    assert.deepEqual(result.changes[0].new_val, {id: 1, foo: 'bar'})
+    assert.deepEqual(result.changes[0].old_val, {id: 1})
 
-    result = yield r.db(dbName).table(tableName).get(1).run();
-    assert.deepEqual(result, {id: 1, foo: "bar"});
+    result = await r.db(dbName).table(tableName).get(1).run()
+    assert.deepEqual(result, {id: 1, foo: 'bar'})
+  })
 
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`update` should work - returnChanges false`', function* (done) {
-  try {
-    result = yield r.db(dbName).table(tableName).delete().run();
-    assert(result);
-    result = yield r.db(dbName).table(tableName).insert({id: 1}).run();
-    assert(result);
+  it('`replace` should work - returnChanges false`', async function () {
+    let result = await r.db(dbName).table(tableName).delete().run()
+    assert(result)
+    result = await r.db(dbName).table(tableName).insert({id: 1}).run()
+    assert(result)
 
-    result = yield r.db(dbName).table(tableName).get(1).update({foo: "bar"}, {returnChanges: false}).run();
-    assert.equal(result.replaced, 1);
-    assert.equal(result.changes, undefined);
-    assert.equal(result.changes, undefined);
+    result = await r.db(dbName).table(tableName).get(1).replace({id: 1, foo: 'bar'}, {returnChanges: false}).run()
+    assert.equal(result.replaced, 1)
+    assert.equal(result.changes, undefined)
+    assert.equal(result.changes, undefined)
 
-    result = yield r.db(dbName).table(tableName).get(1).run();
-    assert.deepEqual(result, {id: 1, foo: "bar"});
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`update` should throw if no argument is given', function* (done) {
-  try{
-    var result = yield r.db(dbName).table(tableName).update().run();
-  }
-  catch(e) {
-    if (e.message === "`update` takes at least 1 argument, 0 provided after:\nr.db(\""+dbName+"\").table(\""+tableName+"\")") {
-      done()
-    }
-    else {
-      done(e);
-    }
-  }
-})
-It('`update` should throw if non valid option', function* (done) {
-  try{
-    var result = yield r.db(dbName).table(tableName).update({}, {nonValidKey: true}).run();
-  }
-  catch(e) {
-    if (e.message === 'Unrecognized option `nonValidKey` in `update` after:\nr.db("'+dbName+'").table("'+tableName+'")\nAvailable options are returnChanges <bool>, durability <string>, nonAtomic <bool>') {
-      done()
-    }
-    else {
-      done(e);
-    }
-  }
-})
-
-It('`replace` should work - point replace`', function* (done) {
-  try {
-    result = yield r.db(dbName).table(tableName).delete().run();
-    assert(result);
-    result = yield r.db(dbName).table(tableName).insert({id: 1}).run();
-    assert(result);
-
-    result = yield r.db(dbName).table(tableName).get(1).replace({id: 1, foo: "bar"}).run();
-    assert.equal(result.replaced, 1);
-
-    result = yield r.db(dbName).table(tableName).get(1).run();
-    assert.deepEqual(result, {id: 1, foo: "bar"});
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-
-It('`replace` should work - range replace`', function* (done) {
-  try {
-    result = yield r.db(dbName).table(tableName).delete().run();
-    assert(result);
-    result = yield r.db(dbName).table(tableName).insert([{id: 1}, {id: 2}]).run();
-    assert(result);
-
-    result = yield r.db(dbName).table(tableName).replace(r.row.merge({foo: "bar"})).run();
-    assert.equal(result.replaced, 2);
-
-    result = yield r.db(dbName).table(tableName).get(1).run();
-    assert.deepEqual(result, {id: 1, foo: "bar"});
-
-    result = yield r.db(dbName).table(tableName).get(2).run();
-    assert.deepEqual(result, {id: 2, foo: "bar"});
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-
-It('`replace` should work - soft durability`', function* (done) {
-  try {
-    result = yield r.db(dbName).table(tableName).delete().run();
-    assert(result);
-    result = yield r.db(dbName).table(tableName).insert({id: 1}).run();
-    assert(result);
-
-    result = yield r.db(dbName).table(tableName).get(1).replace({id: 1, foo: "bar"}, {durability: "soft"}).run();
-    assert.equal(result.replaced, 1);
-
-    result = yield r.db(dbName).table(tableName).get(1).run();
-    assert.deepEqual(result, {id: 1, foo: "bar"});
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`replace` should work - hard durability`', function* (done) {
-  try {
-    result = yield r.db(dbName).table(tableName).delete().run();
-    assert(result);
-    result = yield r.db(dbName).table(tableName).insert({id: 1}).run();
-    assert(result);
-
-    result = yield r.db(dbName).table(tableName).get(1).replace({id: 1, foo: "bar"}, {durability: "hard"}).run();
-    assert.equal(result.replaced, 1);
-
-    result = yield r.db(dbName).table(tableName).get(1).run();
-    assert.deepEqual(result, {id: 1, foo: "bar"});
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-
-It('`replace` should work - returnChanges true', function* (done) {
-  try {
-    result = yield r.db(dbName).table(tableName).delete().run();
-    assert(result);
-    result = yield r.db(dbName).table(tableName).insert({id: 1}).run();
-    assert(result);
-
-    result = yield r.db(dbName).table(tableName).get(1).replace({id: 1, foo: "bar"}, {returnChanges: true}).run();
-    assert.equal(result.replaced, 1);
-    assert.deepEqual(result.changes[0].new_val, {id: 1, foo: "bar"});
-    assert.deepEqual(result.changes[0].old_val, {id: 1});
-
-    result = yield r.db(dbName).table(tableName).get(1).run();
-    assert.deepEqual(result, {id: 1, foo: "bar"});
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
-})
-It('`replace` should work - returnChanges false`', function* (done) {
-  try {
-    result = yield r.db(dbName).table(tableName).delete().run();
-    assert(result);
-    result = yield r.db(dbName).table(tableName).insert({id: 1}).run();
-    assert(result);
-
-    result = yield r.db(dbName).table(tableName).get(1).replace({id: 1, foo: "bar"}, {returnChanges: false}).run();
-    assert.equal(result.replaced, 1);
-    assert.equal(result.changes, undefined);
-    assert.equal(result.changes, undefined);
-
-    result = yield r.db(dbName).table(tableName).get(1).run();
-    assert.deepEqual(result, {id: 1, foo: "bar"});
-
-    done();
-  }
-  catch(e) {
-    done(e);
-  }
+    result = await r.db(dbName).table(tableName).get(1).run()
+    assert.deepEqual(result, {id: 1, foo: 'bar'})
+  })
 })


### PR DESCRIPTION
I've started refactoring the tests.

- [x] accessing_reql.js
- [x] administration.js
- [x] aggregation.js
- [x] backtrace.js
- [x] client-backtrace.js
- [x] control-structures.js
- [x] coverage.js
- [x] cursor.js
- [x] dates-and-times.js
- [x] datum.js
- [x] dequeue.js
- [x] document-manipulation.js
- [x] error.js
- [x] extra.js
- [x] geo.js
- [x] joins.js
- [x] manipulating-databases.js
- [x] manipulating-tables.js
- [x] math-and-logic.js
- [x] multiple-require.js
- [x] nodeify.js
- [x] pool_legacy.js
- [x] selecting-data.js
- [x] stable.js
- [x] stream.js
- [x] string-manipulation.js
- [x] transformations.js
- [x] transform-stream.js
- [x] writable-stream.js
- [x] writing-data.js
